### PR TITLE
Remove Mission Task Magic Numbers In Script Task Progression and Script Cleanup

### DIFF
--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -727,7 +727,6 @@ void PetComponent::NotifyTamingBuildSuccess(NiPoint3 position)
 
     if (missionComponent != nullptr)
     {
-        //missionComponent->ForceProgress(506, 768, 1, false);
         missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_PET_TAMING, m_Parent->GetLOT());
     }
 

--- a/dScripts/ActParadoxPipeFix.cpp
+++ b/dScripts/ActParadoxPipeFix.cpp
@@ -48,7 +48,7 @@ void ActParadoxPipeFix::OnRebuildComplete(Entity* self, Entity* target)
 
                 if (missionComponent != nullptr)
                 {
-                    missionComponent->ForceProgressTaskType(769, 1, 1, false);
+                    missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, object->GetLOT());
                 }
 
                 GameMessages::SendPlayCinematic(player->GetObjectID(), u"ParadoxPipeFinish", player->GetSystemAddress(), true, true, false, false, 0, false, 2.0f);

--- a/dScripts/AmScrollReaderServer.cpp
+++ b/dScripts/AmScrollReaderServer.cpp
@@ -11,7 +11,6 @@ void AmScrollReaderServer::OnMessageBoxResponse(Entity* self, Entity* sender, in
         {
             return;
         }
-
-        missionComponent->ForceProgressTaskType(969, 1, 1, false);
+        missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
     }
 }

--- a/dScripts/AmShieldGeneratorQuickbuild.cpp
+++ b/dScripts/AmShieldGeneratorQuickbuild.cpp
@@ -158,8 +158,7 @@ void AmShieldGeneratorQuickbuild::OnRebuildComplete(Entity* self, Entity* target
         {
             return;
         }
-
-        missionComponent->ForceProgressTaskType(987, 1, 1, false);
+        missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
     }
 }
 

--- a/dScripts/AmSkullkinDrill.cpp
+++ b/dScripts/AmSkullkinDrill.cpp
@@ -281,10 +281,8 @@ void AmSkullkinDrill::OnHitOrHealResult(Entity* self, Entity* attacker, int32_t 
 
         if (missionComponent != nullptr)
         {
-            for (const auto missionID : m_MissionsToUpdate)
-            {
-                missionComponent->ForceProgressValue(missionID, 1, self->GetLOT());
-            }
+            std::cout << self->GetLOT() << std::endl;
+            missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
         }
     }
 

--- a/dScripts/AmSkullkinTower.cpp
+++ b/dScripts/AmSkullkinTower.cpp
@@ -189,17 +189,10 @@ void AmSkullkinTower::OnChildRemoved(Entity* self, Entity* child)
 
             auto* missionComponent = player->GetComponent<MissionComponent>();
 
-            if (missionComponent == nullptr)
-            {
-                continue;
+            if (missionComponent != nullptr) {
+                std::cout << self->GetLOT() << std::endl;
+                missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
             }
-
-            for (const auto missionID : missionIDs)
-            {
-                missionComponent->ForceProgressValue(missionID, 1, self->GetLOT());
-            }
-
-            //missionComponent->ForceProgressValue(1305, 1, self->GetLOT());
         }
     }
 

--- a/dScripts/AmTemplateSkillVolume.cpp
+++ b/dScripts/AmTemplateSkillVolume.cpp
@@ -3,25 +3,12 @@
 
 void AmTemplateSkillVolume::OnSkillEventFired(Entity* self, Entity* caster, const std::string& message) 
 {
-    if (message != "NinjagoSpinAttackEvent")
-    {
-        return;
-    }
+    if (message != "NinjagoSpinAttackEvent") return;
 
     auto* missionComponent = caster->GetComponent<MissionComponent>();
 
-    const auto missionIDsVariable = GeneralUtils::UTF16ToWTF8(self->GetVar<std::u16string>(u"missions"));
-    const auto missionIDs = GeneralUtils::SplitString(missionIDsVariable, '_');
+    if(missionComponent == nullptr) return;
 
-    for (const auto& missionIDStr : missionIDs)
-    {
-        int32_t missionID = 0;
-
-        if (!GeneralUtils::TryParse(missionIDStr, missionID))
-        {
-            continue;
-        }
-
-        missionComponent->ForceProgressTaskType(missionID, 1, 1, false);
-    }
+    std::cout << self->GetLOT() << std::endl;
+    missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
 }

