### PR TITLE
Removed AI Stopping after they use a skill

### DIFF
--- a/dGame/dComponents/BaseCombatAIComponent.cpp
+++ b/dGame/dComponents/BaseCombatAIComponent.cpp
@@ -358,7 +358,7 @@ void BaseCombatAIComponent::CalculateCombat(const float deltaTime) {
 		return;
 	}
 
-
+	m_Downtime = 0.5f;
 	
 	auto* target = GetTargetEntity();
 

--- a/dGame/dComponents/BaseCombatAIComponent.cpp
+++ b/dGame/dComponents/BaseCombatAIComponent.cpp
@@ -192,7 +192,7 @@ void BaseCombatAIComponent::Update(const float deltaTime) {
 		return;
 	}
 
-	if (m_Stunned || m_SkillTime > 0) {
+	if (m_Stunned) {
 		m_MovementAI->Stop();
 
 		return;
@@ -358,7 +358,7 @@ void BaseCombatAIComponent::CalculateCombat(const float deltaTime) {
 		return;
 	}
 
-	m_Downtime = 0.5f; // TODO: find out if this is necessary
+
 	
 	auto* target = GetTargetEntity();
 


### PR DESCRIPTION
This PR makes AI far more live accurate than they were before by removing them standing completely still after using any skill.  Now AI will move around during skill cooldowns, making them accurate to how they worked in live.

Tested on Oogway for a few days and responses have been that AI are indeed more live accurate.