### PR TITLE
Add note to readme for troubleshooting tips with script editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ The client script for the survival minigame has a bug in it which can cause the 
 * Change `PlayerReady(self)` to `onPlayerReady(self)`
 * Save the file, overriding readonly mode if required
 
+If you still experience the bug, try deleting/renaming `res/pack/scripts.pak`.
+
 ### Brick-By-Brick building
 
 Brick-By-Brick building requires `PATCHSERVERIP=0:` in the `boot.cfg` to point to a HTTP server which always returns `HTTP 404 - Not Found` for all requests. This can be achieved by pointing it to `localhost` while having `sudo python -m http.server 80` running in the background.


### PR DESCRIPTION
In my case the client didn't load the fixed, unpacked script and still used the one from the pk. Renaming `res/pack/scripts.pk` to `_scripts.pk` fixed this for me.

Related:
https://www.reddit.com/r/legouniverse/comments/raoj0q/comment/hnony7p/?utm_source=share&utm_medium=web2x&context=3