### PR TITLE
Implemented script for exploding dummy in Nexus Tower Combat Training

### DIFF
--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -177,6 +177,7 @@
 #include "NtVentureCannonServer.h"
 #include "NtCombatChallengeServer.h"
 #include "NtCombatChallengeDummy.h"
+#include "NtCombatChallengeExplodingDummy.h"
 #include "BaseInteractDropLootServer.h"
 #include "NtAssemblyTubeServer.h"
 #include "NtParadoxPanelServer.h"
@@ -603,6 +604,8 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 		script = new NtCombatChallengeServer();
 	else if (scriptName == "scripts\\02_server\\Map\\NT\\L_NT_COMBAT_CHALLENGE_DUMMY.lua")
 		script = new NtCombatChallengeDummy();
+	else if (scriptName == "scripts\\02_server\\Map\\NT\\\\L_NT_COMBAT_EXPLODING_TARGET.lua")
+		script = new NtCombatChallengeExplodingDummy();
 	else if (scriptName == "scripts\\02_server\\Map\\General\\L_BASE_INTERACT_DROP_LOOT_SERVER.lua")
 		script = new BaseInteractDropLootServer();
 	else if (scriptName == "scripts\\02_server\\Map\\NT\\L_NT_ASSEMBLYTUBE_SERVER.lua")

--- a/dScripts/NtCombatChallengeExplodingDummy.cpp
+++ b/dScripts/NtCombatChallengeExplodingDummy.cpp
@@ -1,0 +1,38 @@
+#include "NtCombatChallengeExplodingDummy.h"
+#include "NtCombatChallengeDummy.h"
+#include "EntityManager.h"
+#include "SkillComponent.h"
+
+void NtCombatChallengeExplodingDummy::OnDie(Entity* self, Entity* killer) 
+{
+    const auto challengeObjectID = self->GetVar<LWOOBJID>(u"challengeObjectID");
+
+    auto* challengeObject = EntityManager::Instance()->GetEntity(challengeObjectID);
+
+    if (challengeObject != nullptr)
+    {
+        for (CppScripts::Script* script : CppScripts::GetEntityScripts(challengeObject))
+        {
+            script->OnDie(challengeObject, killer);
+        }
+    }
+}
+
+void NtCombatChallengeExplodingDummy::OnHitOrHealResult(Entity* self, Entity* attacker, int32_t damage) {
+    const auto challengeObjectID = self->GetVar<LWOOBJID>(u"challengeObjectID");
+
+    auto* challengeObject = EntityManager::Instance()->GetEntity(challengeObjectID);
+
+    if (challengeObject != nullptr)
+    {
+        for (CppScripts::Script* script : CppScripts::GetEntityScripts(challengeObject))
+        {
+            script->OnHitOrHealResult(challengeObject, attacker, damage);
+        }
+    }
+    auto skillComponent = self->GetComponent<SkillComponent>();
+    if (skillComponent != nullptr) {
+        skillComponent->CalculateBehavior(1338, 30875, attacker->GetObjectID());
+    }
+    self->Smash();
+}

--- a/dScripts/NtCombatChallengeExplodingDummy.cpp
+++ b/dScripts/NtCombatChallengeExplodingDummy.cpp
@@ -34,5 +34,5 @@ void NtCombatChallengeExplodingDummy::OnHitOrHealResult(Entity* self, Entity* at
     if (skillComponent != nullptr) {
         skillComponent->CalculateBehavior(1338, 30875, attacker->GetObjectID());
     }
-    self->Smash();
+    self->Kill(attacker);
 }

--- a/dScripts/NtCombatChallengeExplodingDummy.h
+++ b/dScripts/NtCombatChallengeExplodingDummy.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "CppScripts.h"
+
+class NtCombatChallengeExplodingDummy : public CppScripts::Script
+{
+    void OnDie(Entity* self, Entity* killer) override;
+    void OnHitOrHealResult(Entity* self, Entity* attacker, int32_t damage) override;
+};


### PR DESCRIPTION
Fixes #264 
Implements the script that is attached to the exploding dummy in Nexus Tower Combat Training.  Pretty much a copy paste of the original Combat Dummy script, but with the added behaviors and the self smash after 1 hit.  

Tested on local ubuntu instance.  Other dummies act normal.  Red exploding dummies now correctly explode, and do their respective AOE attack as well as spawn the next dummy when they die.