### PR TITLE
blacklist support added to chat filter

### DIFF
--- a/dChatFilter/dChatFilter.cpp
+++ b/dChatFilter/dChatFilter.cpp
@@ -8,14 +8,16 @@
 #include <regex>
 
 #include "dCommonVars.h"
-#include "Database.h"
 #include "dLogger.h"
+#include "dConfig.h"
+#include "Database.h"
 #include "Game.h"
 
 using namespace dChatFilterDCF;
 
 dChatFilter::dChatFilter(const std::string& filepath, bool dontGenerateDCF) {
 	m_DontGenerateDCF = dontGenerateDCF;
+	m_UseWhitelist = bool(std::stoi(Game::config->GetValue("use_chat_words_as_whitelist")));
 
 	if (!BinaryIO::DoesFileExist(filepath + ".dcf") || m_DontGenerateDCF) {
 		ReadWordlistPlaintext(filepath + ".txt");
@@ -116,12 +118,19 @@ bool dChatFilter::IsSentenceOkay(const std::string& message, int gmLevel) {
 		size_t hash = CalculateHash(segment);
 
 		if (std::find(m_UserUnapprovedWordCache.begin(), m_UserUnapprovedWordCache.end(), hash) != m_UserUnapprovedWordCache.end()) {
-			return false;
+			return false; // found word that isn't ok, just deny this code works for both white and black list
 		}
 
 		if (!IsInWordlist(hash)) {
-			m_UserUnapprovedWordCache.push_back(hash);
-			return false;
+			if (m_UseWhitelist) {
+				m_UserUnapprovedWordCache.push_back(hash);
+				return false;
+			}
+		} else {
+			if (!m_UseWhitelist) {
+				m_UserUnapprovedWordCache.push_back(hash);
+				return false;
+			}
 		}
 	}
 

--- a/dChatFilter/dChatFilter.h
+++ b/dChatFilter/dChatFilter.h
@@ -26,6 +26,7 @@ public:
 	bool IsSentenceOkay(const std::string& message, int gmLevel);
 
 private:
+	bool m_UseWhitelist;
 	bool m_DontGenerateDCF;
 	std::vector<size_t> m_Words;
 	std::vector<size_t> m_UserUnapprovedWordCache;

--- a/resources/chatconfig.ini
+++ b/resources/chatconfig.ini
@@ -21,3 +21,6 @@ log_to_console=1
 
 # 0 or 1, should not compile chat hash map to file
 dont_generate_dcf=0
+
+# 0 or 1, use chat file as whitelist?
+use_chat_words_as_whitelist=1

--- a/resources/worldconfig.ini
+++ b/resources/worldconfig.ini
@@ -47,3 +47,6 @@ solo_racing=0
 
 # Disables the anti-speedhack system. If you get kicked randomly you might want to disable this, as it might just be lag
 disable_anti_speedhack=0
+
+# 0 or 1, use chat file as whitelist?
+use_chat_words_as_whitelist=1


### PR DESCRIPTION
Enabled support for the chat filter to use the chat words file as a blacklist