--- a/dScripts/AmTemplateSkillVolume.h
+++ b/dScripts/AmTemplateSkillVolume.h
@@ -4,5 +4,12 @@
 class AmTemplateSkillVolume : public CppScripts::Script
 {
 public:
+    /**
+     * @brief Script for checking if player cast a skill near Neido in Crux Prime???
+     * 
+     * @param self This Entity.
+     * @param caster The Caster Entity.
+     * @param message The Casted Ability.
+     */
     void OnSkillEventFired(Entity* self, Entity* caster, const std::string& message) override;
 };

--- a/dScripts/ExplodingAsset.cpp
+++ b/dScripts/ExplodingAsset.cpp
@@ -43,26 +43,11 @@ void ExplodingAsset::OnHit(Entity* self, Entity* attacker) {
 		skillComponent->CalculateBehavior(147, 4721, LWOOBJID_EMPTY, true);
 	}
 
-	const auto missionID = self->GetVar<int32_t>(u"missionID");
-	auto achievementIDs = self->GetVar<std::u16string>(u"achieveID");
-
 	// Progress all scripted missions related to this asset
 	auto* missionComponent = attacker->GetComponent<MissionComponent>();
-	if (missionComponent != nullptr) {
-	    if (missionID != 0) {
-	        missionComponent->ForceProgressValue(missionID,
-                                                 static_cast<uint32_t>(MissionTaskType::MISSION_TASK_TYPE_SCRIPT),
-                                                 self->GetLOT(), false);
-	    }
+	if (missionComponent == nullptr) return;
 
-	    if (!achievementIDs.empty()) {
-	        for (const auto& achievementID : GeneralUtils::SplitString(achievementIDs, u'_')) {
-	            missionComponent->ForceProgressValue(std::stoi(GeneralUtils::UTF16ToWTF8(achievementID)),
-                                                     static_cast<uint32_t>(MissionTaskType::MISSION_TASK_TYPE_SCRIPT),
-                                                     self->GetLOT());
-	        }
-	    }
-	}
+	missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
 
 	self->ScheduleKillAfterUpdate();
 }

--- a/dScripts/FvCandle.cpp
+++ b/dScripts/FvCandle.cpp
@@ -1,8 +1,6 @@
 #include "FvCandle.h"
 #include "MissionComponent.h"
 
-std::vector<int32_t> FvCandle::m_Missions = {850, 1431, 1529, 1566, 1603};
-
 void FvCandle::OnStartup(Entity* self) {
 	auto* render = static_cast<RenderComponent*>(self->GetComponent(COMPONENT_TYPE_RENDER));
 	if (render == nullptr)
@@ -27,15 +25,10 @@ void FvCandle::BlowOutCandle(Entity* self, Entity* blower) {
 	
 	auto* missionComponent = blower->GetComponent<MissionComponent>();
 
-	if (missionComponent != nullptr)
-	{
-		for (const auto mission : m_Missions)
-		{
-			missionComponent->ForceProgressTaskType(mission, 1, 1);
-		}
-	}
+	if (missionComponent == nullptr) return;
 
-	//Update mission tasks here
+	missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
+
 	self->SetBoolean(u"AmHit", true);
 
 	render->StopEffect("candle_light", false);

--- a/dScripts/FvHorsemenTrigger.cpp
+++ b/dScripts/FvHorsemenTrigger.cpp
@@ -56,15 +56,9 @@ FvHorsemenTrigger::OnFireEventServerSide(Entity *self, Entity *sender, std::stri
 
             auto* missionComponent = player->GetComponent<MissionComponent>();
 
-            if (missionComponent == nullptr)
-            {
-                continue;
-            }
+            if (missionComponent == nullptr) return;
 
-            for (const auto missionId : m_Missions)
-            {
-                missionComponent->ForceProgressTaskType(missionId, 1, 1);
-            }
+            missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
         }
     }
 }

