### PR TITLE
Fixed a bug where Chaos Cleaner would accidentally add a Maelstrom Dagger to your inventory

### DIFF
--- a/dScripts/ImgBrickConsoleQB.cpp
+++ b/dScripts/ImgBrickConsoleQB.cpp
@@ -96,7 +96,6 @@ void ImgBrickConsoleQB::OnUse(Entity* self, Entity* user)
             if (missionComponent->GetMissionState(1926) == MissionState::MISSION_STATE_ACTIVE)
             {
                 inventoryComponent->RemoveItem(14472, 1);
-                inventoryComponent->AddItem(14472, 1);
 
                 missionComponent->ForceProgressTaskType(1926, 1, 1);
             }


### PR DESCRIPTION
This mission does take the item away but gives it back to you for some reason.  This has been fixed in this PR.