### PR TITLE
Addressed specific race smash missions not progressing

### DIFF
--- a/dGame/dMission/MissionTask.cpp
+++ b/dGame/dMission/MissionTask.cpp
@@ -420,6 +420,7 @@ void MissionTask::Progress(int32_t value, LWOOBJID associate, const std::string&
 		
 	case MissionTaskType::MISSION_TASK_TYPE_RACING:
 	{
+		// The meaning of associate can be found in RacingTaskParam.h
 		if (parameters.empty()) break;
 
 		if (!InAllTargets(dZoneManager::Instance()->GetZone()->GetWorldID()) && !(parameters[0] == 4 || parameters[0] == 5) && !InAllTargets(value)) break;
@@ -440,6 +441,11 @@ void MissionTask::Progress(int32_t value, LWOOBJID associate, const std::string&
 			AddProgress(count);
 		}
 		else if (associate == 4 || associate == 5 || associate == 14)
+		{
+			if (!InAllTargets(value)) break;
+			AddProgress(count);
+		}
+		else if (associate == 17)
 		{
 			if (!InAllTargets(value)) break;
 			AddProgress(count);

--- a/dGame/dMission/RacingTaskParam.h
+++ b/dGame/dMission/RacingTaskParam.h
@@ -16,5 +16,5 @@ enum class RacingTaskParam : int32_t {
     RACING_TASK_PARAM_WIN_RACE_IN_WORLD = 14,               //<! A task param for winning a race in a specific world.
     RACING_TASK_PARAM_FIRST_PLACE_MULTIPLE_TRACKS = 15,     //<! A task param for finishing in first place on multiple tracks.
     RACING_TASK_PARAM_LAST_PLACE_FINISH = 16,               //<! A task param for finishing in last place.
-    RACING_TASK_PARAM_SMASH_DRAGON_EGGS = 17                //<! A task param for smashing dragon eggs during a race.
+    RACING_TASK_PARAM_SMASH_SPECIFIC_SMASHABLE = 17         //<! A task param for smashing dragon eggs during a race.
 };

--- a/dScripts/FvRaceSmashEggImagineServer.cpp
+++ b/dScripts/FvRaceSmashEggImagineServer.cpp
@@ -27,7 +27,9 @@ void FvRaceSmashEggImagineServer::OnDie(Entity *self, Entity *killer) {
                     characterComponent->UpdatePlayerStatistic(RacingSmashablesSmashed);
                 }
                 if (missionComponent == nullptr) return;
-                missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_RACING, self->GetLOT(), (LWOOBJID)RacingTaskParam::RACING_TASK_PARAM_SMASH_DRAGON_EGGS);
+                // Dragon eggs have their own smash server so we handle mission progression for them here.
+                missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_RACING, 0, (LWOOBJID)RacingTaskParam::RACING_TASK_PARAM_SMASHABLES);
+                missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_RACING, self->GetLOT(), (LWOOBJID)RacingTaskParam::RACING_TASK_PARAM_SMASH_SPECIFIC_SMASHABLE);
             }
         }
 

--- a/dScripts/RaceSmashServer.cpp
+++ b/dScripts/RaceSmashServer.cpp
@@ -22,6 +22,8 @@ void RaceSmashServer::OnDie(Entity *self, Entity *killer) {
             // Progress racing smashable missions
             if(missionComponent == nullptr) return;
             missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_RACING, 0, (LWOOBJID)RacingTaskParam::RACING_TASK_PARAM_SMASHABLES);
+            // Progress missions that ask us to smash a specific smashable.
+            missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_RACING, self->GetLOT(), (LWOOBJID)RacingTaskParam::RACING_TASK_PARAM_SMASH_SPECIFIC_SMASHABLE);
         }
     }
 }


### PR DESCRIPTION
Missions like [1407](https://explorer.lu-dev.net/missions/1407) and [1406](https://explorer.lu-dev.net/missions/1406) use taskparam1 set to 17 to denote the mission as being smashing a specific smashable in a race.  Also addressed an issue where dragon egg smashables did not count towards generic smashing missions.  This is because the dragon eggs use a different smash server than generic race smashables.

Tested changes in Forbidden Valley and Nimbus Station race and the above missions progress without error.  