--- a/dScripts/FvHorsemenTrigger.h
+++ b/dScripts/FvHorsemenTrigger.h
@@ -1,7 +1,11 @@
 #pragma once
 #include "CppScripts.h"
 #include "RenderComponent.h"
-
+/**
+ * @brief Class for Brick Fury in Forbidden Valley.  Deals with mission progression
+ * and killing the enemies.
+ * 
+ */
 class FvHorsemenTrigger : public CppScripts::Script 
 {
 public:
@@ -9,7 +13,4 @@ public:
     void OnProximityUpdate(Entity* self, Entity* entering, std::string name, std::string status) override;
     void OnFireEventServerSide(Entity *self, Entity *sender, std::string args, int32_t param1, int32_t param2,
                                int32_t param3) override;
-
-private:
-    std::vector<int32_t> m_Missions = {854, 738, 1432, 1530, 1567, 1604};
 };

--- a/dScripts/FvNinjaGuard.cpp
+++ b/dScripts/FvNinjaGuard.cpp
@@ -14,23 +14,9 @@ void FvNinjaGuard::OnStartup(Entity* self)
 	}
 }
 
-void FvNinjaGuard::OnEmoteReceived(Entity* self, const int32_t emote, Entity* target)
-{
-	if (emote != 392)
-	{
-		GameMessages::SendPlayAnimation(self, u"no");
-
-		return;
-	}
-
+void FvNinjaGuard::OnEmoteReceived(Entity* self, const int32_t emote, Entity* target) {
+	
 	GameMessages::SendPlayAnimation(self, u"scared");
-
-	auto* missionComponent = target->GetComponent<MissionComponent>();
-
-	if (missionComponent != nullptr && missionComponent->HasMission(737))
-	{
-		missionComponent->ForceProgressTaskType(737, 5, 1, false);
-	}
 
 	if (self->GetLOT() == 7412)
 	{
@@ -50,5 +36,10 @@ void FvNinjaGuard::OnEmoteReceived(Entity* self, const int32_t emote, Entity* ta
 			GameMessages::SendPlayAnimation(leftGuard, u"laugh_lt");
 		}
 	}
+	auto* missionComponent = target->GetComponent<MissionComponent>();
+
+	if (missionComponent == nullptr) return;
+
+	missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_EMOTE, emote, self->GetObjectID());
 }
 

--- a/dScripts/GfCampfire.cpp
+++ b/dScripts/GfCampfire.cpp
@@ -44,13 +44,11 @@ void GfCampfire::OnProximityUpdate(Entity* self, Entity* entering, std::string n
 					skill->CalculateBehavior(m_skillCastId, 115, entering->GetObjectID());
 					self->AddTimer("TimeBetweenCast", FIRE_COOLDOWN);
 
-					//self->SetVar<LWOOBJID>("target", entering->GetObjectID());
+					auto* missionComponent = entering->GetComponent<MissionComponent>();
 
-					auto* missionComponet = entering->GetComponent<MissionComponent>();
-
-					if (missionComponet != nullptr)
+					if (missionComponent != nullptr)
 					{
-						missionComponet->ForceProgress(440, 658, 1);
+						missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
 					}
 				}
 			}

--- a/dScripts/GfCaptainsCannon.cpp
+++ b/dScripts/GfCaptainsCannon.cpp
@@ -80,13 +80,12 @@ void GfCaptainsCannon::OnTimerDone(Entity* self, std::string timerName)
 
         GameMessages::SendStopFXEffect(player, true, "hook");
 
+        GameMessages::SendTerminateInteraction(playerId, FROM_INTERACTION, self->GetObjectID());
+
         auto* missionComponent = player->GetComponent<MissionComponent>();
 
-        if (missionComponent != nullptr)
-        {
-            missionComponent->ForceProgress(601, 910, 1);
-        }
+        if (missionComponent == nullptr) return;
 
-        GameMessages::SendTerminateInteraction(playerId, FROM_INTERACTION, self->GetObjectID());
+        missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
     }
 }

