### PR TITLE
Tracking of currently online accounts

### DIFF
--- a/dGame/UserManager.cpp
+++ b/dGame/UserManager.cpp
@@ -139,6 +139,15 @@ void UserManager::DeletePendingRemovals()
 		Game::logger->Log("UserManager", "Deleted user %i\n", user->GetAccountID());
 
 		delete user;
+
+		//Set account in database as offline
+		sql::PreparedStatement* stmt = Database::CreatePreppedStmt("UPDATE accounts SET is_online = '0' WHERE id = ?;");
+		
+		stmt->setInt(1, user->GetAccountID());
+
+		stmt->executeUpdate();
+
+		delete stmt;
 	}
 
 	m_UsersToDelete.clear();

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -122,6 +122,12 @@ int main(int argc, char** argv) {
 		return 0;
 	}
 
+	//Backwards compatibiliy, add the is_online column to accounts table if it doesnt already exsist
+	sql::PreparedStatement* stmt = Database::CreatePreppedStmt("ALTER TABLE accounts ADD if not exists is_online tinyint(1) NOT NULL DEFAULT 0;");
+
+	stmt->executeUpdate();
+	delete stmt;
+
 	//If the first command line argument is -a or --account then make the user
 	//input a username and password, with the password being hidden.
 	if (argc > 1 &&

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -835,6 +835,17 @@ void HandlePacket(Packet* packet) {
 						bitStream.Write((LWOINSTANCEID)instanceID);
 						Game::server->SendToMaster(&bitStream);
 					}
+
+					//Set account in database as online
+					sql::PreparedStatement* stmt = Database::CreatePreppedStmt("UPDATE accounts SET is_online = '1' WHERE name = ?;");
+					
+					stmt->setString(1, username.c_str());
+
+					stmt->executeUpdate();
+
+					delete stmt;
+
+
 				}
 
 				break;


### PR DESCRIPTION
Implements https://github.com/DarkflameUniverse/DarkflameServer/issues/450 

Adds `is_online` column to `accounts` table, and updates said column for an account with a `1` when they logon, and a `0` when they disconnect or log off.

Has been tested on my GC server with multiple members.