### PR TITLE
Make loot accurate to the loot drop rates during live. 

### DIFF
--- a/dDatabase/Tables/CDLootMatrixTable.cpp
+++ b/dDatabase/Tables/CDLootMatrixTable.cpp
@@ -57,6 +57,6 @@ std::vector<CDLootMatrix> CDLootMatrixTable::Query(std::function<bool(CDLootMatr
 }
 
 //! Gets all the entries in the table
-std::vector<CDLootMatrix> CDLootMatrixTable::GetEntries(void) const {
+const std::vector<CDLootMatrix>& CDLootMatrixTable::GetEntries(void) const {
     return this->entries;
 }

--- a/dDatabase/Tables/CDLootMatrixTable.h
+++ b/dDatabase/Tables/CDLootMatrixTable.h
@@ -50,7 +50,7 @@ public:
     /*!
       \return The entries
      */
-    std::vector<CDLootMatrix> GetEntries(void) const;
+    const std::vector<CDLootMatrix>& GetEntries(void) const;
     
 };
 

--- a/dDatabase/Tables/CDLootTableTable.cpp
+++ b/dDatabase/Tables/CDLootTableTable.cpp
@@ -54,6 +54,6 @@ std::vector<CDLootTable> CDLootTableTable::Query(std::function<bool(CDLootTable)
 }
 
 //! Gets all the entries in the table
-std::vector<CDLootTable> CDLootTableTable::GetEntries(void) const {
+const std::vector<CDLootTable>& CDLootTableTable::GetEntries(void) const {
     return this->entries;
 }

--- a/dDatabase/Tables/CDLootTableTable.h
+++ b/dDatabase/Tables/CDLootTableTable.h
@@ -46,7 +46,7 @@ public:
     /*!
       \return The entries
      */
-    std::vector<CDLootTable> GetEntries(void) const;
+    const std::vector<CDLootTable>& GetEntries(void) const;
     
 };
 

--- a/dDatabase/Tables/CDRarityTableTable.cpp
+++ b/dDatabase/Tables/CDRarityTableTable.cpp
@@ -52,6 +52,6 @@ std::vector<CDRarityTable> CDRarityTableTable::Query(std::function<bool(CDRarity
 }
 
 //! Gets all the entries in the table
-std::vector<CDRarityTable> CDRarityTableTable::GetEntries(void) const {
+const std::vector<CDRarityTable>& CDRarityTableTable::GetEntries(void) const {
     return this->entries;
 }

--- a/dDatabase/Tables/CDRarityTableTable.h
+++ b/dDatabase/Tables/CDRarityTableTable.h
@@ -66,7 +66,7 @@ public:
     /*!
       \return The entries
      */
-    std::vector<CDRarityTable> GetEntries(void) const;
+    const std::vector<CDRarityTable>& GetEntries(void) const;
 
 };
 

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -783,12 +783,12 @@ void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType
 
 					if (member == nullptr) continue;
 
-					Loot::DropLoot(member, m_Parent, GetLootMatrixID(), GetMinCoins(), GetMaxCoins());
+					LootGenerator::Instance()->DropLoot(member, m_Parent, GetLootMatrixID(), GetMinCoins(), GetMaxCoins());
 				}
 			}
 			else
 			{
-				Loot::DropLoot(owner, m_Parent, GetLootMatrixID(), GetMinCoins(), GetMaxCoins());
+				LootGenerator::Instance()->DropLoot(owner, m_Parent, GetLootMatrixID(), GetMinCoins(), GetMaxCoins());
 			}
 		}
 	}
@@ -815,7 +815,7 @@ void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType
 
 			coinsTotal -= coinsToLoose;
 		
-			Loot::DropLoot(m_Parent, m_Parent, -1, coinsToLoose, coinsToLoose);
+			LootGenerator::Instance()->DropLoot(m_Parent, m_Parent, -1, coinsToLoose, coinsToLoose);
 		}
 
 		character->SetCoins(coinsTotal);

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -783,12 +783,12 @@ void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType
 
 					if (member == nullptr) continue;
 
-					LootGenerator::Instance()->DropLoot(member, m_Parent, GetLootMatrixID(), GetMinCoins(), GetMaxCoins());
+					LootGenerator::Instance().DropLoot(member, m_Parent, GetLootMatrixID(), GetMinCoins(), GetMaxCoins());
 				}
 			}
 			else
 			{
-				LootGenerator::Instance()->DropLoot(owner, m_Parent, GetLootMatrixID(), GetMinCoins(), GetMaxCoins());
+				LootGenerator::Instance().DropLoot(owner, m_Parent, GetLootMatrixID(), GetMinCoins(), GetMaxCoins());
 			}
 		}
 	}
@@ -815,7 +815,7 @@ void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType
 
 			coinsTotal -= coinsToLoose;
 		
-			LootGenerator::Instance()->DropLoot(m_Parent, m_Parent, -1, coinsToLoose, coinsToLoose);
+			LootGenerator::Instance().DropLoot(m_Parent, m_Parent, -1, coinsToLoose, coinsToLoose);
 		}
 
 		character->SetCoins(coinsTotal);

--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -390,7 +390,7 @@ void RacingControlComponent::HandleMessageBoxResponse(Entity *player,
         // Calculate the score, different loot depending on player count
         const auto score = m_LoadedPlayers * 10 + data->finished;
 
-        Loot::GiveActivityLoot(player, m_Parent, m_ActivityID, score);
+        LootGenerator::Instance()->GiveActivityLoot(player, m_Parent, m_ActivityID, score);
 
         // Giving rewards
         GameMessages::SendNotifyRacingClient(

--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -390,7 +390,7 @@ void RacingControlComponent::HandleMessageBoxResponse(Entity *player,
         // Calculate the score, different loot depending on player count
         const auto score = m_LoadedPlayers * 10 + data->finished;
 
-        LootGenerator::Instance()->GiveActivityLoot(player, m_Parent, m_ActivityID, score);
+        LootGenerator::Instance().GiveActivityLoot(player, m_Parent, m_ActivityID, score);
 
         // Giving rewards
         GameMessages::SendNotifyRacingClient(

--- a/dGame/dComponents/RebuildComponent.cpp
+++ b/dGame/dComponents/RebuildComponent.cpp
@@ -452,7 +452,7 @@ void RebuildComponent::CompleteRebuild(Entity* user) {
 			missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_ACTIVITY, m_ActivityId);
 		}
 
-		Loot::DropActivityLoot(builder, m_Parent, m_ActivityId, 1);
+		LootGenerator::Instance()->DropActivityLoot(builder, m_Parent, m_ActivityId, 1);
 	}
 
 	m_Builder = LWOOBJID_EMPTY;

--- a/dGame/dComponents/RebuildComponent.cpp
+++ b/dGame/dComponents/RebuildComponent.cpp
@@ -452,7 +452,7 @@ void RebuildComponent::CompleteRebuild(Entity* user) {
 			missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_ACTIVITY, m_ActivityId);
 		}
 
-		LootGenerator::Instance()->DropActivityLoot(builder, m_Parent, m_ActivityId, 1);
+		LootGenerator::Instance().DropActivityLoot(builder, m_Parent, m_ActivityId, 1);
 	}
 
 	m_Builder = LWOOBJID_EMPTY;

--- a/dGame/dComponents/ScriptedActivityComponent.cpp
+++ b/dGame/dComponents/ScriptedActivityComponent.cpp
@@ -524,7 +524,7 @@ void ActivityInstance::RewardParticipant(Entity* participant) {
 			maxCoins = currencyTable[0].maxvalue;
 		}
 
-		Loot::DropLoot(participant, m_Parent, activityRewards[0].LootMatrixIndex, minCoins, maxCoins);
+		LootGenerator::Instance()->DropLoot(participant, m_Parent, activityRewards[0].LootMatrixIndex, minCoins, maxCoins);
 	}
 }
 

--- a/dGame/dComponents/ScriptedActivityComponent.cpp
+++ b/dGame/dComponents/ScriptedActivityComponent.cpp
@@ -524,7 +524,7 @@ void ActivityInstance::RewardParticipant(Entity* participant) {
 			maxCoins = currencyTable[0].maxvalue;
 		}
 
-		LootGenerator::Instance()->DropLoot(participant, m_Parent, activityRewards[0].LootMatrixIndex, minCoins, maxCoins);
+		LootGenerator::Instance().DropLoot(participant, m_Parent, activityRewards[0].LootMatrixIndex, minCoins, maxCoins);
 	}
 }
 

--- a/dGame/dInventory/Item.cpp
+++ b/dGame/dInventory/Item.cpp
@@ -333,14 +333,14 @@ bool Item::UseNonEquip()
 		{
 			std::unordered_map<LOT, int32_t> result {};
 
-			result = LootGenerator::Instance()->RollLootMatrix(entityParent, pack.LootMatrixIndex);
+			result = LootGenerator::Instance().RollLootMatrix(entityParent, pack.LootMatrixIndex);
 
 			if (!inventory->GetComponent()->HasSpaceForLoot(result))
 			{
 				return false;
 			}
 
-			LootGenerator::Instance()->GiveLoot(inventory->GetComponent()->GetParent(), result);
+			LootGenerator::Instance().GiveLoot(inventory->GetComponent()->GetParent(), result);
 		}
 
 		inventory->GetComponent()->RemoveItem(lot, 1);

