### PR TITLE
Remove +4 imagination buff from Proxy Ninja Hood - Back/Neck Proxy

### DIFF
--- a/migrations/cdserver/3_remove_proxy_item_buff.sql
+++ b/migrations/cdserver/3_remove_proxy_item_buff.sql
@@ -1,0 +1,1 @@
+DELETE FROM ObjectSkills WHERE objectTemplate = 10482


### PR DESCRIPTION
Remove the +4 imagination buff from Object 10482 "Proxy Ninja Hood - Back/Neck Proxy" as it causes ninja hoods to give 4 more imagination than their description claims.

Fixes #167 

Tested by equipping items 1889, 2641, and 2642 both before and after applying this fix