### PR TITLE
Changed banana drop spawn Y height to prevent them from getting stuck on the trees

### DIFF
--- a/dScripts/GfBanana.cpp
+++ b/dScripts/GfBanana.cpp
@@ -64,8 +64,13 @@ void GfBanana::OnHit(Entity* self, Entity* attacker)
 
 		return;
 	}
-
-	bananaEntity->SetPosition(bananaEntity->GetPosition() - NiPoint3::UNIT_Y * 5);
+	
+	// Get the banana cluster position
+	auto entityPosition = bananaEntity->GetPosition();
+	// Lower by 10 units to prevent bananas from spawning on top of the tree
+	entityPosition.SetY(entityPosition.GetY() - 10);
+	// Set the position to the new position.
+	bananaEntity->SetPosition(entityPosition);
 
 	auto* bananaDestroyable = bananaEntity->GetComponent<DestroyableComponent>();
 

--- a/dScripts/GfBanana.cpp
+++ b/dScripts/GfBanana.cpp
@@ -65,12 +65,7 @@ void GfBanana::OnHit(Entity* self, Entity* attacker)
 		return;
 	}
 	
-	// Get the banana cluster position
-	auto entityPosition = bananaEntity->GetPosition();
-	// Lower by 10 units to prevent bananas from spawning on top of the tree
-	entityPosition.SetY(entityPosition.GetY() - 10);
-	// Set the position to the new position.
-	bananaEntity->SetPosition(entityPosition);
+	bananaEntity->SetPosition(bananaEntity->GetPosition() - NiPoint3::UNIT_Y * 8);
 
 	auto* bananaDestroyable = bananaEntity->GetComponent<DestroyableComponent>();
 


### PR DESCRIPTION
Changed the Bananas drop Y spawn height to be 10 Y units lower to prevent bananas from getting stuck on the tree.  Tested on various banana trees in my local instance and had zero issues.  