### PR TITLE
Correct documentation for /instanceinfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,10 +289,10 @@ Here is a summary of the commands available in-game. All commands are prefixed b
   </tr>
   <tr>
     <td>
-      instance-info
+      instanceinfo
     </td>
     <td>
-      /instance-info
+      /instanceinfo
     </td>
     <td>
       Displays in the chat the current zone, clone, and instance id. 


### PR DESCRIPTION
`/instanceinfo` is currently documented as `/instance-info`, which silently fails.

I've tested that `/instanceinfo` works in-game, and that `/instance-info` does not. I don't know if either command was present on live.

(sidenote: would a PR with documentation for the other commands be accepted? I've written up notes for all currently-implemented commands, and would be happy to contribute them back here, either in the readme or as comments in the source or somewhere else.)