### PR TITLE
Added missing script for Gate Crasher mission

### DIFF
--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -145,6 +145,7 @@
 #include "ImgBrickConsoleQB.h"
 #include "ActParadoxPipeFix.h"
 #include "FvNinjaGuard.h"
+#include "FvBounceOverWall.h"
 
 // FB Scripts
 #include "AgJetEffectServer.h"
@@ -556,6 +557,8 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 		script = new ActParadoxPipeFix();
 	else if (scriptName == "scripts\\ai\\FV\\L_FV_NINJA_GUARDS.lua")
 		script = new FvNinjaGuard();
+	else if (scriptName == "scripts\\ai\\FV\\L_ACT_BOUNCE_OVER_WALL.lua")
+		script = new FvBounceOverWall();
 
 	//Misc:
 	if (scriptName == "scripts\\02_server\\Map\\General\\L_EXPLODING_ASSET.lua")

--- a/dScripts/FvBounceOverWall.cpp
+++ b/dScripts/FvBounceOverWall.cpp
@@ -1,0 +1,9 @@
+#include "FvBounceOverWall.h"
+
+void FvBounceOverWall::OnCollisionPhantom(Entity* self, Entity* target) {
+    auto missionComponent = target->GetComponent<MissionComponent>();
+    if (missionComponent == nullptr) return;
+
+    // We force progress here to the Gate Crasher mission due to an overlap in LOTs with the 'Shark Bite' missions.
+    missionComponent->ForceProgress(GateCrasherMissionId, GateCrasherMissionUid, 1);
+}

--- a/dScripts/FvBounceOverWall.h
+++ b/dScripts/FvBounceOverWall.h
@@ -1,3 +1,4 @@
+#pragma once
 #include "CppScripts.h"
 
 class FvBounceOverWall : public CppScripts::Script

--- a/dScripts/FvBounceOverWall.h
+++ b/dScripts/FvBounceOverWall.h
@@ -1,0 +1,21 @@
+#include "CppScripts.h"
+
+class FvBounceOverWall : public CppScripts::Script
+{
+    /**
+     * @brief When a collision has been made with self this method is called.
+     * 
+     * @param self The Entity that called this function.
+     * @param target The target Entity of self.
+     */
+    void OnCollisionPhantom(Entity* self, Entity* target) override;
+private:
+    /**
+     * MissionId for the Gate Crasher mission.
+     */
+    int32_t GateCrasherMissionId = 849;
+    /**
+     * MissionUid for the Gate Crasher mission.
+     */
+    int32_t GateCrasherMissionUid = 1241;
+};


### PR DESCRIPTION
Added the missing script for the Gate Crasher mission.  Tested on local ubuntu instance and task was successfully completed without completing other missions.  As of now this must use a forceProgress due to an overlap with the Shark Bite tasks.
Fixes #186 