### PR TITLE
Fix loot crash

### DIFF
--- a/dGame/dUtilities/Loot.cpp
+++ b/dGame/dUtilities/Loot.cpp
@@ -137,6 +137,10 @@ std::unordered_map<LOT, int32_t> LootGenerator::RollLootMatrix(Entity* player, u
 
     std::unordered_map<LOT, int32_t> drops;
 
+    if (missionComponent == nullptr) {
+        return drops;
+    }
+
     const LootMatrix& matrix = m_LootMatrices[matrixIndex];
 
     for (const LootMatrixEntry& entry : matrix) {


### PR DESCRIPTION
When applied this commit fixes a crash with the loot system due to a missing nullptr check.