### PR TITLE
Small fixes for windows clang compile

### DIFF
--- a/dCommon/Diagnostics.cpp
+++ b/dCommon/Diagnostics.cpp
@@ -2,8 +2,9 @@
 
 // If we're on Win32, we'll include our minidump writer
 #ifdef _WIN32
-#include <Dbghelp.h>
+
 #include <Windows.h>
+#include <Dbghelp.h>
 
 #include "Game.h"
 #include "dLogger.h"

--- a/dScripts/NjMonastryBossInstance.cpp
+++ b/dScripts/NjMonastryBossInstance.cpp
@@ -16,7 +16,7 @@
 // // // // // // //
 
 void NjMonastryBossInstance::OnStartup(Entity *self) {
-    auto spawnerNames = std::vector { LedgeFrakjawSpawner, LowerFrakjawSpawner, BaseEnemiesSpawner + std::to_string(1),
+    auto spawnerNames = std::vector<std::string> { LedgeFrakjawSpawner, LowerFrakjawSpawner, BaseEnemiesSpawner + std::to_string(1),
                                       BaseEnemiesSpawner + std::to_string(2), BaseEnemiesSpawner + std::to_string(3),
                                       BaseEnemiesSpawner + std::to_string(4), CounterweightSpawner };
 


### PR DESCRIPTION
Windows server setup:

Clang throws errors for Dbghelp and for the usage of auto to define a vector in NjMonastryBossInstance.cpp, fixed and compiled successfully