### PR TITLE
Damage Buff source fix - inventor beehive bug

### DIFF
--- a/dGame/dComponents/BuffComponent.cpp
+++ b/dGame/dComponents/BuffComponent.cpp
@@ -71,7 +71,7 @@ void BuffComponent::Update(float deltaTime)
 				buff.second.tickTime = buff.second.tick;
 				buff.second.stacks--;
 
-				SkillComponent::HandleUnmanaged(buff.second.behaviorID, m_Parent->GetObjectID());
+				SkillComponent::HandleUnmanaged(buff.second.behaviorID, m_Parent->GetObjectID(), buff.second.source);
 			}
 		}
 

--- a/dGame/dComponents/SkillComponent.cpp
+++ b/dGame/dComponents/SkillComponent.cpp
@@ -481,31 +481,12 @@ void SkillComponent::SyncProjectileCalculation(const ProjectileSyncEntry& entry)
 	delete bitStream;
 }
 
-void SkillComponent::HandleUnmanaged(const uint32_t behaviorId, const LWOOBJID target)
-{
-	auto* context = new BehaviorContext(target);
-
-	context->unmanaged = true;
-	context->caster = target;
-
-	auto* behavior = Behavior::CreateBehavior(behaviorId);
-
-	auto* bitStream = new RakNet::BitStream();
-
-	behavior->Handle(context, bitStream, { target });
-
-	delete bitStream;
-
-	delete context;
-}
-
 void SkillComponent::HandleUnmanaged(const uint32_t behaviorId, const LWOOBJID target, LWOOBJID source)
 {
-	auto* context = new BehaviorContext(target);
+	auto* context = new BehaviorContext(source);
 
 	context->unmanaged = true;
 	context->caster = target;
-	context->originator = source;
 
 	auto* behavior = Behavior::CreateBehavior(behaviorId);
 

--- a/dGame/dComponents/SkillComponent.cpp
+++ b/dGame/dComponents/SkillComponent.cpp
@@ -499,6 +499,25 @@ void SkillComponent::HandleUnmanaged(const uint32_t behaviorId, const LWOOBJID t
 	delete context;
 }
 
+void SkillComponent::HandleUnmanaged(const uint32_t behaviorId, const LWOOBJID target, LWOOBJID source)
+{
+	auto* context = new BehaviorContext(target);
+
+	context->unmanaged = true;
+	context->caster = target;
+	context->originator = source;
+
+	auto* behavior = Behavior::CreateBehavior(behaviorId);
+
+	auto* bitStream = new RakNet::BitStream();
+
+	behavior->Handle(context, bitStream, { target });
+
+	delete bitStream;
+
+	delete context;	
+}
+
 void SkillComponent::HandleUnCast(const uint32_t behaviorId, const LWOOBJID target)
 {
 	auto* context = new BehaviorContext(target);

--- a/dGame/dComponents/SkillComponent.h
+++ b/dGame/dComponents/SkillComponent.h
@@ -158,16 +158,9 @@ public:
      * Computes a server-side skill calculation without an associated entity.
      * @param behaviorId the root behavior ID of the skill
      * @param target the explicit target of the skill
-     */
-    static void HandleUnmanaged(uint32_t behaviorId, LWOOBJID target);
-
-    /**
-     * Computes a server-side skill calculation without an associated entity.
-     * @param behaviorId the root behavior ID of the skill
-     * @param target the explicit target of the skill
      * @param source the explicit source of the skill
      */
-    static void HandleUnmanaged(uint32_t behaviorId, LWOOBJID target, LWOOBJID source);
+    static void HandleUnmanaged(uint32_t behaviorId, LWOOBJID target, LWOOBJID source = LWOOBJID_EMPTY);
 
     /**
      * Computes a server-side skill uncast calculation without an associated entity.

--- a/dGame/dComponents/SkillComponent.h
+++ b/dGame/dComponents/SkillComponent.h
@@ -162,6 +162,14 @@ public:
     static void HandleUnmanaged(uint32_t behaviorId, LWOOBJID target);
 
     /**
+     * Computes a server-side skill calculation without an associated entity.
+     * @param behaviorId the root behavior ID of the skill
+     * @param target the explicit target of the skill
+     * @param source the explicit source of the skill
+     */
+    static void HandleUnmanaged(uint32_t behaviorId, LWOOBJID target, LWOOBJID source);
+
+    /**
      * Computes a server-side skill uncast calculation without an associated entity.
      * @param behaviorId the root behavior ID of the skill
      * @param target the explicit target of the skill


### PR DESCRIPTION
Description:
- Adds an overload for `HandleUnmanaged` that includes the source
- Modifies damage buffs in `BuffComponent.cpp` to also include the source

Motivation and context:
Addresses issue #232 where the surprise beehive inventor skill does not credit kills to the player.

Tested by killing an enemy with the ability and seeing that it now drops loot, which it did not do previously.
[https://streamable.com/btz2vs](https://streamable.com/btz2vs)