### PR TITLE
Fix unimplemented timestamp in dLogger::LogBasic on Win

### DIFF
--- a/dCommon/dLogger.cpp
+++ b/dCommon/dLogger.cpp
@@ -44,8 +44,8 @@ void dLogger::LogBasic(const char * format, ...) {
 	vsprintf_s(message, format, args);
 	va_end(args);
 
-	if (m_logToConsole) std::cout << "[" << "time machine broke" << "] " << message;
-	mFile << "[" << "time" << "] " << message;
+	if (m_logToConsole) std::cout << "[" << timeStr << "] " << message;
+	mFile << "[" << timeStr << "] " << message;
 #else
 	time_t t = time(NULL);
     struct tm * time = localtime(&t);


### PR DESCRIPTION
Spotted that the timestamp for LogBasic on windows wasn't implemented. Follow up to the same fix in #88 which was for dLogger::Log.