### PR TITLE
GM Mail Command Additions and Edits

### DIFF
--- a/dGame/Character.h
+++ b/dGame/Character.h
@@ -364,6 +364,42 @@ public:
      */
 	void SetAnnouncementMessage(const std::string& value) { m_AnnouncementMessage = value; }
 
+    /**
+     * Gets the custom sender name of a mail message (reserved for GMs)
+     * @return the custom sender name of the mail
+     */
+    const std::string& GetMailSender() const { return m_MailSender; }
+
+    /**
+     * Sets the custom sender name of the next GM mail message (reserved for GMs)
+     * @param value the custom sender name of the mail message
+     */
+    void SetMailSender(const std::string& value) { m_MailSender = value; }
+    
+    /**
+     * Gets the subject of a mail message that a character made (reserved for GMs)
+     * @return the title of the announcement a character made
+     */
+    const std::string& GetMailSubject() const { return m_MailSubject; }
+
+    /**
+     * Sets the subject of a mail message a character will make (reserved for GMs)
+     * @param value the subject to set
+     */
+    void SetMailSubject(const std::string& value) { m_MailSubject = value; }
+
+    /**
+     * Gets the body of a mail message a character made (reserved for GMs)
+     * @return the body of the mail
+     */
+    const std::string& GetMailBody() const { return m_MailBody; }
+
+    /**
+     * Sets the body of an mail message to make (reserved for GMs)
+     * @param value the body of the mail message
+     */
+    void SetMailBody(const std::string& value) { m_MailBody = value; }
+
 	/**
 	 * Called when the character has loaded into a zone
 	 */
@@ -594,6 +630,24 @@ private:
      * The body of an announcement this character made (reserved for GMs)
      */
 	std::string m_AnnouncementMessage;
+
+    /**
+     * The custom sender name of a mail message this character made (reserved for GMs)
+     * Default: "Darkflame Universe"
+     */
+    std::string m_MailSender = "Darkflame Universe";
+
+    /**
+     * The subject of a mail message this character made (reserved for GMs)
+     * Default: "Lost item"
+     */
+    std::string m_MailSubject = "Lost item";
+
+    /**
+     * The body of a mail message this character made (reserved for GMs)
+     * Default: "This is a replacement item for one you lost."
+     */
+    std::string m_MailBody = "This is a replacement item for one you lost.";
 
     /**
      * The spawn position of this character when loading in

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -868,7 +868,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 	if (chatCommand == "mailitem" && entity->GetGMLevel() >= GAME_MASTER_LEVEL_MODERATOR) {
 		// Display help for the user
-		if (args.size() <= 1) {
+		if (args.size() < 2) {
 			ChatPackets::SendSystemMessage(sysAddr, u"Mails an item to a specified character");
 			ChatPackets::SendSystemMessage(sysAddr, u"/mailitem <name> <itemid> <count>");
 			return;
@@ -913,6 +913,12 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			}
 
 			count = std::stoi(args[2]);
+			
+			if (count < 1)
+			{
+				ChatPackets::SendSystemMessage(sysAddr, u"Cannot send less than 1 of an item. Defaulting to 1.");
+				count = 1;
+			}
 		}
 
 		uint64_t currentTime = time(NULL);
@@ -985,6 +991,12 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			}
 			
 			count = std::stoi(args[2]);
+
+			if (count < 1)
+			{
+				ChatPackets::SendSystemMessage(sysAddr, u"Cannot send less than 1 of an item. Defaulting to 1.");
+				count = 1;
+			}
 		}
 
 		// Mail each character from the player query.

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -828,6 +828,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		}
 
 		entity->GetCharacter()->SetMailSender(ss.str());
+		ChatPackets::SendSystemMessage(sysAddr, u"Custom mail sender set.");
 		return;
 	}
 
@@ -844,6 +845,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			ss << string << " ";
 
 		entity->GetCharacter()->SetMailSubject(ss.str());
+		ChatPackets::SendSystemMessage(sysAddr, u"Custom mail subject set.");
 		return;
 	}
 
@@ -860,6 +862,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			ss << string << " ";
 
 		entity->GetCharacter()->SetMailBody(ss.str());
+		ChatPackets::SendSystemMessage(sysAddr, u"Custom mail body set.");
 		return;
 	}
 


### PR DESCRIPTION
This is a re-opened PR for PR https://github.com/DarkflameUniverse/DarkflameServer/pull/226. This version has been through much more testing, validation, and has some improvements over the prior PR.

**Additions:**
- `/setmailsender`: Sets the mail "sender" line of the next GM mail sent. Maximum 20 characters.
- `/setmailsub`: Sets the mail "subject" line of the next GM mail sent.
- `/setmailbody`: Sets the mail "body" of the next GM mail sent.
-  `/mailitemall`: Mails an item to all online or all existing characters. Sending to online will be based on the activity log table (which doesn't seem to be accurate every time, but is the only way to get all players cross-world), which attempts to replicate the GM mail events near the end of LU. Sending to all players will send to every character that exists in the charinfo table. This version of the command could be slightly taxing on the database, so it shouldn't be done often (as it inserts into the "mail" table once for every character).

**Modified Commands:**
- `/mailitem`: This command has been modified to allow the custom sender, subject, body to work. It has also been given a syntax helper when the proper number of arguments are not given, the ability to send more than 1 of an item, and more feedback when an item is successfully sent.

**Philosophy for Changes:**
The changes above are quality of life improvements, intended to make the life of a server operator easier, and to expand on the features of the existing mail function. These commands allowed me to send out a custom message on my server with candy canes for a Frostburg Item Vendor I added to Nimbus Plaza (as a holiday event). All players have received the items with no issue, and the `/mailitemall all ... ...` command that was used did not cause any strain on the server, and made my life 10x easier for distributing items.

Let me know if there are any concerns or questions.
Tagging @DarwinAnim8or , since you were assisting me with the original request.