--- a/dScripts/GfTikiTorch.cpp
+++ b/dScripts/GfTikiTorch.cpp
@@ -63,14 +63,13 @@ void GfTikiTorch::OnSkillEventFired(Entity *self, Entity *caster, const std::str
             renderComponent->PlayEffect(611, u"steam", "steam");
         }
 
-        auto* casterMissionComponent = caster->GetComponent<MissionComponent>();
-        if (casterMissionComponent != nullptr) {
-            for (const auto missionID : m_missions) {
-                casterMissionComponent->ForceProgressTaskType(missionID, static_cast<uint32_t>(MissionTaskType::MISSION_TASK_TYPE_SCRIPT), 1);
-            }
-        }
-
         self->AddTimer("Relight", 7.0f);
         self->SetBoolean(u"isBurning", false);
+
+		auto* sprayerMissionComponent = caster->GetComponent<MissionComponent>();
+
+        if (sprayerMissionComponent == nullptr) return;
+
+        sprayerMissionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
     }
 }

--- a/dScripts/GfTikiTorch.h
+++ b/dScripts/GfTikiTorch.h
@@ -13,5 +13,4 @@ private:
 
 	LOT m_imaginationlot = 935;
 	int32_t m_numspawn = 3;
-	std::vector<int> m_missions = {472, 1429, 1527, 1564, 1601};
 };

--- a/dScripts/GrowingFlower.cpp
+++ b/dScripts/GrowingFlower.cpp
@@ -7,22 +7,13 @@ void GrowingFlower::OnSkillEventFired(Entity *self, Entity *target, const std::s
         self->SetNetworkVar(u"blooming", true);
         self->AddTimer("FlowerDie", GrowingFlower::aliveTime);
 
-        const auto mission1 = self->GetVar<int32_t>(u"missionID");
-        const auto mission2 = self->GetVar<int32_t>(u"missionID2");
-
-        LootGenerator::Instance().DropActivityLoot(target, self, self->GetLOT(), 0);
+        LootGenerator::Instance().DropActivityLoot(target, self, self->GetLOT());
 
         auto* missionComponent = target->GetComponent<MissionComponent>();
-        if (missionComponent != nullptr) {
-            for (const auto mission : achievementIDs)
-                missionComponent->ForceProgressTaskType(mission, static_cast<uint32_t>(MissionTaskType::MISSION_TASK_TYPE_SCRIPT), 1);
 
-            if (mission1 && missionComponent->GetMissionState(mission1) == MissionState::MISSION_STATE_ACTIVE)
-                missionComponent->ForceProgressTaskType(mission1, static_cast<uint32_t>(MissionTaskType::MISSION_TASK_TYPE_SCRIPT), 1);
-
-            if (mission2 && missionComponent->GetMissionState(mission2) == MissionState::MISSION_STATE_ACTIVE)
-                missionComponent->ForceProgressTaskType(mission2, static_cast<uint32_t>(MissionTaskType::MISSION_TASK_TYPE_SCRIPT), 1);
-        }
+        if (missionComponent == nullptr) return;
+        
+        missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
     }
 }
 
@@ -31,5 +22,3 @@ void GrowingFlower::OnTimerDone(Entity *self, std::string message) {
         self->Smash();
     }
 }
-
-const std::vector<uint32_t> GrowingFlower::achievementIDs = { 143, 152, 153, 1409, 1507, 1544, 1581, 1845 };

