### PR TITLE
Fix proxy items removing each other's skills

### DIFF
--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -254,8 +254,9 @@ public:
 	/**
 	 * Adds a skill related to a passed item to the currently equipped skills
 	 * @param lot the lot to add a skill for
+	 * @param removePrevious if true, remove the previously equipped skill
 	 */
-	void AddItemSkills(LOT lot);
+	void AddItemSkills(LOT lot, bool removePrevious = true);
 
     /**
      * Removes the skills related to the passed LOT from the currently equipped skills

--- a/dGame/dGameMessages/GameMessageHandler.cpp
+++ b/dGame/dGameMessages/GameMessageHandler.cpp
@@ -109,6 +109,7 @@ void GameMessageHandler::HandleMessage(RakNet::BitStream* inStream, const System
 					if (item.lot == 7292) GameMessages::SendSetJetpackMode(entity, true, true, false);
 					if (item.lot == 14442) GameMessages::SendSetJetpackMode(entity, false, true, true);
 
+					inv->RemoveItemSkills(item.lot);
 					inv->AddItemSkills(item.lot);
 				}
 			}

--- a/dGame/dGameMessages/GameMessageHandler.cpp
+++ b/dGame/dGameMessages/GameMessageHandler.cpp
@@ -109,7 +109,6 @@ void GameMessageHandler::HandleMessage(RakNet::BitStream* inStream, const System
 					if (item.lot == 7292) GameMessages::SendSetJetpackMode(entity, true, true, false);
 					if (item.lot == 14442) GameMessages::SendSetJetpackMode(entity, false, true, true);
 
-					inv->RemoveItemSkills(item.lot);
 					inv->AddItemSkills(item.lot);
 				}
 			}


### PR DESCRIPTION
Fixed where equipping an item with two proxy items in the same slot would have the second proxy remove the first proxy's skill, which prevented some skills from being shown in the hotbar.

Fixes #168 