### PR TITLE
Updated Mail Commands

### DIFF
--- a/dGame/Character.h
+++ b/dGame/Character.h
@@ -364,6 +364,30 @@ public:
      */
 	void SetAnnouncementMessage(const std::string& value) { m_AnnouncementMessage = value; }
 
+    /**
+     * Gets the subject of a mail message that a character made (reserved for GMs)
+     * @return the title of the announcement a character made
+     */
+    const std::string& GetMailSubject() const { return m_MailSubject; }
+
+    /**
+     * Sets the subject of a mail message a character will make (reserved for GMs)
+     * @param value the subject to set
+     */
+    void SetMailSubject(const std::string& value) { m_MailSubject = value; }
+
+    /**
+     * Gets the body of a mail message a character made (reserved for GMs)
+     * @return the body of the mail
+     */
+    const std::string& GetMailBody() const { return m_MailBody; }
+
+    /**
+     * Sets the body of an mail message to make (reserved for GMs)
+     * @param value the body of the mail message
+     */
+    void SetMailBody(const std::string& value) { m_MailBody = value; }
+
 	/**
 	 * Called when the character has loaded into a zone
 	 */
@@ -594,6 +618,16 @@ private:
      * The body of an announcement this character made (reserved for GMs)
      */
 	std::string m_AnnouncementMessage;
+
+    /**
+     * The subject of a mail message this character made (reserved for GMs)
+     */
+    std::string m_MailSubject;
+
+    /**
+     * The body of a mail message this character made (reserved for GMs)
+     */
+    std::string m_MailBody;
 
     /**
      * The spawn position of this character when loading in

--- a/dGame/Character.h
+++ b/dGame/Character.h
@@ -621,13 +621,15 @@ private:
 
     /**
      * The subject of a mail message this character made (reserved for GMs)
+     * Default: "Lost item"
      */
-    std::string m_MailSubject;
+    std::string m_MailSubject = "Lost item";
 
     /**
      * The body of a mail message this character made (reserved for GMs)
+     * Default: "This is a replacement item for one you lost."
      */
-    std::string m_MailBody;
+    std::string m_MailBody = "This is a replacement item for one you lost.";
 
     /**
      * The spawn position of this character when loading in

--- a/dScripts/NtAssemblyTubeServer.cpp
+++ b/dScripts/NtAssemblyTubeServer.cpp
@@ -97,7 +97,7 @@ void NtAssemblyTubeServer::TeleportPlayer(Entity* self, Entity* player)
 
     GameMessages::SendPlayAnimation(player, u"tube-resurrect", 4.0f);
 
-    const auto animTime = 4;
+    const auto animTime = 2;
 
     const auto playerID = player->GetObjectID();
     

--- a/dScripts/NtParadoxTeleServer.cpp
+++ b/dScripts/NtParadoxTeleServer.cpp
@@ -88,7 +88,7 @@ void NtParadoxTeleServer::TeleportPlayer(Entity* self, Entity* player)
 
     GameMessages::SendPlayAnimation(player, u"paradox-teleport-in", 4.0f);
 
-    const auto animTime = 4;
+    const auto animTime = 2;
 
     const auto playerID = player->GetObjectID();
     


### PR DESCRIPTION
- Added 3 new mail commands:
1. setmailsub: Similar to setanntitle with an announcement, this sets the subject of the next mail sent via mailitem or mailitemall.
2. setmailbody: Similar to setannmsg with an announcement, this sets the body of the next mail sent via mailitem or mailitemall.
3. mailitemall: Sends a mail to all characters created on the server (online and offline)
- Added "Help" messages to mail commands when the command is given no arguments.
- Altered the "mail sent" message to be more descriptive when mail is successfully sent.