### PR TITLE
Fix issue #268 : wrong shirt colors in the character selection

### DIFF
--- a/dGame/UserManager.cpp
+++ b/dGame/UserManager.cpp
@@ -566,10 +566,10 @@ void UserManager::LoginCharacter(const SystemAddress& sysAddr, uint32_t playerID
     }
 }
 
-uint32_t getShirtColorId(uint32_t color) {
+uint32_t GetShirtColorId(uint32_t color) {
 	
 	// get the index of the color in shirtColorVector
-	auto colorId = std::find (shirtColorVector.begin(), shirtColorVector.end(), color);
+	auto colorId = std::find(shirtColorVector.begin(), shirtColorVector.end(), color);
 	return color = std::distance(shirtColorVector.begin(), colorId);
 }
 

--- a/dGame/UserManager.cpp
+++ b/dGame/UserManager.cpp
@@ -582,7 +582,7 @@ uint32_t FindCharShirtID(uint32_t shirtColor, uint32_t shirtStyle) {
 	}
 
 	case 3: {
-		shirtID = shirtStyle >= 35 ? 5808 : SHIRT_DARK_GREEN;
+		shirtID = shirtStyle >= 35 ? 5748 : SHIRT_DARK_GREEN;
 		break;
 	}
 
@@ -617,7 +617,7 @@ uint32_t FindCharShirtID(uint32_t shirtColor, uint32_t shirtStyle) {
 	}
 
 	case 11: {
-		shirtID = shirtStyle >= 35 ? 5802 : SHIRT_MEDIUM_BLUE;
+		shirtID = shirtStyle >= 35 ? 5790 : SHIRT_MEDIUM_BLUE;
 		break;
 	}
 

--- a/dGame/UserManager.cpp
+++ b/dGame/UserManager.cpp
@@ -566,114 +566,34 @@ void UserManager::LoginCharacter(const SystemAddress& sysAddr, uint32_t playerID
     }
 }
 
