### PR TITLE
Make some Docker Compose volumes read-only

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,8 @@ services:
         - BUILD_THREADS=${BUILD_THREADS:-1}
         - BUILD_VERSION=${BUILD_VERSION:-171022}
     volumes:
-      - ${CLIENT_PATH:?missing_client_path}:/client
-      - shared_configs:/shared_configs
+      - ${CLIENT_PATH:?missing_client_path}:/client:ro
+      - shared_configs:/shared_configs:ro
     depends_on:
       - database
     ports:


### PR DESCRIPTION
Makes config and client resource volumes used by the server read-only to prevent accidental modification, see [Docker documentation](https://docs.docker.com/compose/compose-file/compose-file-v3/#short-syntax-3).

If I understand it correctly there should by no reason why the server has to modify the configs or client resources. Though please correct me if I am wrong.