### PR TITLE
Remove ability for gmlevel 0 to use /playanim

### DIFF
--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -375,11 +375,6 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 	}
 
     if (user->GetMaxGMLevel() == 0 || entity->GetGMLevel() >= 0) {
-		if ((chatCommand == "playanimation" || chatCommand == "playanim") && args.size() == 1) {
-			std::u16string anim = GeneralUtils::ASCIIToUTF16(args[0], args[0].size());
-			GameMessages::SendPlayAnimation(entity, anim);
-		}
-
 		if (chatCommand == "die") {
 			entity->Smash(entity->GetObjectID());
 		}
@@ -457,6 +452,11 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16(lowerName) + u" set to " + (GeneralUtils::to_u16string(minifigItemId)));
 
 		GameMessages::SendToggleGMInvis(entity->GetObjectID(), false, UNASSIGNED_SYSTEM_ADDRESS); // need to retoggle because it gets reenabled on creation of new character
+	}
+	
+	if ((chatCommand == "playanimation" || chatCommand == "playanim") && args.size() == 1 && entity->GetGMLevel() >= GAME_MASTER_LEVEL_DEVELOPER) {
+		std::u16string anim = GeneralUtils::ASCIIToUTF16(args[0], args[0].size());
+		GameMessages::SendPlayAnimation(entity, anim);
 	}
 
 	if (chatCommand == "list-spawns" && entity->GetGMLevel() >= GAME_MASTER_LEVEL_DEVELOPER) {


### PR DESCRIPTION
This PR removes the ability for players under GAME_MASTER_LEVEL_DEVELOPER to use /playanim. Normally I would just push this change, but there has been controversy in various circles about whether or not this should be removed. To me, the choice is clear: there is no reason normal users should have access to a debug command, and it should be removed. I'd like others' opinions on this.