### PR TITLE
Boogie Down Achievement + MissionTask Error Fix

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -501,6 +501,13 @@ void Entity::Initialize()
 		customScriptServer = "scripts\\02_server\\DLU\\L_SB_LUP_TELEPORT.lua";
 	}
 
+	// Custom script for the "Boogie Down" achievement
+	if (m_TemplateID == 5006 || m_TemplateID == 5007 || m_TemplateID == 3002)
+	{
+		hasCustomServerScript = true;
+		customScriptServer = "scripts\\02_server\\DLU\\L_NS_DANCE_NPCS.lua";
+	}
+
 	const auto customScriptServerName = GetVarAsString(u"custom_script_server");
 	const auto customScriptClientName = GetVarAsString(u"custom_script_client");
 

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -5018,7 +5018,7 @@ void GameMessages::HandlePlayEmote(RakNet::BitStream* inStream, Entity* entity) 
 
 	//if (missionComponent) { // Altered to prevent "[MissionTask] Failed to find associated entity (0)!" every time a player emoted when not near the target for an active mission/achievement
 	if (missionComponent && targetID != LWOOBJID_EMPTY) {
-			missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_EMOTE, emoteID, targetID);
+		missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_EMOTE, emoteID, targetID);
 	}
 	
 	if (targetID != LWOOBJID_EMPTY)

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -5014,9 +5014,11 @@ void GameMessages::HandlePlayEmote(RakNet::BitStream* inStream, Entity* entity) 
 	if (emoteID == 0) return;
 	std::string sAnimationName = "deaded"; //Default name in case we fail to get the emote
 
-	MissionComponent* mission = static_cast<MissionComponent*>(entity->GetComponent(COMPONENT_TYPE_MISSION));
-	if (mission) {
-		mission->Progress(MissionTaskType::MISSION_TASK_TYPE_EMOTE, emoteID, targetID);
+	MissionComponent* missionComponent = static_cast<MissionComponent*>(entity->GetComponent(COMPONENT_TYPE_MISSION));
+
+	//if (missionComponent) { // Altered to prevent "[MissionTask] Failed to find associated entity (0)!" every time a player emoted when not near the target for an active mission/achievement
+	if (missionComponent && targetID != LWOOBJID_EMPTY) {
+			missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_EMOTE, emoteID, targetID);
 	}
 	
 	if (targetID != LWOOBJID_EMPTY)

--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -199,6 +199,7 @@
 // DLU Scripts
 #include "SbLupTeleport.h"
 #include "DLUVanityNPC.h"
+#include "NsDanceNpcs.h"
 
 // AM Scripts
 #include "AmConsoleTeleportServer.h"
@@ -750,6 +751,8 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 		script = new SbLupTeleport();
 	else if (scriptName == "scripts\\02_server\\DLU\\DLUVanityNPC.lua")
 		script = new DLUVanityNPC();
+	else if (scriptName == "scripts\\02_server\\DLU\\L_NS_DANCE_NPCS.lua") // Needed for the "Boogie Down" Achievement (MissionID = 595)
+		script = new NsDanceNpcs();
 
 	// Survival minigame
 	else if (scriptName == "scripts\\02_server\\Enemy\\Survival\\L_AG_SURVIVAL_STROMBIE.lua")

--- a/dScripts/NsDanceNpcs.cpp
+++ b/dScripts/NsDanceNpcs.cpp
@@ -1,0 +1,30 @@
+﻿#include "NsDanceNpcs.h"
+#include "GameMessages.h"
+#include "MissionComponent.h"
+
+void NsDanceNpcs::OnStartup(Entity* self) 
+{
+}
+
+void NsDanceNpcs::OnEmoteReceived(Entity* self, const int32_t emote, Entity* target)
+{
+	int validEmotes[] = { 383, 359, 377, 209, 208, 379, 380, 207, 382, 378, 381 };
+
+	if (!std::find(std::begin(validEmotes), std::end(validEmotes), emote))
+	{
+		return;
+	}
+
+	auto* missionComponent = target->GetComponent<MissionComponent>();
+	
+	if (missionComponent != nullptr)
+	{
+		if (self->GetLOT() == 5006) // taskID(uid) = 898 for 5006 (Kant Dance)
+			missionComponent->ForceProgress(595, 898, 1, false);
+		else if (self->GetLOT() == 5007) // taskID(uid) = 899 for 5007 (Sofie Cushion)
+			missionComponent->ForceProgress(595, 899, 1, false);
+		else if (self->GetLOT() == 3002) // taskID(uid) = 900 for 3002 (Peppy Slapbiscuit)
+			missionComponent->ForceProgress(595, 900, 1, false);
+	}
+}
+

--- a/dScripts/NsDanceNpcs.h
+++ b/dScripts/NsDanceNpcs.h
@@ -1,0 +1,9 @@
+﻿#pragma once
+#include "CppScripts.h"
+
+class NsDanceNpcs final : public CppScripts::Script
+{
+public:
+	void OnStartup(Entity* self) override;
+	void OnEmoteReceived(Entity* self, int32_t emote, Entity* target) override;
+};


### PR DESCRIPTION
I have included the following two fixes together, as they are both related to emotes and mission/achievement progression.

**Boogie Down Achievement Fix:** https://github.com/DarkflameUniverse/DarkflameServer/issues/278
- Fixed the "Boogie Down" achievement by adding a custom script "NsDanceNpcs" in a similar fashion to "SbLupTeleport". 
- This has been tested on a test server and completes the correct step in the achievement depending on which NPC is danced with.

**MissionTask Error Correction**
- Corrected the error "[MissionTask] Failed to find associated entity (0)!" by altering "GameMessages.cpp", which was popping up in the console any time an emote was used that is the condition for a mission/achievement the player is on, but the targetID of the entity was not found. The root cause was that the Progress function for the mission component was still being called, even when a target was not found (and is required).
- An example of this is when the player used a valid dance emote for the Boogie Down achievement, but the targetID of three entities you need to dance near were not found. This error would also occur for other missions/achievements.
- To validate this did not break missions where an emote is required for an NPC, I tested these changes with the mission "Cheer for the Championships!" (MissionID 2077), which requires you to cheer next to Nexus Naomi. The achievement completed successfully.
