### PR TITLE
Add handling of SIGTERM

### DIFF
--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -62,6 +62,7 @@ int main(int argc, char** argv) {
 	//Triggers the shutdown sequence at application exit
 	std::atexit(ShutdownSequence);
 	signal(SIGINT, [](int) { ShutdownSequence(); });
+	signal(SIGTERM, [](int) { ShutdownSequence(); });
 
 	//Create all the objects we need to run our service:
 	Game::logger = SetupLogger();

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -100,10 +100,8 @@ int main(int argc, char** argv) {
 	// Triggers the shutdown sequence at application exit
 	std::atexit(WorldShutdownSequence);
 	
-	signal(SIGINT, [](int)
-	{
-		WorldShutdownSequence();
-	});
+	signal(SIGINT, [](int){ WorldShutdownSequence(); });
+	signal(SIGTERM, [](int){ WorldShutdownSequence(); });
 
 	int zoneID = 1000;
 	int cloneID = 0;


### PR DESCRIPTION
supervisord, systemd services and the kill command by default send SIGTERM signals to shutdown proccesses. The Master Server should handle the SIGTERM signal the same way as SIGINT to ensure a gracefull shutdown on SIGTERM signal.

I tested this on my ubuntu 20.04 VPS and it works as intended.