### PR TITLE
Crux Prime named enemy fix

### DIFF
--- a/dScripts/BaseRandomServer.cpp
+++ b/dScripts/BaseRandomServer.cpp
@@ -91,7 +91,7 @@ void BaseRandomServer::SetSpawnerNetwork(Entity* self, const std::string& spawne
 
     if (spawnerName == "Named_Enemies")
     {
-        //spawner->Reset();
+        spawner->Reset();
     }
 
     spawner->Activate();

--- a/dScripts/BaseRandomServer.cpp
+++ b/dScripts/BaseRandomServer.cpp
@@ -91,7 +91,7 @@ void BaseRandomServer::SetSpawnerNetwork(Entity* self, const std::string& spawne
 
     if (spawnerName == "Named_Enemies")
     {
-        spawner->Reset();
+        spawner->SoftReset();
     }
 
     spawner->Activate();
@@ -169,16 +169,6 @@ void BaseRandomServer::NamedEnemyDeath(Entity* self, Spawner* spawner)
     const auto spawnDelay = GeneralUtils::GenerateRandomNumber<float>(1, 2) * 450;
 
     self->AddTimer("SpawnNewEnemy", spawnDelay);
-}
-
-void BaseRandomServer::SpawnersUp(Entity* self) 
-{
-    
-}
-
-void BaseRandomServer::SpawnersDown(Entity* self) 
-{
-    
 }
 
 void BaseRandomServer::BaseOnTimerDone(Entity* self, const std::string& timerName) 

--- a/dScripts/BaseRandomServer.cpp
+++ b/dScripts/BaseRandomServer.cpp
@@ -171,6 +171,16 @@ void BaseRandomServer::NamedEnemyDeath(Entity* self, Spawner* spawner)
     self->AddTimer("SpawnNewEnemy", spawnDelay);
 }
 
+void BaseRandomServer::SpawnersUp(Entity* self) 
+{
+
+}
+
+void BaseRandomServer::SpawnersDown(Entity* self) 
+{
+
+}
+
 void BaseRandomServer::BaseOnTimerDone(Entity* self, const std::string& timerName) 
 {
     NamedTimerDone(self, timerName);

--- a/dScripts/BaseRandomServer.h
+++ b/dScripts/BaseRandomServer.h
@@ -25,8 +25,6 @@ public:
     void SpawnSection(Entity* self, const std::string& sectionName, float iMultiplier);
     void SetSpawnerNetwork(Entity* self, const std::string& spawnerName, int32_t spawnNum, LOT spawnLOT);
     BaseRandomServer::Zone* GetRandomLoad(Entity* self, const std::string& sectionName);
-    void SpawnersUp(Entity* self);
-    void SpawnersDown(Entity* self);
     void BaseOnTimerDone(Entity* self, const std::string& timerName);
 
     void NotifySpawnerOfDeath(Entity* self, Spawner* spawner);

--- a/dScripts/BaseRandomServer.h
+++ b/dScripts/BaseRandomServer.h
@@ -25,8 +25,10 @@ public:
     void SpawnSection(Entity* self, const std::string& sectionName, float iMultiplier);
     void SetSpawnerNetwork(Entity* self, const std::string& spawnerName, int32_t spawnNum, LOT spawnLOT);
     BaseRandomServer::Zone* GetRandomLoad(Entity* self, const std::string& sectionName);
+    void SpawnersUp(Entity* self);
+    void SpawnersDown(Entity* self);
     void BaseOnTimerDone(Entity* self, const std::string& timerName);
-
+    
     void NotifySpawnerOfDeath(Entity* self, Spawner* spawner);
     void NamedEnemyDeath(Entity* self, Spawner* spawner);
 


### PR DESCRIPTION
Fixed an issue where named enemies on crux prime would no longer spawn by un-commenting a line that was commented out.

I am unsure as to why this was commented out in the first place however un-commenting it does not seem to cause short term issues.  