### PR TITLE
increased the exchange rate of the nimbus station console to 5 faction tokens for 25 maelstrom infected bricks

### DIFF
--- a/dScripts/NsTokenConsoleServer.cpp
+++ b/dScripts/NsTokenConsoleServer.cpp
@@ -50,19 +50,19 @@ void NsTokenConsoleServer::OnUse(Entity* self, Entity* user)
 
     if (character->GetPlayerFlag(46))
     {
-        inventoryComponent->AddItem(8321, 1);
+        inventoryComponent->AddItem(8321, 5);
     }
     else if (character->GetPlayerFlag(47))
     {
-        inventoryComponent->AddItem(8318, 1);
+        inventoryComponent->AddItem(8318, 5);
     }
     else if (character->GetPlayerFlag(48))
     {
-        inventoryComponent->AddItem(8320, 1);
+        inventoryComponent->AddItem(8320, 5);
     }
     else if (character->GetPlayerFlag(49))
     {
-        inventoryComponent->AddItem(8319, 1);
+        inventoryComponent->AddItem(8319, 5);
     }
 
     missionComponent->ForceProgressTaskType(863, 1, 1, false);


### PR DESCRIPTION
Currently when you exchange maelstrom infected bricks at the console you can build out of the anvil at nimbus plaza you receive one token per 25 bricks. There is a prompt ingame that says you should get 5 tokens.

I simply increased the corresponding numbers in the NsTokenConsoleServer.cpp from 1 to 5 and tested these changes on my own server running on Manjaro Linux.
![factiontokens](https://user-images.githubusercontent.com/57260460/145697459-3aac80e7-8bf3-4956-a2ac-0670cf60d68b.png)

