### PR TITLE
Fix spam-log on master disconnect

### DIFF
--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -313,7 +313,8 @@ int main(int argc, char** argv) {
 		if (!Game::server->GetIsConnectedToMaster()) {
 			framesSinceMasterDisconnect++;
 
-			if (framesSinceMasterDisconnect >= 30) {
+			int framesToWaitForMaster = ready ? 10 : 200;
+			if (framesSinceMasterDisconnect >= framesToWaitForMaster && !worldShutdownSequenceStarted) {
 				Game::logger->Log("WorldServer", "Game loop running but no connection to master for 30 frames, shutting down");
 				worldShutdownSequenceStarted = true;
 			}

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -315,7 +315,7 @@ int main(int argc, char** argv) {
 
 			int framesToWaitForMaster = ready ? 10 : 200;
 			if (framesSinceMasterDisconnect >= framesToWaitForMaster && !worldShutdownSequenceStarted) {
-				Game::logger->Log("WorldServer", "Game loop running but no connection to master for ", framesToWaitForMaster, " frames, shutting down");
+				Game::logger->Log("WorldServer", "Game loop running but no connection to master for %d frames, shutting down", framesToWaitForMaster);
 				worldShutdownSequenceStarted = true;
 			}
 		}

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -315,7 +315,7 @@ int main(int argc, char** argv) {
 
 			int framesToWaitForMaster = ready ? 10 : 200;
 			if (framesSinceMasterDisconnect >= framesToWaitForMaster && !worldShutdownSequenceStarted) {
-				Game::logger->Log("WorldServer", "Game loop running but no connection to master for 30 frames, shutting down");
+				Game::logger->Log("WorldServer", "Game loop running but no connection to master for ", framesToWaitForMaster, " frames, shutting down");
 				worldShutdownSequenceStarted = true;
 			}
 		}

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -315,7 +315,7 @@ int main(int argc, char** argv) {
 
 			int framesToWaitForMaster = ready ? 10 : 200;
 			if (framesSinceMasterDisconnect >= framesToWaitForMaster && !worldShutdownSequenceStarted) {
-				Game::logger->Log("WorldServer", "Game loop running but no connection to master for %d frames, shutting down", framesToWaitForMaster);
+				Game::logger->Log("WorldServer", "Game loop running but no connection to master for %d frames, shutting down\n", framesToWaitForMaster);
 				worldShutdownSequenceStarted = true;
 			}
 		}


### PR DESCRIPTION
Only update and log shutdown for missing master connection once.

The log I added in #443 causes spams the log until the main loop terminates. This PR adds a second conditional that prevents this log if `worldShutdownSequenceStarted` is already set.