### PR TITLE
Fixed an issue where the Avant Gardens Survival buff station was not spawning and implemented its' script

### DIFF
--- a/dScripts/AgSurvivalBuffStation.cpp
+++ b/dScripts/AgSurvivalBuffStation.cpp
@@ -2,14 +2,10 @@
 #include "SkillComponent.h"
 #include "dLogger.h"
 
-void AgSurvivalBuffStation::OnStartup(Entity* self) {
-    Game::logger->Log("AgSurvivalBuffStation", "Spawning survival buff station!\n");
-}
-
 void AgSurvivalBuffStation::OnRebuildComplete(Entity* self, Entity* target) {
     auto skillComponent = self->GetComponent<SkillComponent>();
 
     if (skillComponent == nullptr) return;
 
-    skillComponent->CalculateBehavior(201, 1784, self->GetObjectID());
+    skillComponent->CalculateBehavior(skillIdForBuffStation, behaviorIdForBuffStation, self->GetObjectID());
 }

--- a/dScripts/AgSurvivalBuffStation.cpp
+++ b/dScripts/AgSurvivalBuffStation.cpp
@@ -7,5 +7,13 @@ void AgSurvivalBuffStation::OnRebuildComplete(Entity* self, Entity* target) {
 
     if (skillComponent == nullptr) return;
 
-    skillComponent->CalculateBehavior(skillIdForBuffStation, behaviorIdForBuffStation, self->GetObjectID());
+    skillComponent->CalculateBehavior(201, 1784, self->GetObjectID());
+    
+    self->AddTimer("DestroyAfter10Seconds", 10.0f);
+}
+
+void AgSurvivalBuffStation::OnTimerDone(Entity* self, std::string timerName) {
+    if (timerName == "DestroyAfter10Seconds") {
+        self->Smash();
+    }
 }

--- a/dScripts/AgSurvivalBuffStation.cpp
+++ b/dScripts/AgSurvivalBuffStation.cpp
@@ -1,0 +1,15 @@
+#include "AgSurvivalBuffStation.h"
+#include "SkillComponent.h"
+#include "dLogger.h"
+
+void AgSurvivalBuffStation::OnStartup(Entity* self) {
+    Game::logger->Log("AgSurvivalBuffStation", "Spawning survival buff station!\n");
+}
+
+void AgSurvivalBuffStation::OnRebuildComplete(Entity* self, Entity* target) {
+    auto skillComponent = self->GetComponent<SkillComponent>();
+
+    if (skillComponent == nullptr) return;
+
+    skillComponent->CalculateBehavior(201, 1784, self->GetObjectID());
+}

--- a/dScripts/AgSurvivalBuffStation.cpp
+++ b/dScripts/AgSurvivalBuffStation.cpp
@@ -8,12 +8,8 @@ void AgSurvivalBuffStation::OnRebuildComplete(Entity* self, Entity* target) {
     if (skillComponent == nullptr) return;
 
     skillComponent->CalculateBehavior(201, 1784, self->GetObjectID());
-    
-    self->AddTimer("DestroyAfter10Seconds", 10.0f);
-}
 
-void AgSurvivalBuffStation::OnTimerDone(Entity* self, std::string timerName) {
-    if (timerName == "DestroyAfter10Seconds") {
+    self->AddCallbackTimer(10.0f, [self]() {
         self->Smash();
-    }
+    });
 }

--- a/dScripts/AgSurvivalBuffStation.h
+++ b/dScripts/AgSurvivalBuffStation.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "CppScripts.h"
+
+class AgSurvivalBuffStation : public CppScripts::Script
+{
+public:
+    void OnStartup(Entity* self) override;
+    void OnRebuildComplete(Entity* self, Entity* target) override;
+};

--- a/dScripts/AgSurvivalBuffStation.h
+++ b/dScripts/AgSurvivalBuffStation.h
@@ -11,6 +11,12 @@ public:
      * @param target The target of the self that called this script.
      */
     void OnRebuildComplete(Entity* self, Entity* target) override;
