### PR TITLE
Update BaseEnemyMech script to change the default faction

### DIFF
--- a/dScripts/AgDarklingMech.cpp
+++ b/dScripts/AgDarklingMech.cpp
@@ -1,9 +1,0 @@
-#include "AgDarklingMech.h"
-#include "DestroyableComponent.h"
-
-void AgDarklingMech::OnStartup(Entity *self) {
-    auto* destroyableComponent = self->GetComponent<DestroyableComponent>();
-    if (destroyableComponent != nullptr) {
-        destroyableComponent->SetFaction(4);
-    }
-}

--- a/dScripts/AgDarklingMech.h
+++ b/dScripts/AgDarklingMech.h
@@ -1,6 +1,0 @@
-#pragma once
-#include "BaseEnemyMech.h"
-
-class AgDarklingMech : public BaseEnemyMech {
-    void OnStartup(Entity* self) override;
-};

--- a/dScripts/AmDarklingMech.cpp
+++ b/dScripts/AmDarklingMech.cpp
@@ -3,9 +3,6 @@
 
 void AmDarklingMech::OnStartup(Entity* self) 
 {
-    auto* destroyableComponent = self->GetComponent<DestroyableComponent>();
-
-    destroyableComponent->SetFaction(4);
-
+    BaseEnemyMech::OnStartup(self);
     qbTurretLOT = 13171;
 }

--- a/dScripts/BaseEnemyMech.cpp
+++ b/dScripts/BaseEnemyMech.cpp
@@ -7,6 +7,14 @@
 #include "EntityManager.h"
 #include "dpWorld.h"
 #include "GeneralUtils.h"
+#include "DestroyableComponent.h"
+
+void BaseEnemyMech::OnStartup(Entity* self) {
+    auto* destroyableComponent = self->GetComponent<DestroyableComponent>();
+    if (destroyableComponent != nullptr) {
+        destroyableComponent->SetFaction(4);
+    }
+}
 
 void BaseEnemyMech::OnDie(Entity* self, Entity* killer) {
 	ControllablePhysicsComponent* controlPhys = static_cast<ControllablePhysicsComponent*>(self->GetComponent(COMPONENT_TYPE_CONTROLLABLE_PHYSICS));

--- a/dScripts/BaseEnemyMech.h
+++ b/dScripts/BaseEnemyMech.h
@@ -4,6 +4,7 @@
 class BaseEnemyMech : public CppScripts::Script
 {
 public:
+        void OnStartup(Entity* self) override;
 	void OnDie(Entity* self, Entity* killer) override;
 protected:
 	LOT qbTurretLOT = 6254;

--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -51,7 +51,6 @@
 #include "NpcCowboyServer.h"
 #include "ZoneAgMedProperty.h"
 #include "AgStromlingProperty.h"
-#include "AgDarklingMech.h"
 #include "AgDarkSpiderling.h"
 #include "PropertyFXDamage.h"
 #include "AgPropguards.h"
@@ -377,7 +376,7 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 	else if (scriptName == "scripts\\ai\\AG\\L_AG_STROMBIE_PROPERTY.lua")
 	    script = new AgStromlingProperty();
 	else if (scriptName == "scripts\\ai\\AG\\L_AG_DARKLING_MECH.lua")
-	    script = new AgDarklingMech();
+	    script = new BaseEnemyMech();
 	else if (scriptName == "scripts\\ai\\AG\\L_AG_DARK_SPIDERLING.lua")
 	    script = new AgDarkSpiderling();
 	else if (scriptName == "scripts\\ai\\PROPERTY\\L_PROP_GUARDS.lua")

--- a/dScripts/VeMech.cpp
+++ b/dScripts/VeMech.cpp
@@ -1,5 +1,6 @@
 #include "VeMech.h"
 
 void VeMech::OnStartup(Entity *self) {
+    BaseEnemyMech::OnStartup(self);
     qbTurretLOT = 8432;
 }


### PR DESCRIPTION
Fixed #54. As part of the base enemy mech script its faction should be updated to 4
to make sure it's seen as an enemy by the client. The AgDarklingMech script
has been deleted as its functionality was essentially that of BaseEnemyMech
and thus no longer necessary.