### PR TITLE
Fix MasterServer not always closing database connection on exit

### DIFF
--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
 
 	//Create all the objects we need to run our service:
 	Game::logger = SetupLogger();
-	if (!Game::logger) return 0;
+	if (!Game::logger) return -1;
 
 	Game::logger->Log("MasterServer", "Starting Master server...\n");
 	Game::logger->Log("MasterServer", "Version: %i.%i\n", PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR);
@@ -118,7 +118,7 @@ int main(int argc, char** argv) {
 		Database::Connect(mysql_host, mysql_database, mysql_username, mysql_password);
 	} catch (sql::SQLException& ex) {
 		Game::logger->Log("MasterServer", "Got an error while connecting to the database: %s\n", ex.what());
-		return 0;
+		return -1;
 	}
 
 	//If the first command line argument is -a or --account then make the user
@@ -166,6 +166,10 @@ int main(int argc, char** argv) {
 		delete statement;
 
 		std::cout << "Account created successfully!\n";
+
+		Database::Destroy();
+		delete Game::logger;
+
 		return 0;
 	}
 
@@ -266,7 +270,8 @@ int main(int argc, char** argv) {
 		//10m shutdown for universe kill command
 		if (shouldShutdown) {
 			if (framesSinceKillUniverseCommand >= 40000) {
-				std::exit(0);
+				//Break main loop and exit
+				break;
 			}
 			else
 				framesSinceKillUniverseCommand++;

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -66,7 +66,7 @@ int main(int argc, char** argv) {
 
 	//Create all the objects we need to run our service:
 	Game::logger = SetupLogger();
-	if (!Game::logger) return -1;
+	if (!Game::logger) return EXIT_FAILURE;
 
 	Game::logger->Log("MasterServer", "Starting Master server...\n");
 	Game::logger->Log("MasterServer", "Version: %i.%i\n", PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR);
@@ -83,7 +83,7 @@ int main(int argc, char** argv) {
 	std::ifstream cdclient_fd(cdclient_path);
 	if (!cdclient_fd.good()) {
 		Game::logger->Log("WorldServer", "%s could not be opened\n", cdclient_path.c_str());
-		return -1;
+		return EXIT_FAILURE;
 	}
 	cdclient_fd.close();
 
@@ -94,7 +94,7 @@ int main(int argc, char** argv) {
 		Game::logger->Log("WorldServer", "Unable to connect to CDServer SQLite Database\n");
 		Game::logger->Log("WorldServer", "Error: %s\n", e.errorMessage());
 		Game::logger->Log("WorldServer", "Error Code: %i\n", e.errorCode());
-		return -1;
+		return EXIT_FAILURE;
 	}
 
 	//Get CDClient initial information
@@ -105,7 +105,7 @@ int main(int argc, char** argv) {
 		Game::logger->Log("WorldServer", "May be caused by corrupted file: %s\n", cdclient_path.c_str());
 		Game::logger->Log("WorldServer", "Error: %s\n", e.errorMessage());
 		Game::logger->Log("WorldServer", "Error Code: %i\n", e.errorCode());
-		return -1;
+		return EXIT_FAILURE;
 	}
 
 	//Connect to the MySQL Database
@@ -118,7 +118,7 @@ int main(int argc, char** argv) {
 		Database::Connect(mysql_host, mysql_database, mysql_username, mysql_password);
 	} catch (sql::SQLException& ex) {
 		Game::logger->Log("MasterServer", "Got an error while connecting to the database: %s\n", ex.what());
-		return -1;
+		return EXIT_FAILURE;
 	}
 
 	//If the first command line argument is -a or --account then make the user
@@ -170,7 +170,7 @@ int main(int argc, char** argv) {
 		Database::Destroy();
 		delete Game::logger;
 
-		return 0;
+		return EXIT_SUCCESS;
 	}
 
 	int maxClients = 999;
@@ -324,7 +324,7 @@ int main(int argc, char** argv) {
 	delete Game::server;
 	delete Game::logger;
 
-	return 0;
+	return EXIT_SUCCESS;
 }
 
 dLogger* SetupLogger() {


### PR DESCRIPTION
Previously when starting `MasterServer` with `--account` the database connection was apparently not closed which caused the database to log the following warning:
> DarkflameDatabase        | 2022-01-24 22:14:38 3 [Warning] Aborted connection 3 to db: 'darkflame' user: 'darkflame' host: '172.18.0.5' (Got an error reading communication packets)

The disadvantage with this is that now closing the database connection is logged to console and file, which might be a bit irritating. Should it maybe also log that `--account` was used and log the created account name?

Additionally when handling the shutdown command it previously called `std::exit` instead of breaking the main loop and exiting this way (have not tested this behavior change).

Note that I am not very familiar with C++, so any feedback is appreciated!