### PR TITLE
Improve GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -18,6 +18,14 @@ body:
         - label: >
             I have pulled the latest version of the main branch of DarkflameServer and have confirmed that the issue exists there.
           required: true
+  - type: input
+    id: server-version
+    attributes:
+      label: DarkflameServer Version
+      description: >
+        DarkflameServer version or commit SHA
+    validations:
+      required: true
   - type: textarea
     id: problem
     attributes:
@@ -29,7 +37,7 @@ body:
   - type: textarea
     id: reproduction
     attributes:
-      label: Reproduction steps
+      label: Reproduction Steps
       description: >
         Please provide a concise list of steps needed to reproduce this issue.
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -23,7 +23,7 @@ body:
     attributes:
       label: DarkflameServer Version
       description: >
-        DarkflameServer version or commit SHA
+        DarkflameServer version or commit SHA (can be obtained with `git rev-parse --short HEAD`)
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/installation_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/installation_issue.yaml
@@ -17,7 +17,7 @@ body:
     attributes:
       label: DarkflameServer Version
       description: >
-        DarkflameServer version or commit SHA
+        DarkflameServer version or commit SHA (can be obtained with `git rev-parse --short HEAD`)
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/installation_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/installation_issue.yaml
@@ -12,6 +12,14 @@ body:
         - label: >
             I have read the [installation guide](https://github.com/DarkflameUniverse/DarkflameServer/blob/main/README.md).
           required: true
+  - type: input
+    id: server-version
+    attributes:
+      label: DarkflameServer Version
+      description: >
+        DarkflameServer version or commit SHA
+    validations:
+      required: true
   - type: dropdown
     id: platform
     attributes:

--- a/.github/ISSUE_TEMPLATE/performance_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/performance_issue.yaml
@@ -15,6 +15,22 @@ body:
         - label: >
             I have pulled the latest version of the main branch of DarkflameServer and have confirmed that the issue exists there.
           required: true
+  - type: input
+    id: server-version
+    attributes:
+      label: DarkflameServer Version
+      description: >
+        DarkflameServer version or commit SHA
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: >
+        Please include the environment you're running DarkflameServer on (for example: Windows, macOS, Ubuntu, WSL, etc), available memory, number of CPU cores.
+    validations:
+      required: true
   - type: textarea
     id: example
     attributes:

--- a/.github/ISSUE_TEMPLATE/performance_issue.yaml
+++ b/.github/ISSUE_TEMPLATE/performance_issue.yaml
@@ -20,7 +20,7 @@ body:
     attributes:
       label: DarkflameServer Version
       description: >
-        DarkflameServer version or commit SHA
+        DarkflameServer version or commit SHA (can be obtained with `git rev-parse --short HEAD`)
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Tries to improve the GitHub issue templates by:
- Requesting the DarkflameServer version
This makes it later easier to find out which version was affected, and whether the bug might have already been fixed.
- Requesting environment information for performance issues reports
Information about the environment might be quite useful when analyzing performance issues.

Feel free to close this pull request in case you do not think that these changes are useful.