### PR TITLE
Fix Area of Effect Behavior Targets

### DIFF
--- a/dGame/dBehaviors/AreaOfEffectBehavior.cpp
+++ b/dGame/dBehaviors/AreaOfEffectBehavior.cpp
@@ -74,6 +74,7 @@ void AreaOfEffectBehavior::Calculate(BehaviorContext* context, RakNet::BitStream
 		includeFaction = 1;
 	}
 
+	// Gets all of the valid targets, passing in if should target enemies and friends
 	for (auto validTarget : context->GetValidTargets(m_ignoreFaction , includeFaction, m_TargetSelf == 1, m_targetEnemy == 1, m_targetFriend == 1))
 	{
 		auto* entity = EntityManager::Instance()->GetEntity(validTarget);
@@ -156,7 +157,7 @@ void AreaOfEffectBehavior::Load()
 
 	this->m_includeFaction = GetInt("include_faction");
 
-        this->m_TargetSelf = GetInt("target_self");
+    this->m_TargetSelf = GetInt("target_self");
 
 	this->m_targetEnemy = GetInt("target_enemy");
 

--- a/dGame/dBehaviors/AreaOfEffectBehavior.cpp
+++ b/dGame/dBehaviors/AreaOfEffectBehavior.cpp
@@ -74,7 +74,7 @@ void AreaOfEffectBehavior::Calculate(BehaviorContext* context, RakNet::BitStream
 		includeFaction = 1;
 	}
 
-	for (auto validTarget : context->GetValidTargets(m_ignoreFaction , includeFaction, m_TargetSelf == 1))
+	for (auto validTarget : context->GetValidTargets(m_ignoreFaction , includeFaction, m_TargetSelf == 1, m_targetEnemy == 1, m_targetFriend == 1))
 	{
 		auto* entity = EntityManager::Instance()->GetEntity(validTarget);
 
@@ -157,4 +157,8 @@ void AreaOfEffectBehavior::Load()
 	this->m_includeFaction = GetInt("include_faction");
 
         this->m_TargetSelf = GetInt("target_self");
+
+	this->m_targetEnemy = GetInt("target_enemy");
+
+	this->m_targetFriend = GetInt("target_friend");
 }

--- a/dGame/dBehaviors/AreaOfEffectBehavior.h
+++ b/dGame/dBehaviors/AreaOfEffectBehavior.h
@@ -14,7 +14,7 @@ public:
 
 	int32_t m_includeFaction;
 
-        int32_t m_TargetSelf;
+    int32_t m_TargetSelf;
 
 	int32_t m_targetEnemy;
 

--- a/dGame/dBehaviors/AreaOfEffectBehavior.h
+++ b/dGame/dBehaviors/AreaOfEffectBehavior.h
@@ -15,6 +15,10 @@ public:
 	int32_t m_includeFaction;
 
         int32_t m_TargetSelf;
+
+	int32_t m_targetEnemy;
+
+	int32_t m_targetFriend;
 	
 	/*
 	 * Inherited

--- a/dGame/dBehaviors/BehaviorContext.cpp
+++ b/dGame/dBehaviors/BehaviorContext.cpp
@@ -325,7 +325,7 @@ void BehaviorContext::Reset()
 	this->scheduledUpdates.clear();
 }
 
-std::vector<LWOOBJID> BehaviorContext::GetValidTargets(int32_t ignoreFaction, int32_t includeFaction, bool targetSelf) const
+std::vector<LWOOBJID> BehaviorContext::GetValidTargets(int32_t ignoreFaction, int32_t includeFaction, bool targetSelf, bool targetEnemy, bool targetFriend) const
 {
 	auto* entity = EntityManager::Instance()->GetEntity(this->caster);
 
@@ -366,7 +366,7 @@ std::vector<LWOOBJID> BehaviorContext::GetValidTargets(int32_t ignoreFaction, in
 		{
 			const auto id = candidate->GetObjectID();
 			
-			if ((id != entity->GetObjectID() || targetSelf) && destroyableComponent->CheckValidity(id, ignoreFaction || includeFaction))
+			if ((id != entity->GetObjectID() || targetSelf) && destroyableComponent->CheckValidity(id, ignoreFaction || includeFaction, targetEnemy, targetFriend))
 			{
 				targets.push_back(id);
 			}

--- a/dGame/dBehaviors/BehaviorContext.h
+++ b/dGame/dBehaviors/BehaviorContext.h
@@ -102,7 +102,7 @@ struct BehaviorContext
 
 	void Reset();
 
-	std::vector<LWOOBJID> GetValidTargets(int32_t ignoreFaction = 0, int32_t includeFaction = 0, const bool targetSelf = false) const;
+	std::vector<LWOOBJID> GetValidTargets(int32_t ignoreFaction = 0, int32_t includeFaction = 0, const bool targetSelf = false, const bool targetEnemy = true, const bool targetFriend = false) const;
 	
 	explicit BehaviorContext(LWOOBJID originator, bool calculation = false);
 

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -498,7 +498,7 @@ Entity* DestroyableComponent::GetKiller() const
 	return EntityManager::Instance()->GetEntity(m_KillerID);
 }
 
-bool DestroyableComponent::CheckValidity(const LWOOBJID target, const bool ignoreFactions) const
+bool DestroyableComponent::CheckValidity(const LWOOBJID target, const bool ignoreFactions, const bool targetEnemy, const bool targetFriend) const
 {
 	auto* entity = EntityManager::Instance()->GetEntity(target);
 
@@ -537,15 +537,19 @@ bool DestroyableComponent::CheckValidity(const LWOOBJID target, const bool ignor
 
 	auto candidateList = destroyable->GetFactionIDs();
 
+
+	bool isEnemy = false;
+
 	for (auto value : candidateList)
 	{
 		if (std::find(enemyList.begin(), enemyList.end(), value) != enemyList.end())
 		{
-			return true;
+			isEnemy = true;
+			break;
 		}
 	}
 
-	return false;
+	return (isEnemy && targetEnemy) || (!isEnemy && targetFriend);
 }
 
 

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -532,12 +532,12 @@ bool DestroyableComponent::CheckValidity(const LWOOBJID target, const bool ignor
 		return true;
 	}
 
-	// Get if the target entity is an enemy
+	// Get if the target entity is an enemy and friend
 	bool isEnemy = IsEnemy(targetEntity);
+	bool isFriend = IsFriend(targetEntity);
 
 	// Return true if the target type matches what we are targeting
-	// Friends are entities who are not enemies
-	return (isEnemy && targetEnemy) || (!isEnemy && targetFriend);
+	return (isEnemy && targetEnemy) || (isFriend && targetFriend);
 }
 
 

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -500,27 +500,26 @@ Entity* DestroyableComponent::GetKiller() const
 
 bool DestroyableComponent::CheckValidity(const LWOOBJID target, const bool ignoreFactions, const bool targetEnemy, const bool targetFriend) const
 {
-	auto* entity = EntityManager::Instance()->GetEntity(target);
+	auto* targetEntity = EntityManager::Instance()->GetEntity(target);
 
-	if (entity == nullptr)
+	if (targetEntity == nullptr)
 	{
 		Game::logger->Log("DestroyableComponent", "Invalid entity for checking validity (%llu)!\n", target);
-
 		return false;
 	}
 
-	auto* destroyable = entity->GetComponent<DestroyableComponent>();
+	auto* targetDestroyable = targetEntity->GetComponent<DestroyableComponent>();
 
-	if (destroyable == nullptr)
+	if (targetDestroyable == nullptr)
 	{
 		return false;
 	}
 
-	auto* quickbuild = entity->GetComponent<RebuildComponent>();
+	auto* targetQuickbuild = targetEntity->GetComponent<RebuildComponent>();
 
-	if (quickbuild != nullptr)
+	if (targetQuickbuild != nullptr)
 	{
-		const auto state = quickbuild->GetState();
+		const auto state = targetQuickbuild->GetState();
 			
 		if (state != REBUILD_COMPLETED)
 		{
@@ -533,22 +532,11 @@ bool DestroyableComponent::CheckValidity(const LWOOBJID target, const bool ignor
 		return true;
 	}
 
-	auto enemyList = GetEnemyFactionsIDs();
+	// Get if the target entity is an enemy
+	bool isEnemy = IsEnemy(targetEntity);
 
-	auto candidateList = destroyable->GetFactionIDs();
-
-
-	bool isEnemy = false;
-
-	for (auto value : candidateList)
-	{
-		if (std::find(enemyList.begin(), enemyList.end(), value) != enemyList.end())
-		{
-			isEnemy = true;
-			break;
-		}
-	}
-
+	// Return true if the target type matches what we are targeting
+	// Friends are entities who are not enemies
 	return (isEnemy && targetEnemy) || (!isEnemy && targetFriend);
 }
 

--- a/dGame/dComponents/DestroyableComponent.h
+++ b/dGame/dComponents/DestroyableComponent.h
@@ -371,7 +371,7 @@ public:
      * @param ignoreFactions whether or not check for the factions, e.g. just return true if the entity cannot be smashed
      * @return if the target ID is a valid enemy
      */
-    bool CheckValidity(LWOOBJID target, bool ignoreFactions = false) const;
+    bool CheckValidity(LWOOBJID target, bool ignoreFactions = false, bool targetEnemy = true, bool targetFriend = false) const;
 
     /**
      * Attempt to damage this entity, handles everything from health and armor to absorption, immunity and callbacks.


### PR DESCRIPTION
**Description:**
This fixes how entities are targeted during Area of Effect Behaviors. Each AOE Behavior has fields set in the CDClient database to determine who to target. The fields are read in on initialization and are used to filter targets. This fixes issues such as #328 

**Motivation/Context:**
Passive abilities, such as the Samurai's invulnerability at 0 armor, and other in-game effects are handled as an area of effect. The effect targets specific entities based on fields outlined in the CDClient Database. Some behaviors target enemies (such as the buildable sirens in Gnarled Forest), while others target friends (such as the aforementioned Samurai ability). However, there was no logical distinction, and so abilities that should target friends were targeting enemies.

**Types of Changes:**
This is a simple change to the definitions in the area of effect behavior script to read fields from the database related to targeting, as well as changes to destroyable components to allow for validating a target based on these fields.

**Testing:**
This has been tested using multiple players in a variety of situations and behaviors, such as the Sirens and Samurai abilities. Sirens should target enemies (which they do), whereas Samurais should target friends (which they also do)

**Screenshots:**
Below are two screenshots showing the basic functionality.

(1) The siren successfully targets enemies (stromlings) and not friends (players)
![Lego Universe Screenshot 2022 01 02 - 14 22 53 95](https://user-images.githubusercontent.com/45527167/147889846-b86c34b1-c5a2-4b6c-8f42-2a606703e240.png)

(2) The Samurai ability does not target enemies (stromlings), but is in effect (via the glowing orange around the player)
![Lego Universe Screenshot 2022 01 02 - 14 23 22 60](https://user-images.githubusercontent.com/45527167/147889859-b3ad45fe-3a6a-4c87-8ec8-82c645b536f0.png)

