### PR TITLE
Add the 'filter_gm_level' config option to the ChatServer

### DIFF
--- a/dChatFilter/dChatFilter.cpp
+++ b/dChatFilter/dChatFilter.cpp
@@ -14,7 +14,8 @@
 
 using namespace dChatFilterDCF;
 
-dChatFilter::dChatFilter(const std::string& filepath, bool dontGenerateDCF) {
+dChatFilter::dChatFilter(const std::string& filepath, bool dontGenerateDCF, int chatFilterGMLevel) {
+	m_FilterGMLevel = chatFilterGMLevel;
 	m_DontGenerateDCF = dontGenerateDCF;
 
 	if (!BinaryIO::DoesFileExist(filepath + ".dcf") || m_DontGenerateDCF) {
@@ -102,7 +103,7 @@ void dChatFilter::ExportWordlistToDCF(const std::string& filepath) {
 }
 
 bool dChatFilter::IsSentenceOkay(const std::string& message, int gmLevel) {
-	if (gmLevel > GAME_MASTER_LEVEL_FORUM_MODERATOR) return true; //If anything but a forum mod, return true.
+	if (gmLevel >= m_FilterGMLevel) return true;
 	if (message.empty()) return true;
 
 	std::stringstream sMessage(message);

--- a/dChatFilter/dChatFilter.h
+++ b/dChatFilter/dChatFilter.h
@@ -17,7 +17,7 @@ namespace dChatFilterDCF {
 class dChatFilter
 {
 public:
-	dChatFilter(const std::string& filepath, bool dontGenerateDCF);
+	dChatFilter(const std::string& filepath, bool dontGenerateDCF, int chatFilterGMLevel);
 	~dChatFilter();
 
 	void ReadWordlistPlaintext(const std::string & filepath);
@@ -27,6 +27,7 @@ public:
 
 private:
 	bool m_DontGenerateDCF;
+	bool m_FilterGMLevel;
 	std::vector<size_t> m_Words;
 	std::vector<size_t> m_UserUnapprovedWordCache;
 

--- a/dChatServer/ChatServer.cpp
+++ b/dChatServer/ChatServer.cpp
@@ -87,7 +87,9 @@ int main(int argc, char** argv) {
 
 	Game::server = new dServer(config.GetValue("external_ip"), ourPort, 0, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::Chat);
 
-	Game::chatFilter = new dChatFilter("./res/chatplus_en_us", bool(std::stoi(config.GetValue("dont_generate_dcf"))));
+	bool chatFilterGMLevel = std::stoi(config.GetValue("filter_gm_level"));
+
+	Game::chatFilter = new dChatFilter("./res/chatplus_en_us", bool(std::stoi(config.GetValue("dont_generate_dcf"))), chatFilterGMLevel);
 
 	//Run it until server gets a kill message from Master:
 	auto t = std::chrono::high_resolution_clock::now();

--- a/resources/chatconfig.ini
+++ b/resources/chatconfig.ini
@@ -16,6 +16,11 @@ dump_folder=
 # How many clients can be connected to the server at once
 max_clients=999
 
+# The required GM level to ignore the filter.
+# Set to 9 to only allow sysadmins to speak freely.
+# Set to 0 to disable the filter for all players.
+filter_gm_level=1
+
 # 0 or 1, should log to console
 log_to_console=1
 


### PR DESCRIPTION
This PR adds the new configuration option, `filter_gm_level`, to the `chatconfig.ini`. This configuration allows you to set the GM level at which chat filters are applied.

The default value, `1`, only allows forum moderators (GM level 1) and above to speak freely.

Setting the value to `9` restricts all players of GM level 8 and below from speaking freely in chat.

Setting the value to `0` disables chat filters for all players.

TODO:

- [ ] Test the implementation ingame.