### PR TITLE
Addressed some proxy items granting duplicate skills

### DIFF
--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -1010,7 +1010,7 @@ void InventoryComponent::EquipItem(Item* item, const bool skipChecks)
 	
 	UpdateSlot(item->GetInfo().equipLocation, { item->GetId(), item->GetLot(), item->GetCount(), item->GetSlot() });
 
-	ApplyBuff(item->GetLot());
+	if (item->GetParent() == LWOOBJID_EMPTY) ApplyBuff(item->GetLot());
 	
 	AddItemSkills(item->GetLot());
 
@@ -1038,7 +1038,7 @@ void InventoryComponent::UnEquipItem(Item* item)
 		set->OnUnEquip(lot);
 	}
 
-	RemoveBuff(item->GetLot());
+	if (item->GetParent() == LWOOBJID_EMPTY) RemoveBuff(item->GetLot());
 	
 	RemoveItemSkills(item->GetLot());
 
@@ -1498,7 +1498,7 @@ std::vector<Item*> InventoryComponent::GenerateProxies(Item* parent)
 
 		auto* inventory = GetInventory(ITEM_SETS);
 
-		auto* proxy = new Item(lot, inventory, inventory->FindEmptySlot(), 1, {}, parent->GetId(), false);
+		auto* proxy = new Item(lot, inventory, inventory->FindEmptySlot(), 1, {}, parent->GetId(), false, parent->GetId());
 
 		EquipItem(proxy);
 

--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -399,8 +399,8 @@ private:
 	std::vector<Item*> FindProxies(LWOOBJID parent);
 
     /**
-     * Returns if the provided ID is a valid proxy item (e.g. we have children for it)
-     * @param parent the parent item to check for
+     * Returns true if the provided LWOOBJID is the parent of this Item.
+     * @param parent the parent item to check for proxies
      * @return if the provided ID is a valid proxy item
      */
 	bool IsValidProxy(LWOOBJID parent);


### PR DESCRIPTION
Fixes #167
Fixes an issue where proxy items would apply their buffs even when those buffs were already being applied by the parent item.  Now proxy items correctly do NOT apply their buffs, but will apply their skills to the player.

Tested on the following items and was getting the correct stats
Imagination Backpack, all Trial Faction gear from Avant Gardens, all 3 Maelstrom-Infused Hoods