### PR TITLE
Fixed secondary coin UI update

### DIFF
--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -713,8 +713,6 @@ void GameMessages::SendSetCurrency(Entity* entity, int64_t currency, int lootTyp
 	bitStream.Write(entity->GetObjectID());
 	bitStream.Write(uint16_t(GAME_MSG_SET_CURRENCY));
 
-	bitStream.Write(currency);
-
 	bitStream.Write(lootType != LOOTTYPE_NONE);
 	if (lootType != LOOTTYPE_NONE) bitStream.Write(lootType);
 


### PR DESCRIPTION
Removed a secondary UI coin update when completing achievements.  Fixes issues with #279.  I have tested this on one boss kill in Crux Prime and my coins showed the correct amount without having to transfer zones.