+    /**
+     * @brief When 10 seconds have passed, smash self.
+     * 
+     * @param self The Entity whos timer has done.
+     * @param timerName The name of the done timer
+     */
     void OnTimerDone(Entity* self, std::string timerName) override;
 private:
     /**

--- a/dScripts/AgSurvivalBuffStation.h
+++ b/dScripts/AgSurvivalBuffStation.h
@@ -4,6 +4,20 @@
 class AgSurvivalBuffStation : public CppScripts::Script
 {
 public:
-    void OnStartup(Entity* self) override;
+    /**
+     * @brief When the rebuild of self is complete, we calculate the behavior that is assigned to self in the database.  
+     * 
+     * @param self The Entity that called this script.
+     * @param target The target of the self that called this script.
+     */
     void OnRebuildComplete(Entity* self, Entity* target) override;
+private:
+    /**
+     * Skill ID for the buff station.
+     */
+    uint32_t skillIdForBuffStation = 201;
+    /**
+     * Behavior ID for the buff station.
+     */
+    uint32_t behaviorIdForBuffStation = 1784;
 };

--- a/dScripts/AgSurvivalBuffStation.h
+++ b/dScripts/AgSurvivalBuffStation.h
@@ -11,13 +11,6 @@ public:
      * @param target The target of the self that called this script.
      */
     void OnRebuildComplete(Entity* self, Entity* target) override;
-    /**
-     * @brief When 10 seconds have passed, smash self.
-     * 
-     * @param self The Entity whos timer has done.
-     * @param timerName The name of the done timer
-     */
-    void OnTimerDone(Entity* self, std::string timerName) override;
 private:
     /**
      * Skill ID for the buff station.

--- a/dScripts/AgSurvivalBuffStation.h
+++ b/dScripts/AgSurvivalBuffStation.h
@@ -11,6 +11,7 @@ public:
      * @param target The target of the self that called this script.
      */
     void OnRebuildComplete(Entity* self, Entity* target) override;
+    void OnTimerDone(Entity* self, std::string timerName) override;
 private:
     /**
      * Skill ID for the buff station.

--- a/dScripts/BaseSurvivalServer.cpp
+++ b/dScripts/BaseSurvivalServer.cpp
@@ -302,6 +302,7 @@ void BaseSurvivalServer::StartWaves(Entity *self) {
     self->SetVar<bool>(FirstTimeDoneVariable, true);
     self->SetVar<std::string>(MissionTypeVariable, state.players.size() == 1 ? "survival_time_solo" : "survival_time_team");
 
+    ActivateSpawnerNetwork(spawnerNetworks.rewardNetworks);
     ActivateSpawnerNetwork(spawnerNetworks.smashNetworks);
     self->SetNetworkVar<bool>(WavesStartedVariable, true);
     self->SetNetworkVar<std::string>(StartWaveMessageVariable, "Start!");

--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -62,6 +62,7 @@
 #include "VeMech.h"
 #include "VeMissionConsole.h"
 #include "VeEpsilonServer.h"
+#include "AgSurvivalBuffStation.h"
 
 // NS Scripts
 #include "NsModularBuild.h"
@@ -319,6 +320,8 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 		script = new BaseEnemyMech();
 	else if (scriptName == "scripts\\zone\\AG\\L_ZONE_AG_SURVIVAL.lua")
 		script = new ZoneAgSurvival();
+	else if (scriptName == "scripts\\02_server\\Objects\\L_BUFF_STATION_SERVER.lua")
+		script = new AgSurvivalBuffStation();
 	else if (scriptName == "scripts\\ai\\AG\\L_AG_BUS_DOOR.lua")
 		script = new AgBusDoor();
 	else if (scriptName == "scripts\\02_server\\Equipment\\L_MAESTROM_EXTRACTICATOR_SERVER.lua")


### PR DESCRIPTION
Fixes #341 
This PR fixes 2 issues:
First was the issue of the buff station just not spawning.  This was due to a missing spawner network activation in the base survival server when starting the waves.
The second issue was the buff station just not doing anything.  This was due to a missing script.  This script was added and its behavior based on that located at [explorer.lu](https://explorer.lu/objects/6412/9).  The behavior involves every 2.5 seconds, [to heal, buff and imagine all players in its radius by 1.  ](https://explorer.lu/skills/behaviors/1784)
Tested on Ubuntu and had zero issues getting achievement progress and buff station is functioning as expected.