### PR TITLE
Addressed GM Operators not being able to spawn in cars in non-racing worlds

### DIFF
--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -916,7 +916,7 @@ void InventoryComponent::EquipItem(Item* item, const bool skipChecks)
 
 			auto startRotation = NiQuaternion::LookAt(startPosition, startPosition + NiPoint3::UNIT_X);
 			auto angles = startRotation.GetEulerAngles();
-			angles.y -= M_PI;
+			angles.y -= PI;
 			startRotation = NiQuaternion::FromEulerAngles(angles);
 
 			GameMessages::SendTeleport(m_Parent->GetObjectID(), startPosition, startRotation, m_Parent->GetSystemAddress(), true, true);

--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -1052,14 +1052,6 @@ void InventoryComponent::EquipItem(Item* item, const bool skipChecks)
 
 void InventoryComponent::UnEquipItem(Item* item)
 {
-	// if (item->GetLot() == 8092 && m_Parent->GetGMLevel() >= GAME_MASTER_LEVEL_OPERATOR && hasCarEquipped == true)
-	// {
-	// 	auto *playerInstance = dynamic_cast<Player *>(m_Parent);
-	// 	playerInstance->SendToZone(1200);
-
-	// 	equippedCarEntity->Kill();
-	// 	return;
-	// }
 	if (!item->IsEquipped())
 	{
 		return;

--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -911,8 +911,8 @@ void InventoryComponent::EquipItem(Item* item, const bool skipChecks)
 		const auto type = static_cast<eItemType>(item->GetInfo().itemType);
 		
 		if (item->GetLot() == 8092 && m_Parent->GetGMLevel() >= GAME_MASTER_LEVEL_OPERATOR && hasCarEquipped == false)
-		{	// Spawn above current position so we dont fall through floor?
-			auto startPosition = m_Parent->GetPosition() + NiPoint3::UNIT_Y + 2;
+		{	
+			auto startPosition = m_Parent->GetPosition();
 
 			auto startRotation = NiQuaternion::LookAt(startPosition, startPosition + NiPoint3::UNIT_X);
 			auto angles = startRotation.GetEulerAngles();
@@ -989,50 +989,12 @@ void InventoryComponent::EquipItem(Item* item, const bool skipChecks)
     		GameMessages::SendTeleport(carEntity->GetObjectID(), startPosition, startRotation, m_Parent->GetSystemAddress(), true, true);
 			EntityManager::Instance()->SerializeEntity(m_Parent);
 
-			// m_Parent->AddDieCallback([item, this](){
-			// 	this->UnEquipItem(item);
-			// 	this->EquipItem(item);
-			// });
-			// carEntity->AddDieCallback([item, this](){
-			// 	this->UnEquipItem(item);
-			// 	this->EquipItem(item);
-			// });
 			hasCarEquipped = true;
 			equippedCarEntity = carEntity;
 			return;
 		} else if (item->GetLot() == 8092 && m_Parent->GetGMLevel() >= GAME_MASTER_LEVEL_OPERATOR && hasCarEquipped == true)
 		{
-			//GameMessages::SendTeleport(m_Parent->GetObjectID(), m_Parent->GetPosition(), m_Parent->GetRotation(), m_Parent->GetSystemAddress(), true, true);
-			// reset character component back to what it was
-			// auto* characterComponent = m_Parent->GetComponent<CharacterComponent>();
-
-			// if (characterComponent != nullptr)
-			// {
-			// 	characterComponent->SetIsRacing(false);
-			// 	characterComponent->SetVehicleObjectID(LWOOBJID_EMPTY);
-			// }
-
-			// auto* possessableComponent = equippedCarEntity->GetComponent<PossessableComponent>();
-
-			// if (possessableComponent != nullptr)
-			// {
-			// 	possessableComponent->SetPossessor(previousPossessableID);
-			// 	previousPossessableID = LWOOBJID_EMPTY;
-			// }
-
-			// // #107
-			// auto* possessorComponent = m_Parent->GetComponent<PossessorComponent>();
-
-			// if (possessorComponent != nullptr)
-			// {
-			// 	possessorComponent->SetPossessable(previousPossessorID);
-			// 	previousPossessorID = LWOOBJID_EMPTY;
-			// }
 			GameMessages::SendNotifyRacingClient(LWOOBJID_EMPTY, 3, 0, LWOOBJID_EMPTY, u"", m_Parent->GetObjectID(), UNASSIGNED_SYSTEM_ADDRESS);
-			// GameMessages::SendNotifyVehicleOfRacingObject(equippedCarEntity->GetObjectID(), LWOOBJID_EMPTY, UNASSIGNED_SYSTEM_ADDRESS);
-			// GameMessages::SendRacingPlayerLoaded(LWOOBJID_EMPTY, m_Parent->GetObjectID(), LWOOBJID_EMPTY, UNASSIGNED_SYSTEM_ADDRESS);
-			//GameMessages::SendTeleport(m_Parent->GetObjectID(), equippedCarEntity->GetPosition(), equippedCarEntity->GetRotation(), m_Parent->GetSystemAddress(), true, true);
-			// EntityManager::Instance()->SerializeEntity(m_Parent);
 			auto player = dynamic_cast<Player*>(m_Parent);
 			player->SendToZone(player->GetCharacter()->GetZoneID());
 			equippedCarEntity->Kill();

--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -390,6 +390,8 @@ private:
      */
     bool hasCarEquipped = false;
     Entity* equippedCarEntity = nullptr;
+    LWOOBJID previousPossessableID = LWOOBJID_EMPTY;
+    LWOOBJID previousPossessorID = LWOOBJID_EMPTY;
     /**
      * Creates all the proxy items (subitems) for a parent item
      * @param parent the parent item to generate all the subitems for

--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -15,6 +15,7 @@
 #include "Component.h"
 #include "ItemSetPassiveAbility.h"
 #include "ItemSetPassiveAbilityID.h"
+#include "PossessorComponent.h"
 
 class Entity;
 class ItemSet;
@@ -384,6 +385,11 @@ private:
      */
 	LOT m_Consumable;
 
+    /**
+     * Currently has a car equipped
+     */
+    bool hasCarEquipped = false;
+    Entity* equippedCarEntity = nullptr;
     /**
      * Creates all the proxy items (subitems) for a parent item
      * @param parent the parent item to generate all the subitems for


### PR DESCRIPTION
Fixes #351 
Addresses an issue where GMs were unable to spawn in cars in non-racing worlds.   Tested all changes in Nimbus Station without any issues.  The way this works is almost identical to how players are loaded into cars for races and loaded out of cars in races.  Dying currently does not work and I dont know how to fix it however unequipping and re-equipping the car fixes the issue and respawns the player.