### PR TITLE
Add GitHub Actions Workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Cmake CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - name: cmake
+      uses: lukka/run-cmake@v10
+      with:
+        configurePreset: 'default'
+        buildPreset: 'default'
+    - name: artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: linux-build
+        path: |
+          build
+          !build/CMakeCache.txt
+          !build/build.ninja
+          !build/_deps
+          !build/cmake_install.cmake
+          !build/*.a

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,26 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 21,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Default Configure Settings",
+      "description": "Sets build and install directories",
+      "binaryDir": "${sourceDir}/build",
+      "generator": "Unix Makefiles"
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default",
+      "displayName": "Default Build",
+      "description": "Default Build",
+      "jobs": 2
+    }
+  ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,7 +2,7 @@
   "version": 3,
   "cmakeMinimumRequired": {
     "major": 3,
-    "minor": 21,
+    "minor": 12,
     "patch": 0
   },
   "configurePresets": [


### PR DESCRIPTION
This PR adds a github actions workflow for a Linux build as well as a `CMakePresets.json` that is defined by cmake and required by the action ([lukka/run-cmake](https://github.com/lukka/run-cmake)) that is used.

The `CMakePresets.json` file sets `jobs` i.e. the `-j` flag to `2` by default. That corresponds to the hardware as described in https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources and cuts the build time in half (about 8 minutes instead of 15).

Warnings end errors are scraped from the log and displayed inline in the GitHub web UI. See <https://github.com/Xiphoseer/DarkflameServer/pull/2/files> for an example. The warnings there are caused by adding `-Wextra`. This may be a good opportunity to tweak the warning settings a bit more to get more feedback on our own code but using different settings for 3rd party code.

At the end of a build, a zip file is uploaded as an artifact, which a maintainer can use to publish a release.