### PR TITLE
Portal Stun Time Reductions

### DIFF
--- a/dScripts/NtAssemblyTubeServer.cpp
+++ b/dScripts/NtAssemblyTubeServer.cpp
@@ -97,7 +97,7 @@ void NtAssemblyTubeServer::TeleportPlayer(Entity* self, Entity* player)
 
     GameMessages::SendPlayAnimation(player, u"tube-resurrect", 4.0f);
 
-    const auto animTime = 4;
+    const auto animTime = 2;
 
     const auto playerID = player->GetObjectID();
     

--- a/dScripts/NtParadoxTeleServer.cpp
+++ b/dScripts/NtParadoxTeleServer.cpp
@@ -88,7 +88,7 @@ void NtParadoxTeleServer::TeleportPlayer(Entity* self, Entity* player)
 
     GameMessages::SendPlayAnimation(player, u"paradox-teleport-in", 4.0f);
 
-    const auto animTime = 4;
+    const auto animTime = 2;
 
     const auto playerID = player->GetObjectID();
     


### PR DESCRIPTION
The Nexus Tower Assembly and Paradox portals stunned players for an excessive amount of time after the "loading in" animation was complete. This corrects the time so the player can move once the animation ends.