### PR TITLE
Fully implemented Avant Gardens Survival Buff Station

### DIFF
--- a/dScripts/AgSurvivalBuffStation.cpp
+++ b/dScripts/AgSurvivalBuffStation.cpp
@@ -4,6 +4,7 @@
 #include "GameMessages.h"
 #include "SkillComponent.h"
 #include "dLogger.h"
+#include "TeamManager.h"
 
 void AgSurvivalBuffStation::OnRebuildComplete(Entity* self, Entity* target) {
     auto destroyableComponent = self->GetComponent<DestroyableComponent>();
@@ -20,12 +21,24 @@ void AgSurvivalBuffStation::OnRebuildComplete(Entity* self, Entity* target) {
     self->AddTimer("DropArmor", dropArmorTimer);
     self->AddTimer("DropLife", dropLifeTimer);
     self->AddTimer("Dropimagination", dropImaginationTimer);
-    self->SetVar<LWOOBJID>(u"PlayerId", target->GetObjectID());
+    // Since all survival players should be on the same team, we get the team.
+    auto team = TeamManager::Instance()->GetTeam(target->GetObjectID());
+
+    std::vector<LWOOBJID> builderTeam;
+    // Not on a team
+    if (team == nullptr) {
+        builderTeam.push_back(target->GetObjectID());
+        self->SetVar<std::vector<LWOOBJID>>(u"BuilderTeam", builderTeam);
+        return;
+    } 
+
+    for (auto memberID : team->members) {
+        builderTeam.push_back(memberID);
+    }
+    self->SetVar<std::vector<LWOOBJID>>(u"BuilderTeam", builderTeam);
 }
 
 void AgSurvivalBuffStation::OnTimerDone(Entity* self, std::string timerName) {
-    auto targetID = self->GetVar<LWOOBJID>(u"PlayerId");
-    auto target = EntityManager::Instance()->GetEntity(targetID);
     uint32_t powerupToDrop = lifePowerup;
     if (timerName == "DropArmor") {
         powerupToDrop = armorPowerup;
@@ -39,5 +52,15 @@ void AgSurvivalBuffStation::OnTimerDone(Entity* self, std::string timerName) {
         powerupToDrop = imaginationPowerup;
         self->AddTimer("Dropimagination", dropImaginationTimer);
     }
-    if (target != nullptr) GameMessages::SendDropClientLoot(target, self->GetObjectID(), powerupToDrop, 0, self->GetPosition());
+    auto team = self->GetVar<std::vector<LWOOBJID>>(u"BuilderTeam");
+    for (auto memberID : team) {
+        auto member = EntityManager::Instance()->GetEntity(memberID);
+        if (member != nullptr && !member->GetIsDead()) {
+            GameMessages::SendDropClientLoot(member, self->GetObjectID(), powerupToDrop, 0, self->GetPosition());
+        } else {
+            // If player left the team or left early erase them from the team variable.
+            team.erase(std::find(team.begin(), team.end(), memberID));
+            self->SetVar<std::vector<LWOOBJID>>(u"BuilderTeam", team);
+        }
+    }
 }

--- a/dScripts/AgSurvivalBuffStation.cpp
+++ b/dScripts/AgSurvivalBuffStation.cpp
@@ -1,20 +1,46 @@
 #include "AgSurvivalBuffStation.h"
+#include "DestroyableComponent.h"
+#include "EntityManager.h"
+#include "GameMessages.h"
 #include "SkillComponent.h"
 #include "dLogger.h"
-#include "DestroyableComponent.h"
 
 void AgSurvivalBuffStation::OnRebuildComplete(Entity* self, Entity* target) {
     auto destroyableComponent = self->GetComponent<DestroyableComponent>();
-    // We set the faction to 6 so that the buff station sees players as friendly targets
+    // We set the faction to 6 so that the buff station sees players as friendly targets to buff
     if (destroyableComponent != nullptr) destroyableComponent->SetFaction(6);
 
     auto skillComponent = self->GetComponent<SkillComponent>();
 
-    if (skillComponent == nullptr) return;
+    if (skillComponent != nullptr) skillComponent->CalculateBehavior(skillIdForBuffStation, behaviorIdForBuffStation, self->GetObjectID());
 
-    skillComponent->CalculateBehavior(skillIdForBuffStation, behaviorIdForBuffStation, self->GetObjectID());
-
-    self->AddCallbackTimer(10.0f, [self]() {
+    self->AddCallbackTimer(smashTimer, [self]() {
         self->Smash();
     });
+    self->AddTimer("DropArmor", dropArmorTimer);
+    self->AddTimer("DropLife", dropLifeTimer);
+    self->AddTimer("Dropimagination", dropImaginationTimer);
+    self->SetVar<LWOOBJID>(u"PlayerId", target->GetObjectID());
+}
+
+void AgSurvivalBuffStation::OnTimerDone(Entity* self, std::string timerName) {
+    auto targetID = self->GetVar<LWOOBJID>(u"PlayerId");
+    auto target = EntityManager::Instance()->GetEntity(targetID);
+    uint32_t powerupToDrop = lifePowerup;
+    if (timerName == "DropArmor") {
+        powerupToDrop = armorPowerup;
+        self->AddTimer("DropArmor", dropArmorTimer);
+    }
+    if (timerName == "DropLife") {
+        powerupToDrop = lifePowerup;
+        self->AddTimer("DropLife", dropLifeTimer);
+    }
+    if (timerName == "Dropimagination") {
+        powerupToDrop = imaginationPowerup;
+        self->AddTimer("Dropimagination", dropImaginationTimer);
+    }
+    if (target != nullptr) GameMessages::SendDropClientLoot(target, self->GetObjectID(), powerupToDrop, 0, self->GetPosition());
+}
+void AgSurvivalBuffStation::OnDie(Entity* self, Entity* killer) {
+    //self->CancelAllTimers();
 }

--- a/dScripts/AgSurvivalBuffStation.cpp
+++ b/dScripts/AgSurvivalBuffStation.cpp
@@ -5,14 +5,14 @@
 
 void AgSurvivalBuffStation::OnRebuildComplete(Entity* self, Entity* target) {
     auto destroyableComponent = self->GetComponent<DestroyableComponent>();
-    
+    // We set the faction to 6 so that the buff station sees players as friendly targets
     if (destroyableComponent != nullptr) destroyableComponent->SetFaction(6);
 
     auto skillComponent = self->GetComponent<SkillComponent>();
 
     if (skillComponent == nullptr) return;
 
-    skillComponent->CalculateBehavior(201, 1784, self->GetObjectID());
+    skillComponent->CalculateBehavior(skillIdForBuffStation, behaviorIdForBuffStation, self->GetObjectID());
 
     self->AddCallbackTimer(10.0f, [self]() {
         self->Smash();

--- a/dScripts/AgSurvivalBuffStation.cpp
+++ b/dScripts/AgSurvivalBuffStation.cpp
@@ -1,8 +1,13 @@
 #include "AgSurvivalBuffStation.h"
 #include "SkillComponent.h"
 #include "dLogger.h"
+#include "DestroyableComponent.h"
 
 void AgSurvivalBuffStation::OnRebuildComplete(Entity* self, Entity* target) {
+    auto destroyableComponent = self->GetComponent<DestroyableComponent>();
+    
+    if (destroyableComponent != nullptr) destroyableComponent->SetFaction(6);
+
     auto skillComponent = self->GetComponent<SkillComponent>();
 
     if (skillComponent == nullptr) return;

--- a/dScripts/AgSurvivalBuffStation.cpp
+++ b/dScripts/AgSurvivalBuffStation.cpp
@@ -41,6 +41,3 @@ void AgSurvivalBuffStation::OnTimerDone(Entity* self, std::string timerName) {
     }
     if (target != nullptr) GameMessages::SendDropClientLoot(target, self->GetObjectID(), powerupToDrop, 0, self->GetPosition());
 }
-void AgSurvivalBuffStation::OnDie(Entity* self, Entity* killer) {
-    //self->CancelAllTimers();
-}

--- a/dScripts/AgSurvivalBuffStation.h
+++ b/dScripts/AgSurvivalBuffStation.h
@@ -12,7 +12,6 @@ public:
      */
     void OnRebuildComplete(Entity* self, Entity* target) override;
     void OnTimerDone(Entity* self, std::string timerName) override;
-    void OnDie(Entity* self, Entity* killer) override;
 private:
     /**
      * Skill ID for the buff station.

--- a/dScripts/AgSurvivalBuffStation.h
+++ b/dScripts/AgSurvivalBuffStation.h
@@ -11,6 +11,8 @@ public:
      * @param target The target of the self that called this script.
      */
     void OnRebuildComplete(Entity* self, Entity* target) override;
+    void OnTimerDone(Entity* self, std::string timerName) override;
+    void OnDie(Entity* self, Entity* killer) override;
 private:
     /**
      * Skill ID for the buff station.
@@ -20,4 +22,32 @@ private:
      * Behavior ID for the buff station.
      */
     uint32_t behaviorIdForBuffStation = 1784;
+    /**
+     * Timer for dropping armor.
+     */
+    float dropArmorTimer = 6.0f;
+    /**
+     * Timer for dropping life.
+     */
+    float dropLifeTimer = 3.0f;
+    /**
+     * Timer for dropping imagination.
+     */
+    float dropImaginationTimer = 4.0f;
+    /**
+     * Timer for smashing.
+     */
+    float smashTimer = 25.0f;
+    /**
+     * LOT for armor powerup.
+     */
+    LOT armorPowerup = 6431;
+    /**
+     * LOT for life powerup.
+     */
+    LOT lifePowerup = 177;
+    /**
+     * LOT for imagination powerup.
+     */
+    LOT imaginationPowerup = 935;
 };

--- a/dScripts/BaseSurvivalServer.cpp
+++ b/dScripts/BaseSurvivalServer.cpp
@@ -200,6 +200,7 @@ void BaseSurvivalServer::OnActivityTimerDone(Entity *self, const std::string &na
         ActivityTimerStop(self, SpawnTickTimer);
         ActivityTimerStart(self, CoolDownStopTimer, 1, constants.coolDownTime);
 
+        ActivateSpawnerNetwork(spawnerNetworks.rewardNetworks);
         SpawnerReset(spawnerNetworks.baseNetworks, false);
         SpawnerReset(spawnerNetworks.randomNetworks, false);
     } else if (name == CoolDownStopTimer) {
@@ -302,7 +303,6 @@ void BaseSurvivalServer::StartWaves(Entity *self) {
     self->SetVar<bool>(FirstTimeDoneVariable, true);
     self->SetVar<std::string>(MissionTypeVariable, state.players.size() == 1 ? "survival_time_solo" : "survival_time_team");
 
-    ActivateSpawnerNetwork(spawnerNetworks.rewardNetworks);
     ActivateSpawnerNetwork(spawnerNetworks.smashNetworks);
     self->SetNetworkVar<bool>(WavesStartedVariable, true);
     self->SetNetworkVar<std::string>(StartWaveMessageVariable, "Start!");


### PR DESCRIPTION
Fixes #422 
Fully implements the buff station and all functions.  Now correctly spawns powerups.

Tested on local instance and the spawner correctly spawns powerups and smashes itself without error.