### PR TITLE
Shooting Gallery daily mission fix

### DIFF
--- a/dGame/dMission/Mission.cpp
+++ b/dGame/dMission/Mission.cpp
@@ -109,7 +109,7 @@ void Mission::LoadFromXml(tinyxml2::XMLElement* element) {
         } else {
             const auto value = std::stoul(task->Attribute("v"));
 
-            m_Tasks[index]->SetProgress(value, false);
+            m_Tasks[index]->SetProgress(value, m_Tasks[index]->GetType() == MissionTaskType::MISSION_TASK_TYPE_MINIGAME);
 
             task = task->NextSiblingElement();
         }
@@ -356,7 +356,7 @@ void Mission::CheckCompletion() {
         return;
     }
 
-    SetMissionState(MissionState::MISSION_STATE_READY_TO_COMPLETE);
+    MakeReadyToComplete();
 }
 
 void Mission::Catchup() {

--- a/dGame/dMission/MissionTask.cpp
+++ b/dGame/dMission/MissionTask.cpp
@@ -78,14 +78,7 @@ void MissionTask::SetProgress(const uint32_t value, const bool echo)
 
 	std::vector<float> updates;
 	updates.push_back(static_cast<float>(progress));
-
-	GameMessages::SendNotifyMissionTask(
-		entity,
-		entity->GetSystemAddress(),
-		static_cast<int>(info->id),
-		static_cast<int>(1 << (mask + 1)),
-		updates
-	);
+	GameMessages::SendNotifyMissionTask(entity,	entity->GetSystemAddress(), static_cast<int>(info->id), static_cast<int>(1 << (mask + 1)), updates);
 }
 
 
@@ -190,15 +183,13 @@ bool MissionTask::InParameters(const uint32_t value) const
 
 bool MissionTask::IsComplete() const
 {
-    // Minigames are the only ones where the target value is a score they need to get but the actual target is the act ID
-	return GetType() == MissionTaskType::MISSION_TASK_TYPE_MINIGAME ? progress == info->target : progress >= info->targetValue;
+	return progress >= info->targetValue;
 }
 
 
 void MissionTask::Complete()
 {
-    // Minigames are the only ones where the target value is a score they need to get but the actual target is the act ID
-	SetProgress(GetType() == MissionTaskType::MISSION_TASK_TYPE_MINIGAME ? info->target : info->targetValue);
+	SetProgress(info->targetValue);
 }
 
 
@@ -354,7 +345,7 @@ void MissionTask::Progress(int32_t value, LWOOBJID associate, const std::string&
 		}
 
 		if(info->targetGroup == targets && value >= info->targetValue) {
-			SetProgress(info->target);
+			SetProgress(info->targetValue);
 			break;
 		}
 		break;

--- a/dScripts/SGCannon.cpp
+++ b/dScripts/SGCannon.cpp
@@ -61,8 +61,6 @@ void SGCannon::OnStartup(Entity *self) {
 void SGCannon::OnPlayerLoaded(Entity *self, Entity *player) {
     Game::logger->Log("SGCannon", "Player loaded\n");
     self->SetVar<LWOOBJID>(PlayerIDVariable, player->GetObjectID());
-    /*GameMessages::SendSetStunned(player->GetObjectID(), PUSH, player->GetSystemAddress(), LWOOBJID_EMPTY,
-                                 true, true, true, true, true, true, true);*/
 }
 
 void SGCannon::OnFireEventServerSide(Entity *self, Entity *sender, std::string args, int32_t param1, int32_t param2,
@@ -561,32 +559,15 @@ void SGCannon::StopGame(Entity *self, bool cancel) {
 
         auto* missionComponent = player->GetComponent<MissionComponent>();
         
-        if (self->GetVar<uint32_t>(TotalScoreVariable) >= 25000)
-        {
-            // For some reason the client thinks this mission is not complete?
-            auto* mission = missionComponent->GetMission(229);
-
-            if (mission != nullptr && !mission->IsComplete())
-            {
-                mission->Complete();
-            }
-        }
-
         if (missionComponent != nullptr) {
-            missionComponent->Progress(
-                MissionTaskType::MISSION_TASK_TYPE_MINIGAME,
-                self->GetVar<uint32_t>(TotalScoreVariable),
-                self->GetObjectID(),
-                "performact_score"
-            );
+            missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_MINIGAME, self->GetVar<uint32_t>(TotalScoreVariable), self->GetObjectID(), "performact_score");
             missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_MINIGAME, self->GetVar<uint32_t>(MaxStreakVariable), self->GetObjectID(), "performact_streak");
             missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_ACTIVITY, m_CannonLot, 0, "", self->GetVar<uint32_t>(TotalScoreVariable));
         }
 
         LootGenerator::Instance().GiveActivityLoot(player, self, GetGameID(self), self->GetVar<uint32_t>(TotalScoreVariable));
 
-        StopActivity(self, player->GetObjectID(), self->GetVar<uint32_t>(TotalScoreVariable),
-                self->GetVar<uint32_t>(MaxStreakVariable), percentage);
+        StopActivity(self, player->GetObjectID(), self->GetVar<uint32_t>(TotalScoreVariable), self->GetVar<uint32_t>(MaxStreakVariable), percentage);
         self->SetNetworkVar<bool>(AudioFinalWaveDoneVariable, true);
 
         // Give the player the model rewards they earned
@@ -600,7 +581,6 @@ void SGCannon::StopGame(Entity *self, bool cancel) {
         self->SetNetworkVar<std::u16string>(u"UI_Rewards",
             GeneralUtils::to_u16string(self->GetVar<uint32_t>(TotalScoreVariable)) + u"_0_0_0_0_0_0"
         );
-        self->SetVar<uint32_t>(TotalScoreVariable, 0);
 
         GameMessages::SendRequestActivitySummaryLeaderboardData(
             player->GetObjectID(),
@@ -612,9 +592,6 @@ void SGCannon::StopGame(Entity *self, bool cancel) {
             0,
             false
         );
-
-        // The end menu is not in, just send them back to the main world
-        //static_cast<Player*>(player)->SendToZone(1300);
     }
 
     GameMessages::SendActivityStop(self->GetObjectID(), false, cancel, player->GetSystemAddress());


### PR DESCRIPTION
Fixes #448 
Not the best change however any shooting gallery missions that require the player to earn a specific score in one game for some reason fail to keep their state between world changes unlike other missions.  This has been fixed in this PR alongside a couple other bugs I noticed while working on this:
1) MakeReadyToComplete being called instead of a hard flag set to MISSION_STATE_READY_TO_COMPLETE since this method is already implemented and properly sets repeatable missions to the correct complete state.
2) These lines `return GetType() == MissionTaskType::MISSION_TASK_TYPE_MINIGAME ? progress == info->target : progress >= info->targetValue;` in MissionTask made absolutely no sense because info->target is a task target not a target _value_.  Both of these ternary operators have been removed to properly progress minigame tasks.
3) When progressing MissionTasks, again, for some reason the values were being set to info->target and not info->targetValue.  This has been corrected.
4) Bodge mission progression in SGCannon has been removed now that the task can properly complete with the main change of the PR (echoing SetProgress for minigame missions)
5) Comments that were deprecated have been removed.
6) For some reason SGCannon was resetting its score in GameOver and also in ResetVars.  This has been changed so it only happens once.