--- a/dScripts/ImgBrickConsoleQB.cpp
+++ b/dScripts/ImgBrickConsoleQB.cpp
@@ -86,19 +86,22 @@ void ImgBrickConsoleQB::OnUse(Entity* self, Entity* user)
 
         if (missionComponent != nullptr && inventoryComponent != nullptr)
         {
-            if (missionComponent->GetMissionState(1302) == MissionState::MISSION_STATE_ACTIVE)
-            {
-                inventoryComponent->RemoveItem(13074, 1);
-                
-                missionComponent->ForceProgressTaskType(1302, 1, 1);
+            // Check if we have mission 1302, "Secret of The Skeletons"
+            if (missionComponent->GetMissionState(1302) == MissionState::MISSION_STATE_ACTIVE) {
+                // Since we know we are in this mission we make sure we have the "Nuckal's Maelstrom Bone" item in our inventory before removing 1 and progressing the mission.
+                if(inventoryComponent->FindItemByLot(13074)) {
+                    inventoryComponent->RemoveItem(13074, 1);
+                    missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
+                }
             }
             
-            if (missionComponent->GetMissionState(1926) == MissionState::MISSION_STATE_ACTIVE)
-            {
-                inventoryComponent->RemoveItem(14472, 1);
-                inventoryComponent->AddItem(14472, 1);
-
-                missionComponent->ForceProgressTaskType(1926, 1, 1);
+            // Check if we have mission 1926, "Chaos Cleaner"
+            if (missionComponent->GetMissionState(1926) == MissionState::MISSION_STATE_ACTIVE) {
+                 // Since we know we are in this mission we make sure we have the "Maelstrom Dagger" in our inventory before removing 1 and progressing the mission.
+                if(inventoryComponent->FindItemByLot(14472)) {
+                    inventoryComponent->RemoveItem(14472, 1);
+                    missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
+                }
             }
         }
 

--- a/dScripts/ImgBrickConsoleQB.cpp
+++ b/dScripts/ImgBrickConsoleQB.cpp
@@ -89,7 +89,7 @@ void ImgBrickConsoleQB::OnUse(Entity* self, Entity* user)
             // Check if we have mission 1302, "Secret of The Skeletons"
             if (missionComponent->GetMissionState(1302) == MissionState::MISSION_STATE_ACTIVE) {
                 // Since we know we are in this mission we make sure we have the "Nuckal's Maelstrom Bone" item in our inventory before removing 1 and progressing the mission.
-                if(inventoryComponent->FindItemByLot(13074)) {
+                if(inventoryComponent->GetLotCount(13074) > 0) {
                     inventoryComponent->RemoveItem(13074, 1);
                     missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
                 }
@@ -98,7 +98,7 @@ void ImgBrickConsoleQB::OnUse(Entity* self, Entity* user)
             // Check if we have mission 1926, "Chaos Cleaner"
             if (missionComponent->GetMissionState(1926) == MissionState::MISSION_STATE_ACTIVE) {
                  // Since we know we are in this mission we make sure we have the "Maelstrom Dagger" in our inventory before removing 1 and progressing the mission.
-                if(inventoryComponent->FindItemByLot(14472)) {
+                if(inventoryComponent->GetLotCount(14472) > 0) {
                     inventoryComponent->RemoveItem(14472, 1);
                     missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
                 }

--- a/dScripts/LegoDieRoll.cpp
+++ b/dScripts/LegoDieRoll.cpp
@@ -13,43 +13,14 @@ void LegoDieRoll::OnTimerDone(Entity* self, std::string timerName) {
         self->Smash(self->GetObjectID(), SILENT);
     } 
     else if (timerName == "ThrowDice") {
-        int dieRoll = GeneralUtils::GenerateRandomNumber<int>(1, 6);
+        int32_t dieRoll = GeneralUtils::GenerateRandomNumber<int32_t>(1, 6);
+        GameMessages::SendPlayAnimation(self, anims[dieRoll - 1]);
+        if (dieRoll == 6) {
+            auto* user = self->GetOwner();
+            auto* missionComponent = user->GetComponent<MissionComponent>();
+            if(missionComponent == nullptr) return;
 
-        switch (dieRoll)
-        {
-        case 1:
-		    GameMessages::SendPlayAnimation(self, u"roll-die-1");
-            break;
-        case 2:
-		    GameMessages::SendPlayAnimation(self, u"roll-die-2");
-            break;
-        case 3:
-		    GameMessages::SendPlayAnimation(self, u"roll-die-3");
-            break;
-        case 4:
-		    GameMessages::SendPlayAnimation(self, u"roll-die-4");
-            break;
-        case 5:
-		    GameMessages::SendPlayAnimation(self, u"roll-die-5");
-            break;
-        case 6:
-            {
-		    GameMessages::SendPlayAnimation(self, u"roll-die-6");
-            // tracking the It's Truly Random Achievement 
-            auto* owner = self->GetOwner();
-            auto* missionComponent = owner->GetComponent<MissionComponent>();
-
-            if (missionComponent != nullptr) {
-                const auto rollMissionState = missionComponent->GetMissionState(756);
-                if (rollMissionState == MissionState::MISSION_STATE_ACTIVE) {
-                    missionComponent->ForceProgress(756, 1103, 1);
-                }
-            }
-            break;
-            }
-        default:
-	        Game::logger->LogDebug("LegoDieRoll", "Invalid animation: roll-die-%i\n", dieRoll);
-            break;
+            missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
         }
     }
 }

--- a/dScripts/LegoDieRoll.h
+++ b/dScripts/LegoDieRoll.h
@@ -7,5 +7,6 @@ public:
 	void OnTimerDone(Entity* self, std::string timerName);
 private:
     constexpr static const float animTime = 2.0f;
+	const std::u16string anims[6] = { u"roll-die-1", u"roll-die-2", u"roll-die-3", u"roll-die-4", u"roll-die-5", u"roll-die-6"};
 };
 

--- a/dScripts/NjColeNPC.cpp
+++ b/dScripts/NjColeNPC.cpp
@@ -4,56 +4,39 @@
 
 void NjColeNPC::OnEmoteReceived(Entity* self, int32_t emote, Entity* target) 
 {
-    if (emote != 393)
-    {
-        return;
-    }
+    // Check if we used the "Dragon Roar" emote.
+    if (emote != 393) return;
 
     auto* inventoryComponent = target->GetComponent<InventoryComponent>();
 
-    if (inventoryComponent == nullptr)
-    {
-        return;
-    }
+    if (inventoryComponent == nullptr) return;
 
-    if (!inventoryComponent->IsEquipped(14499) && !inventoryComponent->IsEquipped(16644))
-    {
-        return;
-    }
+    // Make sure we have a "Dragon Mask" equipped.
+    if (!inventoryComponent->IsEquipped(14499) && !inventoryComponent->IsEquipped(16644)) return;
 
     auto* missionComponent = target->GetComponent<MissionComponent>();
 
-    if (missionComponent == nullptr)
-    {
-        return;
-    }
+    if (missionComponent == nullptr) return;
 
-    missionComponent->ForceProgressTaskType(1818, 1, 1);
+    missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, self->GetLOT());
 }
 
 void NjColeNPC::OnMissionDialogueOK(Entity* self, Entity* target, int missionID, MissionState missionState) 
 {
     NjNPCMissionSpinjitzuServer::OnMissionDialogueOK(self, target, missionID, missionState);
 
-    if (missionID == 1818 && missionState >= MissionState::MISSION_STATE_READY_TO_COMPLETE)
-    {
-        auto* missionComponent = target->GetComponent<MissionComponent>();
-        auto* inventoryComponent = target->GetComponent<InventoryComponent>();
+    auto* missionComponent = target->GetComponent<MissionComponent>();
 
-        if (missionComponent == nullptr || inventoryComponent == nullptr)
-        {
-            return;
-        }
+    if (missionComponent == nullptr) return;
 
-        if (inventoryComponent->GetLotCount(14499) > 0)
-        {
-            inventoryComponent->RemoveItem(14499, 1);
-        }
-        else
-        {
-            return;
-        }
+    if (missionComponent->GetMissionState(missionID) != MissionState::MISSION_STATE_READY_TO_COMPLETE) return;
+    
+    auto* inventoryComponent = target->GetComponent<InventoryComponent>();
 
-        inventoryComponent->AddItem(16644, 1);
-    }
+    if (inventoryComponent == nullptr) return;
+
+    if (inventoryComponent->GetLotCount(14499) == 0) return;
+
+    inventoryComponent->RemoveItem(14499, 1);
+    inventoryComponent->AddItem(16644, 1);
 }


### PR DESCRIPTION
In many places (mostly scripts) missions are progressed in a way that is not modular and contains many magic numbers.  This PR addresses all of these.  

All of these changes are being tested as I make the changes to make sure nothing breaks.  Thus far I have had zero issues and everything has been running just fine.