### PR TITLE
Added check to prevent accidental sentinel passive proc

### DIFF
--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -246,8 +246,7 @@ void DestroyableComponent::SetArmor(int32_t value) {
     m_DirtyHealth = true;
 
 	// If Destroyable Component already has zero armor do not trigger the passive ability again.
-	bool hasArmor = true;
-	if (m_iArmor == 0) hasArmor = false;
+	bool hadArmor = m_iArmor > 0;
 	
     auto* characterComponent = m_Parent->GetComponent<CharacterComponent>();
     if (characterComponent != nullptr) {
@@ -257,7 +256,7 @@ void DestroyableComponent::SetArmor(int32_t value) {
     m_iArmor = value;
 
 	auto* inventroyComponent = m_Parent->GetComponent<InventoryComponent>();
-	if (m_iArmor == 0 && inventroyComponent != nullptr && hasArmor) {
+	if (m_iArmor == 0 && inventroyComponent != nullptr && hadArmor) {
 		inventroyComponent->TriggerPassiveAbility(PassiveAbilityTrigger::SentinelArmor);
 	}
 }

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -245,6 +245,10 @@ void DestroyableComponent::SetMaxHealth(float value, bool playAnim) {
 void DestroyableComponent::SetArmor(int32_t value) {
     m_DirtyHealth = true;
 
+	// If Destroyable Component already has zero armor do not trigger the passive ability again.
+	bool hasArmor = true;
+	if (m_iArmor == 0) hasArmor = false;
+	
     auto* characterComponent = m_Parent->GetComponent<CharacterComponent>();
     if (characterComponent != nullptr) {
         characterComponent->TrackArmorDelta(value - m_iArmor);
@@ -253,7 +257,7 @@ void DestroyableComponent::SetArmor(int32_t value) {
     m_iArmor = value;
 
 	auto* inventroyComponent = m_Parent->GetComponent<InventoryComponent>();
-	if (m_iArmor == 0 && inventroyComponent != nullptr) {
+	if (m_iArmor == 0 && inventroyComponent != nullptr && hasArmor) {
 		inventroyComponent->TriggerPassiveAbility(PassiveAbilityTrigger::SentinelArmor);
 	}
 }


### PR DESCRIPTION
Added a boolean to check if the player is at zero armor already and if so, do not trigger the passive ability.  Tested on Ubuntu and had zero issues triggering the passive from full armor and the passive did not trigger when at less than zero armor.
Fixes #394 