### PR TITLE
Frakjaw Battle instance fixes

### DIFF
--- a/dScripts/NjMonastryBossInstance.cpp
+++ b/dScripts/NjMonastryBossInstance.cpp
@@ -47,9 +47,8 @@ void NjMonastryBossInstance::OnStartup(Entity *self) {
 void NjMonastryBossInstance::OnPlayerLoaded(Entity *self, Entity *player) {
     ActivityTimerStop(self, WaitingForPlayersTimer);
 
-    // Join the player in the activity and charge for joining
+    // Join the player in the activity
     UpdatePlayer(self, player->GetObjectID());
-    TakeActivityCost(self, player->GetObjectID());
 
     // Buff the player
     auto* destroyableComponent = player->GetComponent<DestroyableComponent>();
@@ -59,11 +58,9 @@ void NjMonastryBossInstance::OnPlayerLoaded(Entity *self, Entity *player) {
         destroyableComponent->SetImagination((int32_t) destroyableComponent->GetMaxImagination());
     }
 
-    // Track the player ID
+    // Add player ID to instance
     auto totalPlayersLoaded = self->GetVar<std::vector<LWOOBJID>>(TotalPlayersLoadedVariable);
-    if (totalPlayersLoaded.empty() || std::find(totalPlayersLoaded.begin(), totalPlayersLoaded.end(), player->GetObjectID()) != totalPlayersLoaded.end()) {
-        totalPlayersLoaded.push_back(player->GetObjectID());
-    }
+    totalPlayersLoaded.push_back(player->GetObjectID());
 
     // Properly position the player
     self->SetVar<std::vector<LWOOBJID>>(TotalPlayersLoadedVariable, totalPlayersLoaded);
@@ -75,7 +72,7 @@ void NjMonastryBossInstance::OnPlayerLoaded(Entity *self, Entity *player) {
 
     // Start the game if all players in the team have loaded
     auto* team = TeamManager::Instance()->GetTeam(player->GetObjectID());
-    if (team == nullptr || totalPlayersLoaded.size() >= team->members.size()) {
+    if (team == nullptr || totalPlayersLoaded.size() == team->members.size()) {
         StartFight(self);
         return;
     }

--- a/dScripts/NjMonastryBossInstance.cpp
+++ b/dScripts/NjMonastryBossInstance.cpp
@@ -68,7 +68,7 @@ void NjMonastryBossInstance::OnPlayerLoaded(Entity *self, Entity *player) {
     TeleportPlayer(player, 1);
 
     // Large teams face a tougher challenge
-    if (totalPlayersLoaded.size() > 2)
+    if (totalPlayersLoaded.size() >= 3)
         self->SetVar<bool>(LargeTeamVariable, true);
 
     // Start the game if all players in the team have loaded
@@ -91,6 +91,7 @@ void NjMonastryBossInstance::OnPlayerLoaded(Entity *self, Entity *player) {
 
 void NjMonastryBossInstance::OnPlayerExit(Entity *self, Entity *player) {
     UpdatePlayer(self, player->GetObjectID(), true);
+    //TODO: Add functionality to dynamically turn off the large team variable when enough players leave.
     GameMessages::SendNotifyClientObject(self->GetObjectID(), u"PlayerLeft", 0, 0,
                                          player->GetObjectID(), "", UNASSIGNED_SYSTEM_ADDRESS);
 }

--- a/dScripts/NjMonastryBossInstance.cpp
+++ b/dScripts/NjMonastryBossInstance.cpp
@@ -64,7 +64,8 @@ void NjMonastryBossInstance::OnPlayerLoaded(Entity *self, Entity *player) {
 
     // Properly position the player
     self->SetVar<std::vector<LWOOBJID>>(TotalPlayersLoadedVariable, totalPlayersLoaded);
-    TeleportPlayer(player, totalPlayersLoaded.size());
+    // This was always spawning all players at position one before and other values cause players to be invisible.
+    TeleportPlayer(player, 1);
 
     // Large teams face a tougher challenge
     if (totalPlayersLoaded.size() > 2)


### PR DESCRIPTION
Fixes #362 
- Address the issue where the minigame would consume 2 Green Imaginate per play.  Now only 1 is correctly consumed.
- Addresses an issue where the minigame was not initializing properly for instances of more than 1 player.  What was happening was the variable `totalPlayersLoaded` was not adding players correctly to its list and for some reason either overwriting the previous list of players each time or was giving each player their own `totalPlayersLoaded` list.  This caused all players lists to have to wait for the ActivityTimerStart and also defaulted the instance to always being single player, even if there were 2 or more players.

Now the instance variable `totalPlayersLoaded` correctly has the number of players that would be loaded in the instance and starts the activity when the size of `totalPlayersLoaded` matches `team->members.size()` exactly. 
Tested on local Ubuntu instance with 1 player, 2 players and 3 players.  Instance correctly loaded and initialized for all counts of players.  