### PR TITLE
Make 0_initial.sql compatible with MySQL

### DIFF
--- a/migrations/dlu/0_initial.sql
+++ b/migrations/dlu/0_initial.sql
@@ -1,4 +1,5 @@
-CREATE OR REPLACE TABLE accounts (
+DROP TABLE IF EXISTS accounts;
+CREATE TABLE accounts (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     name VARCHAR(35) NOT NULL UNIQUE,
     password TEXT NOT NULL,
@@ -10,7 +11,8 @@ CREATE OR REPLACE TABLE accounts (
     mute_expire BIGINT UNSIGNED NOT NULL DEFAULT 0
 );
 
-CREATE OR REPLACE TABLE charinfo (
+DROP TABLE IF EXISTS charinfo;
+CREATE TABLE charinfo (
     id BIGINT NOT NULL PRIMARY KEY,
     account_id INT NOT NULL REFERENCES accounts(id),
     name VARCHAR(35) NOT NULL,
@@ -21,18 +23,21 @@ CREATE OR REPLACE TABLE charinfo (
     permission_map BIGINT UNSIGNED NOT NULL DEFAULT 0
 );
 
-CREATE OR REPLACE TABLE charxml (
+DROP TABLE IF EXISTS charxml;
+CREATE TABLE charxml (
     id BIGINT NOT NULL PRIMARY KEY REFERENCES charinfo(id),
     xml_data LONGTEXT NOT NULL
 );
 
-CREATE OR REPLACE TABLE command_log (
+DROP TABLE IF EXISTS command_log;
+CREATE TABLE command_log (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     character_id BIGINT NOT NULL REFERENCES charinfo(id),
     command VARCHAR(256) NOT NULL
 );
 
-CREATE OR REPLACE TABLE friends (
+DROP TABLE IF EXISTS friends;
+CREATE TABLE friends (
     player_id BIGINT NOT NULL REFERENCES charinfo(id),
     friend_id BIGINT NOT NULL REFERENCES charinfo(id),
     best_friend BOOLEAN NOT NULL DEFAULT FALSE,
@@ -40,7 +45,8 @@ CREATE OR REPLACE TABLE friends (
     PRIMARY KEY (player_id, friend_id)
 );
 
-CREATE OR REPLACE TABLE leaderboard (
+DROP TABLE IF EXISTS leaderboard;
+CREATE TABLE leaderboard (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     game_id INT UNSIGNED NOT NULL DEFAULT 0,
     last_played TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP(),
@@ -49,7 +55,8 @@ CREATE OR REPLACE TABLE leaderboard (
     score BIGINT UNSIGNED NOT NULL DEFAULT 0
 );
 
-CREATE OR REPLACE TABLE mail (
+DROP TABLE IF EXISTS mail;
+CREATE TABLE mail (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     sender_id INT NOT NULL DEFAULT 0,
     sender_name VARCHAR(35) NOT NULL DEFAULT '',
@@ -65,17 +72,20 @@ CREATE OR REPLACE TABLE mail (
     was_read BOOLEAN NOT NULL DEFAULT FALSE
 );
 
-CREATE OR REPLACE TABLE object_id_tracker (
+DROP TABLE IF EXISTS object_id_tracker;
+CREATE TABLE object_id_tracker (
     last_object_id BIGINT UNSIGNED NOT NULL DEFAULT 0 PRIMARY KEY
 );
 
-CREATE OR REPLACE TABLE pet_names (
+DROP TABLE IF EXISTS pet_names;
+CREATE TABLE pet_names (
     id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     pet_name TEXT NOT NULL,
     approved INT UNSIGNED NOT NULL
 );
 
-CREATE OR REPLACE TABLE play_keys (
+DROP TABLE IF EXISTS play_keys;
+CREATE TABLE play_keys (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     key_string CHAR(19) NOT NULL UNIQUE,
     key_uses INT NOT NULL DEFAULT 1,
@@ -83,7 +93,8 @@ CREATE OR REPLACE TABLE play_keys (
     active BOOLEAN NOT NULL DEFAULT TRUE
 );
 
-CREATE OR REPLACE TABLE properties (
+DROP TABLE IF EXISTS properties;
+CREATE TABLE properties (
     id BIGINT NOT NULL PRIMARY KEY,
     owner_id BIGINT NOT NULL REFERENCES charinfo(id),
     template_id INT UNSIGNED NOT NULL,
@@ -101,17 +112,19 @@ CREATE OR REPLACE TABLE properties (
     zone_id INT NOT NULL
 );
 
-CREATE OR REPLACE TABLE ugc (
+DROP TABLE IF EXISTS ugc;
+CREATE TABLE ugc (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     account_id INT NOT NULL REFERENCES accounts(id),
     character_id BIGINT NOT NULL REFERENCES charinfo(id),
     is_optimized BOOLEAN NOT NULL DEFAULT FALSE,
     lxfml MEDIUMBLOB NOT NULL,
     bake_ao BOOLEAN NOT NULL DEFAULT FALSE,
-    filename TEXT NOT NULL DEFAULT ''
+    filename TEXT NOT NULL DEFAULT ('')
 );
 
-CREATE OR REPLACE TABLE properties_contents (
+DROP TABLE IF EXISTS properties_contents;
+CREATE TABLE properties_contents (
     id BIGINT NOT NULL PRIMARY KEY,
     property_id BIGINT NOT NULL REFERENCES properties(id),
     ugc_id INT NULL REFERENCES ugc(id),
@@ -125,7 +138,8 @@ CREATE OR REPLACE TABLE properties_contents (
     rw FLOAT NOT NULL
 );
 
-CREATE OR REPLACE TABLE activity_log (
+DROP TABLE IF EXISTS activity_log;
+CREATE TABLE activity_log (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     character_id BIGINT NOT NULL REFERENCES charinfo(id),
     activity INT NOT NULL,
@@ -133,7 +147,8 @@ CREATE OR REPLACE TABLE activity_log (
     map_id INT NOT NULL
 );
 
-CREATE OR REPLACE TABLE bug_reports (
+DROP TABLE IF EXISTS bug_reports;
+CREATE TABLE bug_reports (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     body TEXT NOT NULL,
     client_version TEXT NOT NULL,
@@ -142,7 +157,8 @@ CREATE OR REPLACE TABLE bug_reports (
     submitted TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP()
 );
 
-CREATE OR REPLACE TABLE servers (
+DROP TABLE IF EXISTS servers;
+CREATE TABLE servers (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     name TEXT NOT NULL,
     ip TEXT NOT NULL,


### PR DESCRIPTION
Adjusts the syntax of 0_initial.sql to be compatible with MySQL while retaining MariaDB support. Changes `CREATE OR REPLACE TABLE` with `DROP TABLE IF EXISTS` + `CREATE TABLE` and wraps the '' in ugc's filename entry in parentheses.

This should close https://github.com/DarkflameUniverse/DarkflameServer/issues/4.