--- a/dGame/dInventory/Item.cpp
+++ b/dGame/dInventory/Item.cpp
@@ -333,14 +333,14 @@ bool Item::UseNonEquip()
 		{
 			std::unordered_map<LOT, int32_t> result {};
 
-			Loot::CalculateLootMatrix(pack.LootMatrixIndex, entityParent, result);
+			result = LootGenerator::Instance()->RollLootMatrix(entityParent, pack.LootMatrixIndex);
 
 			if (!inventory->GetComponent()->HasSpaceForLoot(result))
 			{
 				return false;
 			}
 
-			Loot::GiveLoot(inventory->GetComponent()->GetParent(), result);
+			LootGenerator::Instance()->GiveLoot(inventory->GetComponent()->GetParent(), result);
 		}
 
 		inventory->GetComponent()->RemoveItem(lot, 1);

--- a/dGame/dUtilities/Loot.cpp
+++ b/dGame/dUtilities/Loot.cpp
@@ -67,7 +67,7 @@ LootGenerator::LootGenerator() {
         }
 
         // sort in descending order based on randMax
-        std::sort(rarityTable.begin(), rarityTable.end(), [](const RarityTableEntry& x, const RarityTableEntry& y) { return x.randMax < y.randMax; });
+        std::sort(rarityTable.begin(), rarityTable.end(), [](const RarityTableEntry& x, const RarityTableEntry& y) { return x.randMax > y.randMax; });
 
         m_RarityTables.insert({index, rarityTable});
     }
