### PR TITLE
Changed Script Created for Apes on Crux Prime to allow for Anchor QuickBuilds

### DIFF
--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -681,7 +681,7 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 	else if (scriptName == "scripts\\02_server\\Enemy\\AM\\L_AM_DARKLING_DRAGON.lua")
 		script = new AmNamedDarklingDragon();
 	else if (scriptName == "scripts\\02_server\\Enemy\\AM\\L_AM_DARKLING_APE.lua")
-		script = new AmNamedDarklingDragon();
+		script = new BaseEnemyApe();
 	else if (scriptName == "scripts\\02_server\\Map\\AM\\L_BLUE_X.lua")
 	    script = new AmBlueX();
 


### PR DESCRIPTION
Fixes #221 
Address an issue where the anchor quickbuilds would not spawn for Crux Prime apes.  I deduced this to being an issue with the script created in cppscripts with the incorrect script being used for them.  The only thing AmNamedDarklingDragon does is make self immune to stuns, which BaseEnemyApe does already.

Tested in my local instance with Roo Morgg and various stromling invader apes.