### PR TITLE
Remove <filesystem> dependency

### DIFF
--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -5,7 +5,7 @@
 #include <map>
 #include <string>
 #include <thread>
-#include <filesystem>
+#include <fstream>
 
 #ifdef _WIN32
 #include <bcrypt/BCrypt.hpp>
@@ -80,10 +80,12 @@ int main(int argc, char** argv) {
 
 	//Check CDClient exists
 	const std::string cdclient_path = "./res/CDServer.sqlite";
-	if (!std::filesystem::is_regular_file(cdclient_path)) {
-		Game::logger->Log("WorldServer", "%s does not exist\n", cdclient_path.c_str());
+	std::ifstream cdclient_fd(cdclient_path);
+	if (!cdclient_fd.good()) {
+		Game::logger->Log("WorldServer", "%s could not be opened\n", cdclient_path.c_str());
 		return -1;
 	}
+	cdclient_fd.close();
 
 	//Connect to CDClient
 	try {


### PR DESCRIPTION
Unfortunately, Google Cloud Compute Engine does not support the `<filesystem>` library.

Even if the special flag `-lstdc++fs` is passed, the build still fails to link the appropriate functions.

```
cloudshell:~$ g++ -g -lstdc++fs -std=gnu++17 test.cpp
/usr/bin/ld: /tmp/ccYF9KdM.o: in function `std::filesystem::is_regular_file(std::filesystem::__cxx11::path const&)':/usr/include/c++/8/bits/fs_ops.h:213: undefined reference to `std::filesystem::status(std::filesystem::__cxx11::path const&)'/usr/bin/ld: /tmp/ccYF9KdM.o: in function `std::filesystem::__cxx11::path::path<char [9], std::filesystem::__cxx11::path>(char const (&) [9], std::filesystem::__cxx11::path::format)':/usr/include/c++/8/bits/fs_path.h:184: undefined reference to `std::filesystem::__cxx11::path::_M_split_cmpts()'collect2: error: ld returned 1 exit status
```

Google Cloud uses GCC 8 (`gcc (Debian 8.3.0-6) 8.3.0`), but proper filesystem support was not added until GCC 9.

As a workaround, this PR removes the use of the filesystem library from DLU.