@@ -125,7 +125,7 @@ LootGenerator::LootGenerator() {
 
         // sort by item rarity descending
         std::sort(lootTable.begin(), lootTable.end(), [&](const LootTableEntry& x, const LootTableEntry& y) {
-            return m_ItemRarities[x.itemID] < m_ItemRarities[y.itemID];
+            return m_ItemRarities[x.itemID] > m_ItemRarities[y.itemID];
         });
 
         m_LootTables.insert({index, lootTable});
@@ -191,6 +191,10 @@ std::unordered_map<LOT, int32_t> LootGenerator::RollLootMatrix(Entity* player, u
                         else if (missionComponent->GetMissionState(578) == MissionState::MISSION_STATE_COMPLETE)
                             drop.itemID = 8320; // "Paradox Token"
                     }
+
+                    if (drop.itemID == 13763) {
+                        continue;
+                    } // check if we aren't in faction
 
                     if (drops.find(drop.itemID) == drops.end()) {
                         drops.insert({drop.itemID, 1});

--- a/dGame/dUtilities/Loot.cpp
+++ b/dGame/dUtilities/Loot.cpp
@@ -37,7 +37,7 @@ LootGenerator::LootGenerator() {
 
     for (const uint32_t itemID : uniqueItems) {
         uint32_t itemComponentID = componentsRegistryTable->GetByIDAndType(itemID, COMPONENT_TYPE_ITEM);
-        CDItemComponent item = itemComponentTable->GetItemComponentByID(itemComponentID);
+        const CDItemComponent& item = itemComponentTable->GetItemComponentByID(itemComponentID);
 
         m_ItemRarities.insert({itemID, item.rarity});
     }
@@ -137,12 +137,12 @@ std::unordered_map<LOT, int32_t> LootGenerator::RollLootMatrix(Entity* player, u
 
     std::unordered_map<LOT, int32_t> drops;
 
-    LootMatrix matrix = m_LootMatrices[matrixIndex];
+    const LootMatrix& matrix = m_LootMatrices[matrixIndex];
 
     for (const LootMatrixEntry& entry : matrix) {
         if (GeneralUtils::GenerateRandomNumber<float>(0, 1) < entry.percent) {
-            LootTable lootTable = m_LootTables[entry.lootTableIndex];
-            RarityTable rarityTable = m_RarityTables[entry.rarityTableIndex];
+            const LootTable& lootTable = m_LootTables[entry.lootTableIndex];
+            const RarityTable& rarityTable = m_RarityTables[entry.rarityTableIndex];
 
             uint32_t dropCount = GeneralUtils::GenerateRandomNumber<uint32_t>(entry.minDrop, entry.maxDrop);
             for (uint32_t i = 0; i < dropCount; ++i) {
@@ -150,7 +150,7 @@ std::unordered_map<LOT, int32_t> LootGenerator::RollLootMatrix(Entity* player, u
 
                 float rarityRoll = GeneralUtils::GenerateRandomNumber<float>(0, 1);
 
-                for (RarityTableEntry rarity : rarityTable) {
+                for (const RarityTableEntry& rarity : rarityTable) {
                     if (rarity.randMax >= rarityRoll) {
                         maxRarity = rarity.rarity;
                     } else {
@@ -212,12 +212,12 @@ std::unordered_map<LOT, int32_t> LootGenerator::RollLootMatrix(Entity* player, u
 std::unordered_map<LOT, int32_t> LootGenerator::RollLootMatrix(uint32_t matrixIndex) {
     std::unordered_map<LOT, int32_t> drops;
 
-    LootMatrix matrix = m_LootMatrices[matrixIndex];
+    const LootMatrix& matrix = m_LootMatrices[matrixIndex];
 
     for (const LootMatrixEntry& entry : matrix) {
         if (GeneralUtils::GenerateRandomNumber<float>(0, 1) < entry.percent) {
-            LootTable lootTable = m_LootTables[entry.lootTableIndex];
-            RarityTable rarityTable = m_RarityTables[entry.rarityTableIndex];
+            const LootTable& lootTable = m_LootTables[entry.lootTableIndex];
+            const RarityTable& rarityTable = m_RarityTables[entry.rarityTableIndex];
 
             uint32_t dropCount = GeneralUtils::GenerateRandomNumber<uint32_t>(entry.minDrop, entry.maxDrop);
             for (uint32_t i = 0; i < dropCount; ++i) {
@@ -225,7 +225,7 @@ std::unordered_map<LOT, int32_t> LootGenerator::RollLootMatrix(uint32_t matrixIn
 
                 float rarityRoll = GeneralUtils::GenerateRandomNumber<float>(0, 1);
 
-                for (RarityTableEntry rarity : rarityTable) {
+                for (const RarityTableEntry& rarity : rarityTable) {
                     if (rarity.randMax >= rarityRoll) {
                         maxRarity = rarity.rarity;
                     } else {
@@ -249,7 +249,7 @@ std::unordered_map<LOT, int32_t> LootGenerator::RollLootMatrix(uint32_t matrixIn
                 }
 
                 if (possibleDrops.size() > 0) {
-                    LootTableEntry drop = possibleDrops[GeneralUtils::GenerateRandomNumber<uint32_t>(0, possibleDrops.size() - 1)];
+                    const LootTableEntry& drop = possibleDrops[GeneralUtils::GenerateRandomNumber<uint32_t>(0, possibleDrops.size() - 1)];
 
                     if (drops.find(drop.itemID) == drops.end()) {
                         drops.insert({drop.itemID, 1});
@@ -287,7 +287,7 @@ void LootGenerator::GiveLoot(Entity* player, std::unordered_map<LOT, int32_t>& r
 
 void LootGenerator::GiveActivityLoot(Entity* player, Entity* source, uint32_t activityID, int32_t rating) {
     CDActivityRewardsTable* activityRewardsTable = CDClientManager::Instance()->GetTable<CDActivityRewardsTable>("ActivityRewards");
-    std::vector<CDActivityRewards> activityRewards = activityRewardsTable->Query([=](CDActivityRewards entry) { return (entry.objectTemplate == activityID); });
+    std::vector<CDActivityRewards> activityRewards = activityRewardsTable->Query([activityID](CDActivityRewards entry) { return (entry.objectTemplate == activityID); });
 
     const CDActivityRewards* selectedReward = nullptr;
     for (const auto& activityReward : activityRewards) {
@@ -303,7 +303,7 @@ void LootGenerator::GiveActivityLoot(Entity* player, Entity* source, uint32_t ac
     uint32_t maxCoins = 0;
 
     CDCurrencyTableTable* currencyTableTable = CDClientManager::Instance()->GetTable<CDCurrencyTableTable>("CurrencyTable");
-    std::vector<CDCurrencyTable> currencyTable = currencyTableTable->Query([=](CDCurrencyTable entry) { return (entry.currencyIndex == selectedReward->CurrencyIndex && entry.npcminlevel == 1); });
+    std::vector<CDCurrencyTable> currencyTable = currencyTableTable->Query([selectedReward](CDCurrencyTable entry) { return (entry.currencyIndex == selectedReward->CurrencyIndex && entry.npcminlevel == 1); });
 
     if (currencyTable.size() > 0) {
         minCoins = currencyTable[0].minvalue;
@@ -357,7 +357,7 @@ void LootGenerator::DropLoot(Entity* player, Entity* killedObject, std::unordere
 
 void LootGenerator::DropActivityLoot(Entity* player, Entity* source, uint32_t activityID, int32_t rating) {
     CDActivityRewardsTable* activityRewardsTable = CDClientManager::Instance()->GetTable<CDActivityRewardsTable>("ActivityRewards");
-    std::vector<CDActivityRewards> activityRewards = activityRewardsTable->Query([=](CDActivityRewards entry) { return (entry.objectTemplate == activityID); });
+    std::vector<CDActivityRewards> activityRewards = activityRewardsTable->Query([activityID](CDActivityRewards entry) { return (entry.objectTemplate == activityID); });
 
     const CDActivityRewards* selectedReward = nullptr;
     for (const auto& activityReward : activityRewards) {
@@ -374,7 +374,7 @@ void LootGenerator::DropActivityLoot(Entity* player, Entity* source, uint32_t ac
     uint32_t maxCoins = 0;
 
     CDCurrencyTableTable* currencyTableTable = CDClientManager::Instance()->GetTable<CDCurrencyTableTable>("CurrencyTable");
-    std::vector<CDCurrencyTable> currencyTable = currencyTableTable->Query([=](CDCurrencyTable entry) { return (entry.currencyIndex == selectedReward->CurrencyIndex && entry.npcminlevel == 1); });
+    std::vector<CDCurrencyTable> currencyTable = currencyTableTable->Query([selectedReward](CDCurrencyTable entry) { return (entry.currencyIndex == selectedReward->CurrencyIndex && entry.npcminlevel == 1); });
 
     if (currencyTable.size() > 0) {
         minCoins = currencyTable[0].minvalue;

--- a/dGame/dUtilities/Loot.cpp
+++ b/dGame/dUtilities/Loot.cpp
@@ -1,384 +1,326 @@
-#include "Loot.h"
-#include "GameMessages.h"
-
-#include "CDClientManager.h"
-#include "CDLootMatrixTable.h"
-#include "CDLootTableTable.h"
-
-#include "SimplePhysicsComponent.h"
-#include "ControllablePhysicsComponent.h"
-#include "DestroyableComponent.h"
-#include "MissionComponent.h"
-#include "CharacterComponent.h"
-#include "TeamManager.h"
-
 #include <algorithm>
 
-std::vector<CDLootTable> Loot::GetLootOfRarity(const std::vector<CDLootTable> &lootTable, uint32_t rarity) {
-	std::vector<CDLootTable> refinedLoot;
-	for (auto loot : lootTable) {
-		CDItemComponent item = Inventory::FindItemComponent(loot.itemid);
-		if (item.rarity == rarity) {
-			refinedLoot.push_back(loot);
-		}
-		else if (item.rarity == 0) {
-			refinedLoot.push_back(loot); // powerups
-		}
-	}
+#include "Loot.h"
 
-	return refinedLoot;
+#include "CDComponentsRegistryTable.h"
+#include "CDItemComponentTable.h"
+#include "CDLootMatrixTable.h"
+#include "CDLootTableTable.h"
+#include "CDRarityTableTable.h"
+#include "Character.h"
+#include "Entity.h"
+#include "GameMessages.h"
+#include "GeneralUtils.h"
+#include "InventoryComponent.h"
+#include "MissionComponent.h"
+
+LootGenerator::LootGenerator() {
+    CDLootTableTable* lootTableTable = CDClientManager::Instance()->GetTable<CDLootTableTable>("LootTable");
+    CDComponentsRegistryTable* componentsRegistryTable = CDClientManager::Instance()->GetTable<CDComponentsRegistryTable>("ComponentsRegistry");
+    CDItemComponentTable* itemComponentTable = CDClientManager::Instance()->GetTable<CDItemComponentTable>("ItemComponent");
+    CDLootMatrixTable* lootMatrixTable = CDClientManager::Instance()->GetTable<CDLootMatrixTable>("LootMatrix");
+    CDRarityTableTable* rarityTableTable = CDClientManager::Instance()->GetTable<CDRarityTableTable>("RarityTable");
+
+    // ==============================
+    // Cache Item Rarities
+    // ==============================
+
+    std::vector<uint32_t> uniqueItems;
+
+    for (const CDLootTable& loot : lootTableTable->GetEntries()) {
+        uniqueItems.push_back(loot.itemid);
+    }
+
+    // filter out duplicates
+    std::sort(uniqueItems.begin(), uniqueItems.end());
+    uniqueItems.erase(std::unique(uniqueItems.begin(), uniqueItems.end()), uniqueItems.end());
+
+    for (const uint32_t itemID : uniqueItems) {
+        uint32_t itemComponentID = componentsRegistryTable->GetByIDAndType(itemID, COMPONENT_TYPE_ITEM);
+        CDItemComponent item = itemComponentTable->GetItemComponentByID(itemComponentID);
+
+        m_ItemRarities.insert({itemID, item.rarity});
+    }
+
+    // ==============================
+    // Cache Rarity Tables
+    // ==============================
+
+    std::vector<uint32_t> uniqueRarityIndices;
+
+    for (const CDRarityTable& rarity : rarityTableTable->GetEntries()) {
+        uniqueRarityIndices.push_back(rarity.RarityTableIndex);
+    }
+
+    // filter out duplicates
+    std::sort(uniqueRarityIndices.begin(), uniqueRarityIndices.end());
+    uniqueRarityIndices.erase(std::unique(uniqueRarityIndices.begin(), uniqueRarityIndices.end()), uniqueRarityIndices.end());
+
+    for (const uint32_t index : uniqueRarityIndices) {
+        std::vector<CDRarityTable> table = rarityTableTable->Query([index](const CDRarityTable& entry) { return entry.RarityTableIndex == index; });
+
+        RarityTable rarityTable;
+
+        for (const CDRarityTable& entry : table) {
+            RarityTableEntry rarity{entry.rarity, entry.randmax};
+            rarityTable.push_back(rarity);
+        }
+
+        // sort in descending order based on randMax
+        std::sort(rarityTable.begin(), rarityTable.end(), [](const RarityTableEntry& x, const RarityTableEntry& y) { return x.randMax < y.randMax; });
+
+        m_RarityTables.insert({index, rarityTable});
+    }
+
+    // ==============================
+    // Cache Loot Matrices
+    // ==============================
+
+    std::vector<uint32_t> uniqueMatrixIndices;
+
+    for (const CDLootMatrix& matrix : lootMatrixTable->GetEntries()) {
+        uniqueMatrixIndices.push_back(matrix.LootMatrixIndex);
+    }
+
+    // filter out duplicates
+    std::sort(uniqueMatrixIndices.begin(), uniqueMatrixIndices.end());
+    uniqueMatrixIndices.erase(std::unique(uniqueMatrixIndices.begin(), uniqueMatrixIndices.end()), uniqueMatrixIndices.end());
+
+    for (const uint32_t index : uniqueMatrixIndices) {
+        std::vector<CDLootMatrix> matrix = lootMatrixTable->Query([index](const CDLootMatrix& entry) { return entry.LootMatrixIndex == index; });
+
+        LootMatrix lootMatrix;
+
+        for (const CDLootMatrix& entry : matrix) {
+            LootMatrixEntry matrixEntry{entry.LootTableIndex, entry.RarityTableIndex, entry.percent, entry.minToDrop, entry.maxToDrop};
+            lootMatrix.push_back(matrixEntry);
+        }
+
+        m_LootMatrices.insert({index, lootMatrix});
+    }
+
+    // ==============================
+    // Cache Loot Tables
+    // ==============================
+
+    std::vector<uint32_t> uniqueTableIndices;
+
+    for (const CDLootTable& entry : lootTableTable->GetEntries()) {
+        uniqueTableIndices.push_back(entry.LootTableIndex);
+    }
+
+    // filter out duplicates
+    std::sort(uniqueTableIndices.begin(), uniqueTableIndices.end());
+    uniqueTableIndices.erase(std::unique(uniqueTableIndices.begin(), uniqueTableIndices.end()), uniqueTableIndices.end());
+
+    for (const uint32_t index : uniqueTableIndices) {
+        std::vector<CDLootTable> entries = lootTableTable->Query([index](const CDLootTable& entry) { return entry.LootTableIndex == index; });
+
+        LootTable lootTable;
+
+        for (const CDLootTable& entry : entries) {
+            LootTableEntry tableEntry{entry.itemid, entry.MissionDrop};
+            lootTable.push_back(tableEntry);
+        }
+
+        // sort by item rarity descending
+        std::sort(lootTable.begin(), lootTable.end(), [&](const LootTableEntry& x, const LootTableEntry& y) {
+            return m_ItemRarities[x.itemID] < m_ItemRarities[y.itemID];
+        });
+
+        m_LootTables.insert({index, lootTable});
+    }
 }
 
-void Loot::GiveLoot(Entity* user, uint32_t lootMatrixID) {
-	user = user->GetOwner(); // If the owner is overwritten, we collect that here
+std::unordered_map<LOT, int32_t> LootGenerator::RollLootMatrix(Entity* player, uint32_t matrixIndex) {
+    auto* missionComponent = player->GetComponent<MissionComponent>();
 
-	std::unordered_map<LOT, int32_t> result {};
+    std::unordered_map<LOT, int32_t> drops;
 
-	CalculateLootMatrix(lootMatrixID, user, result);
+    LootMatrix matrix = m_LootMatrices[matrixIndex];
 
-	GiveLoot(user, result);
+    for (const LootMatrixEntry& entry : matrix) {
+        if (GeneralUtils::GenerateRandomNumber<float>(0, 1) < entry.percent) {
+            LootTable lootTable = m_LootTables[entry.lootTableIndex];
+            RarityTable rarityTable = m_RarityTables[entry.rarityTableIndex];
+
+            uint32_t dropCount = GeneralUtils::GenerateRandomNumber<uint32_t>(entry.minDrop, entry.maxDrop);
+            for (uint32_t i = 0; i < dropCount; ++i) {
+                uint32_t maxRarity = 1;
+
+                float rarityRoll = GeneralUtils::GenerateRandomNumber<float>(0, 1);
+
+                for (RarityTableEntry rarity : rarityTable) {
+                    if (rarity.randMax >= rarityRoll) {
+                        maxRarity = rarity.rarity;
+                    } else {
+                        break;
+                    }
+                }
+
+                bool rarityFound = false;
+                std::vector<LootTableEntry> possibleDrops;
+
+                for (const LootTableEntry& loot : lootTable) {
+                    uint32_t rarity = m_ItemRarities[loot.itemID];
+
+                    if (rarity == maxRarity) {
+                        possibleDrops.push_back(loot);
+                        rarityFound = true;
+                    } else if (rarity < maxRarity && !rarityFound) {
+                        possibleDrops.push_back(loot);
+                        maxRarity = rarity;
+                    }
+                }
+
+                if (possibleDrops.size() > 0) {
+                    LootTableEntry drop = possibleDrops[GeneralUtils::GenerateRandomNumber<uint32_t>(0, possibleDrops.size() - 1)];
+
+                    // filter out uneeded mission items
+                    if (drop.isMissionDrop && !missionComponent->RequiresItem(drop.itemID))
+                        continue;
+
+                    // convert faction token proxy
+                    if (drop.itemID == 13763) {
+                        if (missionComponent->GetMissionState(545) == MissionState::MISSION_STATE_COMPLETE)
+                            drop.itemID = 8318; // "Assembly Token"
+                        else if (missionComponent->GetMissionState(556) == MissionState::MISSION_STATE_COMPLETE)
+                            drop.itemID = 8321; // "Venture League Token"
+                        else if (missionComponent->GetMissionState(567) == MissionState::MISSION_STATE_COMPLETE)
+                            drop.itemID = 8319; // "Sentinels Token"
+                        else if (missionComponent->GetMissionState(578) == MissionState::MISSION_STATE_COMPLETE)
+                            drop.itemID = 8320; // "Paradox Token"
+                    }
+
+                    if (drops.find(drop.itemID) == drops.end()) {
+                        drops.insert({drop.itemID, 1});
+                    } else {
+                        ++drops[drop.itemID];
+                    }
+                }
+            }
+        }
+    }
+
+    return drops;
 }
 
-void Loot::DropLoot(Entity* user, Entity* killedObject, uint32_t lootMatrixID, uint32_t minCoins, uint32_t maxCoins) {
-	user = user->GetOwner(); // If the owner is overwritten, we collect that here
+void LootGenerator::GiveLoot(Entity* player, uint32_t matrixIndex) {
+    player = player->GetOwner(); // If the owner is overwritten, we collect that here
 
-	auto* inventoryComponent = user->GetComponent<InventoryComponent>();
+    std::unordered_map<LOT, int32_t> result = RollLootMatrix(player, matrixIndex);
 
-	if (inventoryComponent == nullptr) {
-		return;
-	}
-
-	std::unordered_map<LOT, int32_t> result {};
-
-	CalculateLootMatrix(lootMatrixID, user, result);
-
-	DropLoot(user, killedObject, result, minCoins, maxCoins);
+    GiveLoot(player, result);
 }
 
-void Loot::GiveLoot(Entity* user, std::unordered_map<LOT, int32_t>& result) {
-	user = user->GetOwner(); // If the owner is overwritten, we collect that here
+void LootGenerator::GiveLoot(Entity* player, std::unordered_map<LOT, int32_t>& result) {
+    player = player->GetOwner(); // if the owner is overwritten, we collect that here
 
-	auto* inventoryComponent = user->GetComponent<InventoryComponent>();
+    auto* inventoryComponent = player->GetComponent<InventoryComponent>();
 
-	if (inventoryComponent == nullptr) {
-		return;
-	}
+    if (!inventoryComponent)
+        return;
 
-	for (const auto& pair : result) {
-		inventoryComponent->AddItem(pair.first, pair.second);
-	}
+    for (const auto& pair : result) {
+        inventoryComponent->AddItem(pair.first, pair.second);
+    }
 }
 
-void Loot::DropLoot(Entity* user, Entity* killedObject, std::unordered_map<LOT, int32_t>& result, uint32_t minCoins, uint32_t maxCoins) {
-	user = user->GetOwner(); // If the owner is overwritten, we collect that here
+void LootGenerator::GiveActivityLoot(Entity* player, Entity* source, uint32_t activityID, int32_t rating) {
+    CDActivityRewardsTable* activityRewardsTable = CDClientManager::Instance()->GetTable<CDActivityRewardsTable>("ActivityRewards");
+    std::vector<CDActivityRewards> activityRewards = activityRewardsTable->Query([=](CDActivityRewards entry) { return (entry.objectTemplate == activityID); });
 
-	auto* inventoryComponent = user->GetComponent<InventoryComponent>();
+    const CDActivityRewards* selectedReward = nullptr;
+    for (const auto& activityReward : activityRewards) {
+        if (activityReward.activityRating <= rating && (selectedReward == nullptr || activityReward.activityRating > selectedReward->activityRating)) {
+            selectedReward = &activityReward;
+        }
+    }
 
-	if (inventoryComponent == nullptr) {
-		return;
-	}
+    if (!selectedReward)
+        return;
 
-	const auto spawnPosition = killedObject->GetPosition();
-	
-	const auto source = killedObject->GetObjectID();
+    uint32_t minCoins = 0;
+    uint32_t maxCoins = 0;
 
-	for (const auto& pair : result) {
-		for (int i = 0; i < pair.second; ++i) {
-			GameMessages::SendDropClientLoot(user, source, pair.first, 0, spawnPosition, 1);
-		}
-	}
+    CDCurrencyTableTable* currencyTableTable = CDClientManager::Instance()->GetTable<CDCurrencyTableTable>("CurrencyTable");
+    std::vector<CDCurrencyTable> currencyTable = currencyTableTable->Query([=](CDCurrencyTable entry) { return (entry.currencyIndex == selectedReward->CurrencyIndex && entry.npcminlevel == 1); });
 
-	uint32_t coins = (int)(minCoins + GeneralUtils::GenerateRandomNumber<float>(0, 1) * (maxCoins - minCoins));
+    if (currencyTable.size() > 0) {
+        minCoins = currencyTable[0].minvalue;
+        maxCoins = currencyTable[0].maxvalue;
+    }
 
-	GameMessages::SendDropClientLoot(user, source, LOT_NULL, coins, spawnPosition);
+    GiveLoot(player, selectedReward->LootMatrixIndex);
+
+    uint32_t coins = (int)(minCoins + GeneralUtils::GenerateRandomNumber<float>(0, 1) * (maxCoins - minCoins));
+
+    auto* character = player->GetCharacter();
+
+    character->SetCoins(character->GetCoins() + coins);
 }
 
-void Loot::DropActivityLoot(Entity* user, Entity* source, uint32_t activityID, int32_t rating)
-{
-	CDActivityRewardsTable* activityRewardsTable = CDClientManager::Instance()->GetTable<CDActivityRewardsTable>("ActivityRewards");
-	std::vector<CDActivityRewards> activityRewards = activityRewardsTable->Query([=](CDActivityRewards entry) { return (entry.objectTemplate == activityID); });
+void LootGenerator::DropLoot(Entity* player, Entity* killedObject, uint32_t matrixIndex, uint32_t minCoins, uint32_t maxCoins) {
+    player = player->GetOwner(); // if the owner is overwritten, we collect that here
 
-	const CDActivityRewards* selectedReward = nullptr;
-	for (const auto& activityReward : activityRewards)
-	{
-		if (activityReward.activityRating <= rating && (selectedReward == nullptr || activityReward.activityRating > selectedReward->activityRating))
-		{
-			selectedReward = &activityReward;
-		}
-	}
+    auto* inventoryComponent = player->GetComponent<InventoryComponent>();
 
-	if (selectedReward == nullptr)
-	{
-		return;
-	}
+    if (!inventoryComponent)
+        return;
 
-	uint32_t minCoins = 0;
-	uint32_t maxCoins = 0;
+    std::unordered_map<LOT, int32_t> result = RollLootMatrix(player, matrixIndex);
 
-	CDCurrencyTableTable* currencyTableTable = CDClientManager::Instance()->GetTable<CDCurrencyTableTable>("CurrencyTable");
-	std::vector<CDCurrencyTable> currencyTable = currencyTableTable->Query([=](CDCurrencyTable entry) { return (entry.currencyIndex == selectedReward->CurrencyIndex && entry.npcminlevel == 1); });
-
-	if (currencyTable.size() > 0) {
-		minCoins = currencyTable[0].minvalue;
-		maxCoins = currencyTable[0].maxvalue;
-	}
-
-	Loot::DropLoot(user, source, selectedReward->LootMatrixIndex, minCoins, maxCoins);
+    DropLoot(player, killedObject, result, minCoins, maxCoins);
 }
 
-void Loot::GiveActivityLoot(Entity* user, Entity* source, uint32_t activityID, int32_t rating) 
-{
-	CDActivityRewardsTable* activityRewardsTable = CDClientManager::Instance()->GetTable<CDActivityRewardsTable>("ActivityRewards");
-	std::vector<CDActivityRewards> activityRewards = activityRewardsTable->Query([=](CDActivityRewards entry) { return (entry.objectTemplate == activityID); });
+void LootGenerator::DropLoot(Entity* player, Entity* killedObject, std::unordered_map<LOT, int32_t>& result, uint32_t minCoins, uint32_t maxCoins) {
+    player = player->GetOwner(); // if the owner is overwritten, we collect that here
 
-	const CDActivityRewards* selectedReward = nullptr;
-	for (const auto& activityReward : activityRewards)
-	{
-		if (activityReward.activityRating <= rating && (selectedReward == nullptr || activityReward.activityRating > selectedReward->activityRating))
-		{
-			selectedReward = &activityReward;
-		}
-	}
+    auto* inventoryComponent = player->GetComponent<InventoryComponent>();
 
-	if (selectedReward == nullptr)
-	{
-		return;
-	}
+    if (!inventoryComponent)
+        return;
 
-	uint32_t minCoins = 0;
-	uint32_t maxCoins = 0;
+    const auto spawnPosition = killedObject->GetPosition();
 
-	CDCurrencyTableTable* currencyTableTable = CDClientManager::Instance()->GetTable<CDCurrencyTableTable>("CurrencyTable");
-	std::vector<CDCurrencyTable> currencyTable = currencyTableTable->Query([=](CDCurrencyTable entry) { return (entry.currencyIndex == selectedReward->CurrencyIndex && entry.npcminlevel == 1); });
+    const auto source = killedObject->GetObjectID();
 
-	if (currencyTable.size() > 0) {
-		minCoins = currencyTable[0].minvalue;
-		maxCoins = currencyTable[0].maxvalue;
-	}
+    for (const auto& pair : result) {
+        for (int i = 0; i < pair.second; ++i) {
+            GameMessages::SendDropClientLoot(player, source, pair.first, 0, spawnPosition, 1);
+        }
+    }
 
-	Loot::GiveLoot(user, selectedReward->LootMatrixIndex);
+    uint32_t coins = (int)(minCoins + GeneralUtils::GenerateRandomNumber<float>(0, 1) * (maxCoins - minCoins));
 
-	uint32_t coins = (int)(minCoins + GeneralUtils::GenerateRandomNumber<float>(0, 1) * (maxCoins - minCoins));
-
-	auto* charactert = user->GetCharacter();
-
-	charactert->SetCoins(charactert->GetCoins() + coins);
+    GameMessages::SendDropClientLoot(player, source, LOT_NULL, coins, spawnPosition);
 }
 
-void Loot::CalculateLootMatrix(uint32_t lootMatrixID, Entity* user, std::unordered_map<LOT, int32_t>& result) 
-{
-	user = user->GetOwner();
+void LootGenerator::DropActivityLoot(Entity* player, Entity* source, uint32_t activityID, int32_t rating) {
+    CDActivityRewardsTable* activityRewardsTable = CDClientManager::Instance()->GetTable<CDActivityRewardsTable>("ActivityRewards");
+    std::vector<CDActivityRewards> activityRewards = activityRewardsTable->Query([=](CDActivityRewards entry) { return (entry.objectTemplate == activityID); });
 
-	auto* missionComponent = user->GetComponent<MissionComponent>();
+    const CDActivityRewards* selectedReward = nullptr;
+    for (const auto& activityReward : activityRewards) {
+        if (activityReward.activityRating <= rating && (selectedReward == nullptr || activityReward.activityRating > selectedReward->activityRating)) {
+            selectedReward = &activityReward;
+        }
+    }
 
-	// Get our loot for this LOT's lootMatrixID:
-	CDLootMatrixTable* lootMatrixTable = CDClientManager::Instance()->GetTable<CDLootMatrixTable>("LootMatrix");
-	CDLootTableTable* lootTableTable = CDClientManager::Instance()->GetTable<CDLootTableTable>("LootTable");
-	CDRarityTableTable* rarityTableTable = CDClientManager::Instance()->GetTable<CDRarityTableTable>("RarityTable");
+    if (selectedReward == nullptr) {
+        return;
+    }
 
-	std::vector<CDLootMatrix> lootMatrix = lootMatrixTable->Query([lootMatrixID](CDLootMatrix entry) { return (entry.LootMatrixIndex == lootMatrixID); });
+    uint32_t minCoins = 0;
+    uint32_t maxCoins = 0;
 
-	// Now, loop through each entry
-	for (uint32_t i = 0; i < lootMatrix.size(); ++i) {
-		// Now, determine whether or not we should drop this
-		float chanceToDrop = 1.0 - lootMatrix[i].percent;
-		float shouldDrop = GeneralUtils::GenerateRandomNumber<float>(0, 1);
+    CDCurrencyTableTable* currencyTableTable = CDClientManager::Instance()->GetTable<CDCurrencyTableTable>("CurrencyTable");
+    std::vector<CDCurrencyTable> currencyTable = currencyTableTable->Query([=](CDCurrencyTable entry) { return (entry.currencyIndex == selectedReward->CurrencyIndex && entry.npcminlevel == 1); });
 
-		const auto rarityTableIndex = lootMatrix[i].RarityTableIndex;
+    if (currencyTable.size() > 0) {
+        minCoins = currencyTable[0].minvalue;
+        maxCoins = currencyTable[0].maxvalue;
+    }
 
-		std::vector<CDRarityTable> rarityTable = rarityTableTable->Query([rarityTableIndex](CDRarityTable entry) { return (entry.RarityTableIndex == rarityTableIndex); });
-		
-		std::sort(rarityTable.begin(), rarityTable.end());
-
-		if (shouldDrop < chanceToDrop) {
-			// We are not able to drop this item, so continue
-			continue;
-		}
-
-		// If we reached here, we are able to drop the item
-		uint32_t minToDrop = lootMatrix[i].minToDrop;
-		uint32_t maxToDrop = lootMatrix[i].maxToDrop;
-
-		// Now determine the number we will drop of items from this table
-		uint32_t numToDrop = GeneralUtils::GenerateRandomNumber<uint32_t>(minToDrop, maxToDrop);
-
-		// Now, query the loot matrix index
-		const auto lootTableIndex = lootMatrix[i].LootTableIndex;
-
-		std::vector<CDLootTable> lootTable = lootTableTable->Query([lootTableIndex](CDLootTable entry) { return (entry.LootTableIndex == lootTableIndex); });
-
-		// Now randomize these entries
-		if (lootTable.size() > 1) {
-			std::shuffle(std::begin(lootTable), std::end(lootTable), Game::randomEngine);
-		}
-
-		uint32_t addedItems = 0;
-
-		if (lootTable.empty()) continue;
-
-		while (addedItems < numToDrop) {
-			addedItems++;
-			
-			float rarityRoll = GeneralUtils::GenerateRandomNumber<float>(0, 1);
-
-			// im sorry
-			uint32_t highestRarity = 1; // LOOT_COMMON
-			float highestRandMax = 0.0f;
-			for (const auto& rarity : rarityTable) {
-				if (rarityRoll > rarity.randmax && rarity.randmax > highestRandMax) {
-					highestRandMax = rarity.randmax;
-					highestRarity = rarity.rarity + 1;
-				}
-			}
-
-			std::vector<CDLootTable> refinedLoot;
-
-			if (lootTable.size() == 1)
-			{
-				refinedLoot = lootTable;
-			}
-			else
-			{
-				refinedLoot = GetLootOfRarity(lootTable, highestRarity);
-
-				bool continueLoop = false;
-				while (refinedLoot.empty())
-				{
-					if (highestRarity == 1)
-					{
-						continueLoop = true;
-						break;
-					}
-
-					highestRarity -= 1;
-
-					refinedLoot = GetLootOfRarity(lootTable, highestRarity);
-
-					if (!refinedLoot.empty())
-					{
-						break;
-					}
-				}
-
-				if (continueLoop) continue;
-			}
-			
-			int randomTable = GeneralUtils::GenerateRandomNumber<int>(0, refinedLoot.size() - 1);
-
-			const auto& selectedTable = refinedLoot[randomTable];
-
-			uint32_t itemLOT = selectedTable.itemid;
-			bool isMissionItem = selectedTable.MissionDrop;
-
-			if (isMissionItem && missionComponent != nullptr)
-			{
-                // TODO: this executes a query in a hot path, might be worth refactoring away
-				if (!missionComponent->RequiresItem(itemLOT))
-				{
-					continue;
-				}
-			}
-
-			if (lootTable.size() > numToDrop)
-			{
-				for (size_t i = 0; i < lootTable.size(); i++)
-				{
-					if (lootTable[i].id == selectedTable.id)
-					{
-						lootTable.erase(lootTable.begin() + i);
-
-						break;
-					}
-				}
-			}
-
-			const auto& it = result.find(itemLOT);
-			if (it != result.end()) {
-				it->second++;
-			}
-			else {
-				result.emplace(itemLOT, 1);
-			}
-		}
-	}
-
-	int32_t tokenCount = 0;
-
-	const auto& tokens = result.find(13763);
-
-	if (tokens != result.end()) {
-		tokenCount = tokens->second;
-
-		result.erase(tokens);
-	}
-
-	if (tokenCount == 0 || user == nullptr) {
-		return;
-	}
-
-	if (missionComponent == nullptr) {
-		return;
-	}
-
-	LOT tokenId = -1;
-
-	if (missionComponent->GetMissionState(545) == MissionState::MISSION_STATE_COMPLETE) // "Join Assembly!"
-	{
-		tokenId = 8318; // "Assembly Token"
-	}
-
-	if (missionComponent->GetMissionState(556) == MissionState::MISSION_STATE_COMPLETE) // "Join Venture League!"
-	{
-		tokenId = 8321; // "Venture League Token"
-	}
-
-	if (missionComponent->GetMissionState(567) == MissionState::MISSION_STATE_COMPLETE) // "Join The Sentinels!"
-	{
-		tokenId = 8319; // "Sentinels Token"
-	}
-
-	if (missionComponent->GetMissionState(578) == MissionState::MISSION_STATE_COMPLETE) // "Join Paradox!"
-	{
-		tokenId = 8320; // "Paradox Token"
-	}
-
-	if (tokenId != -1)
-	{
-		result.emplace(tokenId, tokenCount);
-	}
-}
-
-void Loot::DropItem(Entity* user, Entity* sourceObject, LOT item, int32_t currency, int32_t count, bool useTeam, bool freeForAll) 
-{
-	if (sourceObject == nullptr)
-	{
-		return;
-	}
-
-	const auto sourceID = sourceObject->GetObjectID();
-	const auto sourcePosition = sourceObject->GetPosition();
-
-	// If useTeam, drop the item once for each team member.
-	auto* team = TeamManager::Instance()->GetTeam(user->GetObjectID());
-
-	if (team != nullptr && useTeam)
-	{
-		for (const auto& memberID : team->members)
-		{
-			// Get the team member from its ID.
-			auto* member = EntityManager::Instance()->GetEntity(memberID);
-
-			if (member == nullptr) 
-			{
-				continue;
-			}
-
-			// Drop the item.
-			GameMessages::SendDropClientLoot(member, sourceID, item, currency, sourcePosition, count);
-		}
-
-		return;
-	}
-
-	GameMessages::SendDropClientLoot(user, sourceID, item, currency, sourcePosition, count);
+    DropLoot(player, source, selectedReward->LootMatrixIndex, minCoins, maxCoins);
 }

--- a/dGame/dUtilities/Loot.h
+++ b/dGame/dUtilities/Loot.h
@@ -1,31 +1,71 @@
 #pragma once
+
 #include "dCommonVars.h"
-#include <vector>
-#include "CDClientManager.h"
+#include <unordered_map>
+
 class Entity;
 
+struct RarityTableEntry {
+    uint8_t rarity;
+    float randMax;
+};
+
+typedef std::vector<RarityTableEntry> RarityTable;
+
+struct LootMatrixEntry {
+    uint32_t lootTableIndex;
+    uint32_t rarityTableIndex;
+    float percent;
+    uint32_t minDrop;
+    uint32_t maxDrop;
+};
+
+typedef std::vector<LootMatrixEntry> LootMatrix;
+
+struct LootTableEntry {
+    LOT itemID;
+    bool isMissionDrop;
+};
+
+typedef std::vector<LootTableEntry> LootTable;
+
+// used for glue code with Entity and Player classes
 namespace Loot {
-	struct Info {
-		LWOOBJID id;
-		LOT lot;
-		uint32_t count;
-	};
+    struct Info {
+        LWOOBJID id;
+        LOT lot;
+        uint32_t count;
+    };
+}
 
-	std::vector<CDLootTable> GetLootOfRarity(const std::vector<CDLootTable> &lootTable, uint32_t rarity);
+class LootGenerator;
 
-	void DropActivityLoot(Entity* user, Entity* source, uint32_t activityID, int32_t rating = 0);
+static LootGenerator* m_Address;
 
-	void GiveActivityLoot(Entity* user, Entity* source, uint32_t activityID, int32_t rating = 0);
+class LootGenerator {
+  public:
+    LootGenerator();
 
-	void CalculateLootMatrix(uint32_t lootMatrixID, Entity* user, std::unordered_map<LOT, int32_t>& result);
+    
+    static LootGenerator* Instance() {
+        if (!m_Address) {
+            m_Address = new LootGenerator();
+        }
 
-	void GiveLoot(Entity* user, uint32_t lootMatrixID);
+        return m_Address;
+    }
 
-	void DropLoot(Entity* user, Entity* killedObject, uint32_t lootMatrixID, uint32_t minCoins, uint32_t maxCoins);
+    std::unordered_map<LOT, int32_t> RollLootMatrix(Entity* player, uint32_t matrixIndex);
+    void GiveLoot(Entity* player, uint32_t matrixIndex);
+    void GiveLoot(Entity* player, std::unordered_map<LOT, int32_t>& result);
+    void GiveActivityLoot(Entity* player, Entity* source, uint32_t activityID, int32_t rating = 0);
+    void DropLoot(Entity* player, Entity* killedObject, uint32_t matrixIndex, uint32_t minCoins, uint32_t maxCoins);
+    void DropLoot(Entity* player, Entity* killedObject, std::unordered_map<LOT, int32_t>& result, uint32_t minCoins, uint32_t maxCoins);
+    void DropActivityLoot(Entity* player, Entity* source, uint32_t activityID, int32_t rating = 0);
 
-	void GiveLoot(Entity* user, std::unordered_map<LOT, int32_t>& result);
-
-	void DropLoot(Entity* user, Entity* killedObject, std::unordered_map<LOT, int32_t>& result, uint32_t minCoins, uint32_t maxCoins);
-
-	void DropItem(Entity* user, Entity* sourceObject, LOT item, int32_t currency, int32_t count, bool useTeam = false, bool freeForAll = false);
+  private:
+    std::unordered_map<uint32_t, uint8_t> m_ItemRarities;
+    std::unordered_map<uint32_t, RarityTable> m_RarityTables;
+    std::unordered_map<uint32_t, LootMatrix> m_LootMatrices;
+    std::unordered_map<uint32_t, LootTable> m_LootTables;
 };

--- a/dGame/dUtilities/Loot.h
+++ b/dGame/dUtilities/Loot.h
@@ -2,6 +2,7 @@
 
 #include "dCommonVars.h"
 #include <unordered_map>
+#include "Singleton.h"
 
 class Entity;
 
@@ -38,22 +39,10 @@ namespace Loot {
     };
 }
 
-class LootGenerator;
 
-static LootGenerator* m_Address;
-
-class LootGenerator {
+class LootGenerator : public Singleton<LootGenerator> {
   public:
     LootGenerator();
-
-    
-    static LootGenerator* Instance() {
-        if (!m_Address) {
-            m_Address = new LootGenerator();
-        }
-
-        return m_Address;
-    }
 
     std::unordered_map<LOT, int32_t> RollLootMatrix(Entity* player, uint32_t matrixIndex);
     void GiveLoot(Entity* player, uint32_t matrixIndex);

--- a/dGame/dUtilities/Loot.h
+++ b/dGame/dUtilities/Loot.h
@@ -7,7 +7,7 @@
 class Entity;
 
 struct RarityTableEntry {
-    uint8_t rarity;
+    uint32_t rarity;
     float randMax;
 };
 
@@ -45,6 +45,7 @@ class LootGenerator : public Singleton<LootGenerator> {
     LootGenerator();
 
     std::unordered_map<LOT, int32_t> RollLootMatrix(Entity* player, uint32_t matrixIndex);
+    std::unordered_map<LOT, int32_t> RollLootMatrix(uint32_t matrixIndex);
     void GiveLoot(Entity* player, uint32_t matrixIndex);
     void GiveLoot(Entity* player, std::unordered_map<LOT, int32_t>& result);
     void GiveActivityLoot(Entity* player, Entity* source, uint32_t activityID, int32_t rating = 0);

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -618,18 +618,6 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		return;
 	}
 
-	if (chatCommand == "clearinv" && entity->GetGMLevel() >= GAME_MASTER_LEVEL_DEVELOPER) {
-        auto comp = static_cast<InventoryComponent*>(entity->GetComponent(COMPONENT_TYPE_INVENTORY));
-        if (comp) {
-			for (const auto& item : comp->GetInventories()) {
-				for (const auto& invItem : item.second->GetItems()) {
-					comp->RemoveItem(invItem.second->GetLot(), invItem.second->GetCount(), item.first);
-				}
-			}
-		}
-            
-    }
-
 	if (chatCommand == "addmission" && entity->GetGMLevel() >= GAME_MASTER_LEVEL_DEVELOPER) {
 		if (args.size() == 0) return;
 

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -1691,6 +1691,44 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		return;
 	}
 
+	if (chatCommand == "rollloot" && entity->GetGMLevel() >= GAME_MASTER_LEVEL_OPERATOR && args.size() >= 3) {
+		uint32_t lootMatrixIndex = 0;
+		uint32_t targetLot = 0;
+		uint32_t loops = 1;
+
+		if (!GeneralUtils::TryParse(args[0], lootMatrixIndex)) return;
+		if (!GeneralUtils::TryParse(args[1], targetLot)) return;
+		if (!GeneralUtils::TryParse(args[2], loops)) return;
+
+		uint64_t totalRuns = 0;
+
+		for (uint32_t i = 0; i < loops; i++) {
+			while (true) {
+				auto lootRoll = LootGenerator::Instance().RollLootMatrix(lootMatrixIndex);
+				totalRuns += 1;
+				bool doBreak = false;
+				for (const auto& kv : lootRoll) {
+					if ((uint32_t)kv.first == targetLot) {
+						doBreak = true;
+					}
+				}
+				if (doBreak) break;
+			}
+			Game::logger->Log("Debug", "On roll " + std::to_string(i) + " out of " + std::to_string(loops) + ". \n");
+		}
+
+		std::u16string message = u"Ran loot drops looking for "
+			+ GeneralUtils::to_u16string(targetLot) 
+			+ u", " 
+			+ GeneralUtils::to_u16string(loops) 
+			+ u" times. It ran " 
+			+ GeneralUtils::to_u16string(totalRuns) 
+			+ u" times. Averaging out at "
+			+ GeneralUtils::to_u16string((float) totalRuns / loops);
+
+		ChatPackets::SendSystemMessage(sysAddr, message);
+	}
+
 	if (chatCommand == "inspect" && entity->GetGMLevel() >= GAME_MASTER_LEVEL_DEVELOPER && args.size() >= 1)
 	{
 		Entity* closest = nullptr;

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -618,6 +618,18 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		return;
 	}
 
+	if (chatCommand == "clearinv" && entity->GetGMLevel() >= GAME_MASTER_LEVEL_DEVELOPER) {
+        auto comp = static_cast<InventoryComponent*>(entity->GetComponent(COMPONENT_TYPE_INVENTORY));
+        if (comp) {
+			for (const auto& item : comp->GetInventories()) {
+				for (const auto& invItem : item.second->GetItems()) {
+					comp->RemoveItem(invItem.second->GetLot(), invItem.second->GetCount(), item.first);
+				}
+			}
+		}
+            
+    }
+
 	if (chatCommand == "addmission" && entity->GetGMLevel() >= GAME_MASTER_LEVEL_DEVELOPER) {
 		if (args.size() == 0) return;
 

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -1714,7 +1714,6 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 				}
 				if (doBreak) break;
 			}
-			Game::logger->Log("Debug", "On roll " + std::to_string(i) + " out of " + std::to_string(loops) + ". \n");
 		}
 
 		std::u16string message = u"Ran loot drops looking for "

--- a/dScripts/ActivityManager.cpp
+++ b/dScripts/ActivityManager.cpp
@@ -70,7 +70,7 @@ void ActivityManager::StopActivity(Entity *self, const LWOOBJID playerID, const 
         SetActivityValue(self, playerID, 1, value1);
         SetActivityValue(self, playerID, 2, value2);
 
-        Loot::GiveActivityLoot(player, self, gameID, CalculateActivityRating(self, playerID));
+        LootGenerator::Instance()->GiveActivityLoot(player, self, gameID, CalculateActivityRating(self, playerID));
 
         // Save the new score to the leaderboard and show the leaderboard to the player
         LeaderboardManager::SaveScore(playerID, gameID, score, value1);

--- a/dScripts/ActivityManager.cpp
+++ b/dScripts/ActivityManager.cpp
@@ -70,7 +70,7 @@ void ActivityManager::StopActivity(Entity *self, const LWOOBJID playerID, const 
         SetActivityValue(self, playerID, 1, value1);
         SetActivityValue(self, playerID, 2, value2);
 
-        LootGenerator::Instance()->GiveActivityLoot(player, self, gameID, CalculateActivityRating(self, playerID));
+        LootGenerator::Instance().GiveActivityLoot(player, self, gameID, CalculateActivityRating(self, playerID));
 
         // Save the new score to the leaderboard and show the leaderboard to the player
         LeaderboardManager::SaveScore(playerID, gameID, score, value1);

--- a/dScripts/AgPicnicBlanket.cpp
+++ b/dScripts/AgPicnicBlanket.cpp
@@ -8,7 +8,7 @@ void AgPicnicBlanket::OnUse(Entity *self, Entity *user) {
     self->SetVar<bool>(u"active", true);
 
     auto lootTable = std::unordered_map<LOT, int32_t> {{935, 3}};
-    LootGenerator::Instance()->DropLoot(user, self, lootTable, 0, 0);
+    LootGenerator::Instance().DropLoot(user, self, lootTable, 0, 0);
 
     self->AddCallbackTimer(5.0f, [self]() {
         self->SetVar<bool>(u"active", false);

--- a/dScripts/AgPicnicBlanket.cpp
+++ b/dScripts/AgPicnicBlanket.cpp
@@ -8,7 +8,7 @@ void AgPicnicBlanket::OnUse(Entity *self, Entity *user) {
     self->SetVar<bool>(u"active", true);
 
     auto lootTable = std::unordered_map<LOT, int32_t> {{935, 3}};
-    Loot::DropLoot(user, self, lootTable, 0, 0);
+    LootGenerator::Instance()->DropLoot(user, self, lootTable, 0, 0);
 
     self->AddCallbackTimer(5.0f, [self]() {
         self->SetVar<bool>(u"active", false);

--- a/dScripts/BaseInteractDropLootServer.cpp
+++ b/dScripts/BaseInteractDropLootServer.cpp
@@ -25,7 +25,7 @@ void BaseInteractDropLootServer::BaseUse(Entity* self, Entity* user)
 
     self->SetNetworkVar(u"bInUse", true);
 
-    LootGenerator::Instance()->DropLoot(user, self, lootMatrix, 0, 0);
+    LootGenerator::Instance().DropLoot(user, self, lootMatrix, 0, 0);
 
     self->AddCallbackTimer(cooldownTime, [this, self] () {
         self->SetNetworkVar(u"bInUse", false);

--- a/dScripts/BaseInteractDropLootServer.cpp
+++ b/dScripts/BaseInteractDropLootServer.cpp
@@ -25,7 +25,7 @@ void BaseInteractDropLootServer::BaseUse(Entity* self, Entity* user)
 
     self->SetNetworkVar(u"bInUse", true);
 
-    Loot::DropLoot(user, self, lootMatrix, 0, 0);
+    LootGenerator::Instance()->DropLoot(user, self, lootMatrix, 0, 0);
 
     self->AddCallbackTimer(cooldownTime, [this, self] () {
         self->SetNetworkVar(u"bInUse", false);

--- a/dScripts/BootyDigServer.cpp
+++ b/dScripts/BootyDigServer.cpp
@@ -41,7 +41,7 @@ BootyDigServer::OnFireEventServerSide(Entity *self, Entity *sender, std::string 
                 if (renderComponent != nullptr)
                     renderComponent->PlayEffect(7730, u"cast", "bootyshine");
 
-                LootGenerator::Instance()->DropLoot(player, self, 231, 75, 75);
+                LootGenerator::Instance().DropLoot(player, self, 231, 75, 75);
             }
         }
     } else if (args == "ChestDead") {

--- a/dScripts/BootyDigServer.cpp
+++ b/dScripts/BootyDigServer.cpp
@@ -41,7 +41,7 @@ BootyDigServer::OnFireEventServerSide(Entity *self, Entity *sender, std::string 
                 if (renderComponent != nullptr)
                     renderComponent->PlayEffect(7730, u"cast", "bootyshine");
 
-                Loot::DropLoot(player, self, 231, 75, 75);
+                LootGenerator::Instance()->DropLoot(player, self, 231, 75, 75);
             }
         }
     } else if (args == "ChestDead") {

--- a/dScripts/BuccaneerValiantShip.cpp
+++ b/dScripts/BuccaneerValiantShip.cpp
@@ -7,7 +7,7 @@ void BuccaneerValiantShip::OnStartup(Entity* self) {
     const auto behavior = 20577;
     const auto skillCastTimer = 1.0F;
 
-    self->AddCallbackTimer(skillCastTimer, [self]() {
+    self->AddCallbackTimer(skillCastTimer, [&]() {
         auto* skillComponent = self->GetComponent<SkillComponent>();
         auto* owner = self->GetOwner();
 

--- a/dScripts/CppScripts.h
+++ b/dScripts/CppScripts.h
@@ -6,6 +6,7 @@
 #include "MissionState.h"
 #include "Game.h"
 #include "dLogger.h"
+#include "Loot.h"
 
 class User;
 class Entity;

--- a/dScripts/GrowingFlower.cpp
+++ b/dScripts/GrowingFlower.cpp
@@ -10,7 +10,7 @@ void GrowingFlower::OnSkillEventFired(Entity *self, Entity *target, const std::s
         const auto mission1 = self->GetVar<int32_t>(u"missionID");
         const auto mission2 = self->GetVar<int32_t>(u"missionID2");
 
-        LootGenerator::Instance()->DropActivityLoot(target, self, self->GetLOT(), 0);
+        LootGenerator::Instance().DropActivityLoot(target, self, self->GetLOT(), 0);
 
         auto* missionComponent = target->GetComponent<MissionComponent>();
         if (missionComponent != nullptr) {

--- a/dScripts/GrowingFlower.cpp
+++ b/dScripts/GrowingFlower.cpp
@@ -10,7 +10,7 @@ void GrowingFlower::OnSkillEventFired(Entity *self, Entity *target, const std::s
         const auto mission1 = self->GetVar<int32_t>(u"missionID");
         const auto mission2 = self->GetVar<int32_t>(u"missionID2");
 
-        Loot::DropActivityLoot(target, self, self->GetLOT(), 0);
+        LootGenerator::Instance()->DropActivityLoot(target, self, self->GetLOT(), 0);
 
         auto* missionComponent = target->GetComponent<MissionComponent>();
         if (missionComponent != nullptr) {

--- a/dScripts/MinigameTreasureChestServer.cpp
+++ b/dScripts/MinigameTreasureChestServer.cpp
@@ -22,10 +22,10 @@ void MinigameTreasureChestServer::OnUse(Entity *self, Entity *user) {
         for (const auto& teamMemberID : team->members) {
             auto* teamMember = EntityManager::Instance()->GetEntity(teamMemberID);
             if (teamMember != nullptr)
-                LootGenerator::Instance()->DropActivityLoot(teamMember, self, sac->GetActivityID(), CalculateActivityRating(self, teamMemberID));
+                LootGenerator::Instance().DropActivityLoot(teamMember, self, sac->GetActivityID(), CalculateActivityRating(self, teamMemberID));
         }
     } else {
-        LootGenerator::Instance()->DropActivityLoot(user, self, sac->GetActivityID(), CalculateActivityRating(self, user->GetObjectID()));
+        LootGenerator::Instance().DropActivityLoot(user, self, sac->GetActivityID(), CalculateActivityRating(self, user->GetObjectID()));
     }
 
     sac->PlayerRemove(user->GetObjectID());

--- a/dScripts/MinigameTreasureChestServer.cpp
+++ b/dScripts/MinigameTreasureChestServer.cpp
@@ -22,10 +22,10 @@ void MinigameTreasureChestServer::OnUse(Entity *self, Entity *user) {
         for (const auto& teamMemberID : team->members) {
             auto* teamMember = EntityManager::Instance()->GetEntity(teamMemberID);
             if (teamMember != nullptr)
-                Loot::DropActivityLoot(teamMember, self, sac->GetActivityID(), CalculateActivityRating(self, teamMemberID));
+                LootGenerator::Instance()->DropActivityLoot(teamMember, self, sac->GetActivityID(), CalculateActivityRating(self, teamMemberID));
         }
     } else {
-        Loot::DropActivityLoot(user, self, sac->GetActivityID(), CalculateActivityRating(self, user->GetObjectID()));
+        LootGenerator::Instance()->DropActivityLoot(user, self, sac->GetActivityID(), CalculateActivityRating(self, user->GetObjectID()));
     }
 
     sac->PlayerRemove(user->GetObjectID());

--- a/dScripts/NjDragonEmblemChestServer.cpp
+++ b/dScripts/NjDragonEmblemChestServer.cpp
@@ -10,6 +10,6 @@ void NjDragonEmblemChestServer::OnUse(Entity *self, Entity *user) {
 
     auto* destroyable = self->GetComponent<DestroyableComponent>();
     if (destroyable != nullptr) {
-        LootGenerator::Instance()->DropLoot(user, self, destroyable->GetLootMatrixID(), 0, 0);
+        LootGenerator::Instance().DropLoot(user, self, destroyable->GetLootMatrixID(), 0, 0);
     }
 }

--- a/dScripts/NjDragonEmblemChestServer.cpp
+++ b/dScripts/NjDragonEmblemChestServer.cpp
@@ -10,6 +10,6 @@ void NjDragonEmblemChestServer::OnUse(Entity *self, Entity *user) {
 
     auto* destroyable = self->GetComponent<DestroyableComponent>();
     if (destroyable != nullptr) {
-        Loot::DropLoot(user, self, destroyable->GetLootMatrixID(), 0, 0);
+        LootGenerator::Instance()->DropLoot(user, self, destroyable->GetLootMatrixID(), 0, 0);
     }
 }

--- a/dScripts/SGCannon.cpp
+++ b/dScripts/SGCannon.cpp
@@ -423,7 +423,7 @@ void SGCannon::SpawnNewModel(Entity *self) {
 
             if (lootMatrix != 0) {
                 std::unordered_map<LOT, int32_t> toDrop = {};
-                toDrop = LootGenerator::Instance()->RollLootMatrix(player, lootMatrix);
+                toDrop = LootGenerator::Instance().RollLootMatrix(player, lootMatrix);
 
                 for (auto drop : toDrop) {
                     rewardModel->OnFireEventServerSide(self, ModelToBuildEvent, drop.first);
@@ -581,7 +581,7 @@ void SGCannon::StopGame(Entity *self, bool cancel) {
             );
         }
 
-        LootGenerator::Instance()->GiveActivityLoot(player, self, GetGameID(self), self->GetVar<uint32_t>(TotalScoreVariable));
+        LootGenerator::Instance().GiveActivityLoot(player, self, GetGameID(self), self->GetVar<uint32_t>(TotalScoreVariable));
 
         StopActivity(self, player->GetObjectID(), self->GetVar<uint32_t>(TotalScoreVariable),
                 self->GetVar<uint32_t>(MaxStreakVariable), percentage);

--- a/dScripts/SGCannon.cpp
+++ b/dScripts/SGCannon.cpp
@@ -423,7 +423,7 @@ void SGCannon::SpawnNewModel(Entity *self) {
 
             if (lootMatrix != 0) {
                 std::unordered_map<LOT, int32_t> toDrop = {};
-                Loot::CalculateLootMatrix(lootMatrix, player, toDrop);
+                toDrop = LootGenerator::Instance()->RollLootMatrix(player, lootMatrix);
 
                 for (auto drop : toDrop) {
                     rewardModel->OnFireEventServerSide(self, ModelToBuildEvent, drop.first);
@@ -581,7 +581,7 @@ void SGCannon::StopGame(Entity *self, bool cancel) {
             );
         }
 
-        Loot::GiveActivityLoot(player, self, GetGameID(self), self->GetVar<uint32_t>(TotalScoreVariable));
+        LootGenerator::Instance()->GiveActivityLoot(player, self, GetGameID(self), self->GetVar<uint32_t>(TotalScoreVariable));
 
         StopActivity(self, player->GetObjectID(), self->GetVar<uint32_t>(TotalScoreVariable),
                 self->GetVar<uint32_t>(MaxStreakVariable), percentage);

--- a/dScripts/ScriptedPowerupSpawner.cpp
+++ b/dScripts/ScriptedPowerupSpawner.cpp
@@ -24,7 +24,7 @@ void ScriptedPowerupSpawner::OnTimerDone(Entity *self, std::string message) {
                     renderComponent->PlayEffect(0, u"cast", "N_cast");
                 }
 
-                Loot::DropItem(owner, self, itemLOT, 0, 1, true, true);
+                LootGenerator::Instance()->DropLoot(owner, self, itemLOT, 0, 1);
             }
 
             // Increment the current cycle

--- a/dScripts/ScriptedPowerupSpawner.cpp
+++ b/dScripts/ScriptedPowerupSpawner.cpp
@@ -24,7 +24,7 @@ void ScriptedPowerupSpawner::OnTimerDone(Entity *self, std::string message) {
                     renderComponent->PlayEffect(0, u"cast", "N_cast");
                 }
 
-                LootGenerator::Instance()->DropLoot(owner, self, itemLOT, 0, 1);
+                LootGenerator::Instance().DropLoot(owner, self, itemLOT, 0, 1);
             }
 
             // Increment the current cycle

--- a/dScripts/TreasureChestDragonServer.cpp
+++ b/dScripts/TreasureChestDragonServer.cpp
@@ -39,12 +39,12 @@ void TreasureChestDragonServer::OnUse(Entity* self, Entity* user)
 
             if (memberObject == nullptr) continue;
 
-            Loot::DropActivityLoot(memberObject, self, scriptedActivityComponent->GetActivityID(), rating);
+            LootGenerator::Instance()->DropActivityLoot(memberObject, self, scriptedActivityComponent->GetActivityID(), rating);
         }
     }
     else
     {
-        Loot::DropActivityLoot(user, self, scriptedActivityComponent->GetActivityID(), rating);
+        LootGenerator::Instance()->DropActivityLoot(user, self, scriptedActivityComponent->GetActivityID(), rating);
     }
 
     self->Smash(self->GetObjectID());

--- a/dScripts/TreasureChestDragonServer.cpp
+++ b/dScripts/TreasureChestDragonServer.cpp
@@ -39,12 +39,12 @@ void TreasureChestDragonServer::OnUse(Entity* self, Entity* user)
 
             if (memberObject == nullptr) continue;
 
-            LootGenerator::Instance()->DropActivityLoot(memberObject, self, scriptedActivityComponent->GetActivityID(), rating);
+            LootGenerator::Instance().DropActivityLoot(memberObject, self, scriptedActivityComponent->GetActivityID(), rating);
         }
     }
     else
     {
-        LootGenerator::Instance()->DropActivityLoot(user, self, scriptedActivityComponent->GetActivityID(), rating);
+        LootGenerator::Instance().DropActivityLoot(user, self, scriptedActivityComponent->GetActivityID(), rating);
     }
 
     self->Smash(self->GetObjectID());

--- a/dScripts/VeMissionConsole.cpp
+++ b/dScripts/VeMissionConsole.cpp
@@ -4,7 +4,7 @@
 #include "GameMessages.h"
 
 void VeMissionConsole::OnUse(Entity *self, Entity *user) {
-    LootGenerator::Instance()->DropActivityLoot(user, self, 12551);
+    LootGenerator::Instance().DropActivityLoot(user, self, 12551);
 
     auto* inventoryComponent = user->GetComponent<InventoryComponent>();
     if (inventoryComponent != nullptr) {

--- a/dScripts/VeMissionConsole.cpp
+++ b/dScripts/VeMissionConsole.cpp
@@ -4,7 +4,7 @@
 #include "GameMessages.h"
 
 void VeMissionConsole::OnUse(Entity *self, Entity *user) {
-    Loot::DropActivityLoot(user, self, 12551);
+    LootGenerator::Instance()->DropActivityLoot(user, self, 12551);
 
     auto* inventoryComponent = user->GetComponent<InventoryComponent>();
     if (inventoryComponent != nullptr) {

--- a/dScripts/WishingWellServer.cpp
+++ b/dScripts/WishingWellServer.cpp
@@ -24,7 +24,7 @@ void WishingWellServer::OnUse(Entity* self, Entity* user)
         GameMessages::SendPlayNDAudioEmitter(self, user->GetSystemAddress(), audio);
     }
 
-    LootGenerator::Instance()->DropActivityLoot(
+    LootGenerator::Instance().DropActivityLoot(
         user,
         self,
         static_cast<uint32_t>(scriptedActivity->GetActivityID()),

--- a/dScripts/WishingWellServer.cpp
+++ b/dScripts/WishingWellServer.cpp
@@ -24,7 +24,7 @@ void WishingWellServer::OnUse(Entity* self, Entity* user)
         GameMessages::SendPlayNDAudioEmitter(self, user->GetSystemAddress(), audio);
     }
 
-    Loot::DropActivityLoot(
+    LootGenerator::Instance()->DropActivityLoot(
         user,
         self,
         static_cast<uint32_t>(scriptedActivity->GetActivityID()),

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -187,6 +187,7 @@ int main(int argc, char** argv) {
 
 	ObjectIDManager::Instance()->Initialize();
 	UserManager::Instance()->Initialize();
+	LootGenerator::Instance();
 	Game::chatFilter = new dChatFilter("./res/chatplus_en_us", bool(std::stoi(config.GetValue("dont_generate_dcf"))));
 
 	Game::server = new dServer(masterIP, ourPort, instanceID, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::World, zoneID);

--- a/dZoneManager/Level.cpp
+++ b/dZoneManager/Level.cpp
@@ -11,6 +11,8 @@
 #include "GeneralUtils.h"
 #include "Entity.h"
 #include "EntityManager.h"
+#include "CDFeatureGatingTable.h"
+#include "CDClientManager.h"
 
 Level::Level(Zone* parentZone, const std::string& filepath) {
     m_ParentZone = parentZone;


### PR DESCRIPTION
This PR is mostly made of repaired code from @averysumner that was never finished and has now been reimplemented.

I have no idea of knowing if these drops are accurate however Krysto (a prominent community member, who knows much more about loot than I) had spent a good amount of time with this build testing the drop rates.