### PR TITLE
fixed a bug where the smashedTimes counter was falsely incremented

### DIFF
--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -317,7 +317,9 @@ void RacingControlComponent::OnRequestDie(Entity *player) {
             return;
         }
 
-        racingPlayer.smashedTimes++;
+        if (!racingPlayer.noSmashOnReload) {
+            racingPlayer.smashedTimes++;
+        }
 
         // Reset player to last checkpoint
         GameMessages::SendRacingSetPlayerResetInfo(


### PR DESCRIPTION
This fixes the first part of issue #218.

The smashedTimes counter in the RacingPlayerInfo struct was incremented by accident i assume. In Line 696 of the RacingControlComponent.cpp the OnRequestDie method always increments the smashedTimes counter.

I added an if condition to only increment the counter when the noSmashOnReload attribute is set to false. I think this was supposed to be handled like this, because the noSmashOnReload attribute is set to true in Line 694.

I will probably look into the second bug of issue #218, when i get some time off from doing my uni research.
