### PR TITLE
Log WorldServer shutdown when MasterServer connection is missing

### DIFF
--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -314,6 +314,7 @@ int main(int argc, char** argv) {
 			framesSinceMasterDisconnect++;
 
 			if (framesSinceMasterDisconnect >= 30) {
+				Game::logger->Log("WorldServer", "Game loop running but no connection to master for 30 frames, shutting down");
 				worldShutdownSequenceStarted = true;
 			}
 		}


### PR DESCRIPTION
Log when a WorldServer initiates shutdown because the master server connection went missing or wasn't established in the first place.