+uint32_t getShirtColorId(uint32_t color) {
+	
+	// get the index of the color in shirtColorVector
+	auto colorId = std::find (shirtColorVector.begin(), shirtColorVector.end(), color);
+	return color = std::distance(shirtColorVector.begin(), colorId);
+}
+
 uint32_t FindCharShirtID(uint32_t shirtColor, uint32_t shirtStyle) {
-	uint32_t shirtID = 0;
-
-	// s p e c i a l  code follows
-	switch (shirtColor) {
-	case 0: {
-		shirtID = shirtStyle >= 35 ? 5730 : SHIRT_BRIGHT_RED;
-		break;
-	}
-
-	case 1: {
-		shirtID = shirtStyle >= 35 ? 5736 : SHIRT_BRIGHT_BLUE;
-		break;
-	}
-
-	case 3: {
-		shirtID = shirtStyle >= 35 ? 5748 : SHIRT_DARK_GREEN;
-		break;
-	}
-
-	case 5: {
-		shirtID = shirtStyle >= 35 ? 5754 : SHIRT_BRIGHT_ORANGE;
-		break;
-	}
-
-	case 6: {
-		shirtID = shirtStyle >= 35 ? 5760 : SHIRT_BLACK;
-		break;
-	}
-
-	case 7: {
-		shirtID = shirtStyle >= 35 ? 5766 : SHIRT_DARK_STONE_GRAY;
-		break;
-	}
-
-	case 8: {
-		shirtID = shirtStyle >= 35 ? 5772 : SHIRT_MEDIUM_STONE_GRAY;
-		break;
-	}
-
-	case 9: {
-		shirtID = shirtStyle >= 35 ? 5778 : SHIRT_REDDISH_BROWN;
-		break;
-	}
-
-	case 10: {
-		shirtID = shirtStyle >= 35 ? 5784 : SHIRT_WHITE;
-		break;
-	}
-
-	case 11: {
-		shirtID = shirtStyle >= 35 ? 5790 : SHIRT_MEDIUM_BLUE;
-		break;
-	}
-
-	case 13: {
-		shirtID = shirtStyle >= 35 ? 5796 : SHIRT_DARK_RED;
-		break;
-	}
-
-	case 14: {
-		shirtID = shirtStyle >= 35 ? 5802 : SHIRT_EARTH_BLUE;
-		break;
-	}
-
-	case 15: {
-		shirtID = shirtStyle >= 35 ? 5808 : SHIRT_EARTH_GREEN;
-		break;
-	}
-
-	case 16: {
-		shirtID = shirtStyle >= 35 ? 5814 : SHIRT_BRICK_YELLOW;
-		break;
-	}
-
-	case 84: {
-		shirtID = shirtStyle >= 35 ? 5820 : SHIRT_SAND_BLUE;
-		break;
-	}
-
-	case 96: {
-		shirtID = shirtStyle >= 35 ? 5826 : SHIRT_SAND_GREEN;
-		shirtColor = 16;
-		break;
-	}
-	}
-
-	// Initialize another variable for the shirt color
-	uint32_t editedShirtColor = shirtID;
-
-	// This will be the final shirt ID
-	uint32_t shirtIDFinal;
-
-	// For some reason, if the shirt color is 35 - 40,
+	
+	shirtStyle--; // to start at 0 instead of 1
+	uint32_t stylesCount = 34;
+	uint32_t colorId = getShirtColorId(shirtColor);
+	
+	uint32_t startID = 4049; // item ID of the shirt with color 0 (red) and style 0 (plain)
+	
+    // For some reason, if the shirt style is 34 - 39,
 	// The ID is different than the original... Was this because
 	// these shirts were added later?
-	if (shirtStyle >= 35) {
-		shirtIDFinal = editedShirtColor += (shirtStyle - 35);
+	if (shirtStyle >= 34) {
+		startID = 5730; // item ID of the shirt with color 0 (red) and style 34 (butterflies)
+        shirtStyle -= stylesCount; //change style from range 35-40 to range 0-5
+		stylesCount = 6;
 	}
-	else {
-		// Get the final ID of the shirt by adding the shirt
-		// style to the editedShirtColor
-		shirtIDFinal = editedShirtColor += (shirtStyle - 1);
-	}
+	
+    // Get the final ID of the shirt
+	uint32_t shirtID = startID + (colorId * stylesCount) + shirtStyle;
 
-	//cout << "Shirt ID is: " << shirtIDFinal << endl;
-
-	return shirtIDFinal;
+	return shirtID;
 }
 
 uint32_t FindCharPantsID(uint32_t pantsColor) {

--- a/dGame/UserManager.cpp
+++ b/dGame/UserManager.cpp
@@ -577,7 +577,7 @@ uint32_t FindCharShirtID(uint32_t shirtColor, uint32_t shirtStyle) {
 	
 	shirtStyle--; // to start at 0 instead of 1
 	uint32_t stylesCount = 34;
-	uint32_t colorId = getShirtColorId(shirtColor);
+	uint32_t colorId = GetShirtColorId(shirtColor);
 	
 	uint32_t startID = 4049; // item ID of the shirt with color 0 (red) and style 0 (plain)
 	

--- a/dGame/UserManager.h
+++ b/dGame/UserManager.h
@@ -33,10 +33,10 @@ public:
 	bool IsNamePreapproved(const std::string& requestedName);
 	
 	void RequestCharacterList(const SystemAddress& sysAddr);
-    void CreateCharacter(const SystemAddress& sysAddr, Packet* packet);
-    void DeleteCharacter(const SystemAddress& sysAddr, Packet* packet);
-    void RenameCharacter(const SystemAddress& sysAddr, Packet* packet);
-    void LoginCharacter(const SystemAddress& sysAddr, uint32_t playerID);
+	void CreateCharacter(const SystemAddress& sysAddr, Packet* packet);
+	void DeleteCharacter(const SystemAddress& sysAddr, Packet* packet);
+	void RenameCharacter(const SystemAddress& sysAddr, Packet* packet);
+	void LoginCharacter(const SystemAddress& sysAddr, uint32_t playerID);
 
 	void SaveAllActiveCharacters();
 
@@ -48,9 +48,9 @@ private:
 	std::map<SystemAddress, User*> m_Users;
 	std::vector<User*> m_UsersToDelete;
 	
-    std::vector<std::string> m_FirstNames;
-    std::vector<std::string> m_MiddleNames;
-    std::vector<std::string> m_LastNames;
+	std::vector<std::string> m_FirstNames;
+	std::vector<std::string> m_MiddleNames;
+	std::vector<std::string> m_LastNames;
 	std::vector<std::string> m_PreapprovedNames;
 };
 
@@ -73,24 +73,24 @@ enum CharCreatePantsColor : uint32_t {
 	PANTS_DARK_RED = 2527
 };
 
-enum CharCreateShirtColor : uint32_t {
-	SHIRT_BRIGHT_RED = 4049,
-	SHIRT_BRIGHT_BLUE = 4083,
-	SHIRT_BRIGHT_YELLOW = 4117,
-	SHIRT_DARK_GREEN = 4151,
-	SHIRT_BRIGHT_ORANGE = 4185,
-	SHIRT_BLACK = 4219,
-	SHIRT_DARK_STONE_GRAY = 4253,
-	SHIRT_MEDIUM_STONE_GRAY = 4287,
-	SHIRT_REDDISH_BROWN = 4321,
-	SHIRT_WHITE = 4355,
-	SHIRT_MEDIUM_BLUE = 4389,
-	SHIRT_DARK_RED = 4423,
-	SHIRT_EARTH_BLUE = 4457,
-	SHIRT_EARTH_GREEN = 4491,
-	SHIRT_BRICK_YELLOW = 4525,
-	SHIRT_SAND_BLUE = 4559,
-	SHIRT_SAND_GREEN = 4593
+const std::vector<uint32_t> shirtColorVector {
+	0, // BRIGHT_RED
+	1, // BRIGHT_BLUE
+	2, // BRIGHT_YELLOW
+	3, // DARK_GREEN
+	5, // BRIGHT_ORANGE
+	6, // BLACK
+	7, // DARK_STONE_GRAY
+	8, // MEDIUM_STONE_GRAY
+	9, // REDDISH_BROWN
+	10, // WHITE
+	11, // MEDIUM_BLUE
+	13, // DARK_RED
+	14, // EARTH_BLUE
+	15, // EARTH_GREEN
+	16, // BRICK_YELLOW
+	84, // SAND_BLUE
+	96 // SAND_GREEN
 };
 
 #endif // USERMANAGER_H


### PR DESCRIPTION
This pull request fixes the issue #268 .
Now the characters will get the correct shirt color for shirts such as the space suit from the server following character creation (dark green and medium blue).
The error was probably due to a wrong copy and paste in the code.
Has been tested locally.