### PR TITLE
Add port recycling to instance creation

### DIFF
--- a/dMasterServer/InstanceManager.h
+++ b/dMasterServer/InstanceManager.h
@@ -102,6 +102,7 @@ public:
 
 	Instance* GetInstance(LWOMAPID mapID, bool isFriendTransfer, LWOCLONEID cloneID); //Creates an instance if none found
 	bool IsPortInUse(uint32_t port);
+	uint32_t GetFreePort();
 	
 	void AddPlayer(SystemAddress systemAddr, LWOMAPID mapID, LWOINSTANCEID instanceID);
 	void RemovePlayer(SystemAddress systemAddr, LWOMAPID mapID, LWOINSTANCEID instanceID);


### PR DESCRIPTION
Made instance creation use previously used ports when available, to prevent
crashes caused by ports being used that are outside of the assigned range.