### PR TITLE
Fixed an issue where Gate Crasher task was progressed when eaten by a shark

### DIFF
--- a/dScripts/ActSharkPlayerDeathTrigger.cpp
+++ b/dScripts/ActSharkPlayerDeathTrigger.cpp
@@ -14,7 +14,7 @@ void ActSharkPlayerDeathTrigger::OnFireEventServerSide(Entity *self, Entity *sen
 		MissionComponent* mis = static_cast<MissionComponent*>(sender->GetComponent(COMPONENT_TYPE_MISSION));
 		if (!mis) return;
 
-		mis->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, 4734);
+		mis->Progress(MissionTaskType::MISSION_TASK_TYPE_SCRIPT, 8419);
 
 		if (sender->GetIsDead() || !sender->GetPlayerReadyForUpdates()) return; //Don't kill already dead players or players not ready
 		


### PR DESCRIPTION
Fixed an issue where getting eaten by a shark would accidentally progress the task for entering the Ravencloud gate's left hand side.  

This creates an issue where you are now unable to get the achievement Gate Crasher however this is due to a larger issue that is not easily fixed.

Tested getting killed by a shark on Ubuntu and behavior is as expected; Shark mission progresses and Gate Crasher does not