### PR TITLE
Implemented die roll animations for the Lego Dice item

### DIFF
--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -778,8 +778,8 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 	    script = new ImaginationBackpackHealServer();
 	else if (scriptName == "scripts\\ai\\GENERAL\\L_LEGO_DIE_ROLL.lua")
 		script = new LegoDieRoll();
-  else if (scriptName == "scripts\\EquipmentScripts\\BuccaneerValiantShip.lua")
-    script = new BuccaneerValiantShip();
+  	else if (scriptName == "scripts\\EquipmentScripts\\BuccaneerValiantShip.lua")
+    	script = new BuccaneerValiantShip();
 
 	//Ignore these scripts:
 	else if (scriptName == "scripts\\02_server\\Enemy\\General\\L_SUSPEND_LUA_AI.lua")

--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -261,6 +261,7 @@
 #include "PersonalFortress.h"
 #include "PropertyDevice.h"
 #include "ImaginationBackpackHealServer.h"
+#include "LegoDieRoll.h"
 
 // Survival scripts
 #include "AgSurvivalStromling.h"
@@ -774,6 +775,8 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 	    script = new PropertyDevice();
 	else if (scriptName == "scripts\\02_server\\Map\\General\\L_IMAG_BACKPACK_HEALS_SERVER.lua")
 	    script = new ImaginationBackpackHealServer();
+	else if (scriptName == "scripts\\ai\\GENERAL\\L_LEGO_DIE_ROLL.lua")
+		script = new LegoDieRoll();
 
 	//Ignore these scripts:
 	else if (scriptName == "scripts\\02_server\\Enemy\\General\\L_SUSPEND_LUA_AI.lua")

--- a/dScripts/LegoDieRoll.cpp
+++ b/dScripts/LegoDieRoll.cpp
@@ -36,7 +36,7 @@ void LegoDieRoll::OnTimerDone(Entity* self, std::string timerName) {
 		    GameMessages::SendPlayAnimation(self, u"roll-die-6");
             break;
         default:
-	        Game::logger->Log("LegoDieRoll", "Invalid animation: roll-die-%i\n", dieRoll);
+	        Game::logger->LogDebug("LegoDieRoll", "Invalid animation: roll-die-%i\n", dieRoll);
             break;
         }
     }

--- a/dScripts/LegoDieRoll.cpp
+++ b/dScripts/LegoDieRoll.cpp
@@ -1,5 +1,6 @@
 #include "LegoDieRoll.h"
 #include "Entity.h"
+#include "dLogger.h"
 #include "GameMessages.h"
 
 void LegoDieRoll::OnStartup(Entity* self) {
@@ -35,6 +36,7 @@ void LegoDieRoll::OnTimerDone(Entity* self, std::string timerName) {
 		    GameMessages::SendPlayAnimation(self, u"roll-die-6");
             break;
         default:
+	        Game::logger->Log("LegoDieRoll", "Invalid animation: roll-die-%i\n", dieRoll);
             break;
         }
     }

--- a/dScripts/LegoDieRoll.cpp
+++ b/dScripts/LegoDieRoll.cpp
@@ -1,0 +1,41 @@
+#include "LegoDieRoll.h"
+#include "Entity.h"
+#include "GameMessages.h"
+
+void LegoDieRoll::OnStartup(Entity* self) {
+    self->AddTimer("DoneRolling", 10.0f);
+    self->AddTimer("ThrowDice", LegoDieRoll::animTime);
+}
+
+void LegoDieRoll::OnTimerDone(Entity* self, std::string timerName) {
+    if (timerName == "DoneRolling") {
+        self->Smash(self->GetObjectID(), SILENT);
+    } 
+    else if (timerName == "ThrowDice") {
+        int dieRoll = GeneralUtils::GenerateRandomNumber<int>(1, 6);
+
+        switch (dieRoll)
+        {
+        case 1:
+		    GameMessages::SendPlayAnimation(self, u"roll-die-1");
+            break;
+        case 2:
+		    GameMessages::SendPlayAnimation(self, u"roll-die-2");
+            break;
+        case 3:
+		    GameMessages::SendPlayAnimation(self, u"roll-die-3");
+            break;
+        case 4:
+		    GameMessages::SendPlayAnimation(self, u"roll-die-4");
+            break;
+        case 5:
+		    GameMessages::SendPlayAnimation(self, u"roll-die-5");
+            break;
+        case 6:
+		    GameMessages::SendPlayAnimation(self, u"roll-die-6");
+            break;
+        default:
+            break;
+        }
+    }
+}

--- a/dScripts/LegoDieRoll.h
+++ b/dScripts/LegoDieRoll.h
@@ -1,0 +1,11 @@
+#pragma once
+#include "CppScripts.h"
+
+class LegoDieRoll : public CppScripts::Script {
+public:
+	void OnStartup(Entity* self);
+	void OnTimerDone(Entity* self, std::string timerName);
+private:
+    constexpr static const float animTime = 2.0f;
+};
+


### PR DESCRIPTION
The Lego Dice item does not complete its roll animation (just spins in the air before disappearing). This is because the client lua script is not implemented server-side. This PR adds the server-side c++ script and header.

IMPORTANT: I was not able to test this with multiple accounts, so I'm not sure if this fixes the animations from the view of other players on the server. This should ideally be tested before merging.