### PR TITLE
Added Bat Lord Full Set Bonus

### DIFF
--- a/dGame/dInventory/ItemSetPassiveAbility.cpp
+++ b/dGame/dInventory/ItemSetPassiveAbility.cpp
@@ -169,7 +169,8 @@ std::vector<ItemSetPassiveAbility> ItemSetPassiveAbility::FindAbilities(uint32_t
 
         break;
     }
-    // Sentinel
+    // Sentinel and Bat Lord
+    case ItemSetPassiveAbilityID::BatLord:
     case ItemSetPassiveAbilityID::KnightRank1:
     case ItemSetPassiveAbilityID::KnightRank2:
     case ItemSetPassiveAbilityID::KnightRank3:
@@ -223,6 +224,12 @@ void ItemSetPassiveAbility::OnEnemySmshed()
 
     switch (id)
     {
+    // Bat Lord
+    case ItemSetPassiveAbilityID::BatLord: {
+        if(equippedCount < 5) return;
+        destroyableComponent->Heal(3);
+        break;
+    }
     // Sentinel
     case ItemSetPassiveAbilityID::KnightRank1: {
         if (equippedCount < 5) return;

--- a/dGame/dInventory/ItemSetPassiveAbility.cpp
+++ b/dGame/dInventory/ItemSetPassiveAbility.cpp
@@ -169,8 +169,7 @@ std::vector<ItemSetPassiveAbility> ItemSetPassiveAbility::FindAbilities(uint32_t
 
         break;
     }
-    // Sentinel and Bat Lord
-    case ItemSetPassiveAbilityID::BatLord:
+    // Sentinel
     case ItemSetPassiveAbilityID::KnightRank1:
     case ItemSetPassiveAbilityID::KnightRank2:
     case ItemSetPassiveAbilityID::KnightRank3:
@@ -186,6 +185,7 @@ std::vector<ItemSetPassiveAbility> ItemSetPassiveAbility::FindAbilities(uint32_t
         break;
     }
     // Paradox
+    case ItemSetPassiveAbilityID::BatLord:
     case ItemSetPassiveAbilityID::SpaceMarauderRank1:
     case ItemSetPassiveAbilityID::SpaceMarauderRank2:
     case ItemSetPassiveAbilityID::SpaceMarauderRank3:


### PR DESCRIPTION
Previously the Bat Lord full set bonus was not implemented at all.  This PR implements the functionality for the full set to properly restore 3 hp on a kill.