### PR TITLE
Change the win delay to increase time to get BONS loot

### DIFF
--- a/dScripts/ZoneNsWaves.cpp
+++ b/dScripts/ZoneNsWaves.cpp
@@ -439,7 +439,7 @@ std::vector<Wave> ZoneNsWaves::GetWaves() {
             5.0f,
             (uint32_t) -1,
             true,
-            5,
+            30,
         },
     };
 }


### PR DESCRIPTION
The time was previously 5 seconds, 30 seconds is what it was in live.