### PR TITLE
Add server version command

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 Dockerfile
 *.md
 logo.png

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,27 @@ foreach(variable ${variables})
     message(STATUS "Variable: ${variable_name} = ${variable_value}")
 endforeach()
 
+# Obtain Git commit SHA, see https://stackoverflow.com/a/21028226
+find_package(Git)
+if(GIT_FOUND)
+    message(STATUS "Git ${GIT_VERSION_STRING} found: ${GIT_EXECUTABLE}")
+    execute_process(COMMAND
+        "${GIT_EXECUTABLE}" rev-parse --short HEAD
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        OUTPUT_VARIABLE GIT_COMMIT_SHA
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE GIT_EXIT_CODE
+    )
+
+    if(GIT_EXIT_CODE)
+        message(WARNING "Failed obtaining Git commit SHA")
+        set(GIT_COMMIT_SHA "???")
+    endif()
+else()
+    message(WARNING "Git not found")
+    set(GIT_COMMIT_SHA "???")
+endif()
+
 # On windows it's better to build this from source, as there's no way FindZLIB is gonna find it
 if(NOT WIN32)
 find_package(ZLIB REQUIRED)
@@ -143,7 +164,7 @@ endif()
 if (NOT EXISTS ${PROJECT_BINARY_DIR}/worldconfig.ini)
     configure_file(
         ${CMAKE_SOURCE_DIR}/resources/worldconfig.ini ${PROJECT_BINARY_DIR}/worldconfig.ini
-        COPYONLY
+        @ONLY
     )
 endif()
 if (NOT EXISTS ${PROJECT_BINARY_DIR}/masterconfig.ini)

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -26,6 +26,7 @@
 #include "UserManager.h"
 #include "BitStream.h"
 #include "dCommonVars.h"
+#include "dConfig.h"
 #include "GeneralUtils.h"
 #include "Entity.h"
 #include "EntityManager.h"
@@ -260,6 +261,15 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 		// Fix the destroyable component
 		destroyableComponent->FixStats();
+	}
+
+	if (chatCommand == "server-version")
+	{
+		auto& serverName = Game::config->GetValue("server_name");
+		auto& serverVersion = Game::config->GetValue("server_version");
+		auto& gitCommitSha = Game::config->GetValue("git_commit_sha");
+		ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16(serverName) + u" " + GeneralUtils::ASCIIToUTF16(serverVersion) + u" (" + GeneralUtils::ASCIIToUTF16(gitCommitSha) + u")");
+		return;
 	}
 
 	if (chatCommand == "credits" || chatCommand == "info")

--- a/dGame/dUtilities/VanityUtilities.cpp
+++ b/dGame/dUtilities/VanityUtilities.cpp
@@ -473,8 +473,9 @@ std::string VanityUtilities::ParseMarkdown(const std::string& file)
 
         // Replace "__TIMESTAMP__" with the __TIMESTAMP__
         GeneralUtils::ReplaceInString(line, "__TIMESTAMP__", __TIMESTAMP__);
-        // Replace "__VERSION__" wit'h the PROJECT_VERSION
-        GeneralUtils::ReplaceInString(line, "__VERSION__", STRINGIFY(PROJECT_VERSION));
+        // Replace "__VERSION__" with the PROJECT_VERSION
+        std::string version = Game::config->GetValue("server_version") + " (" + Game::config->GetValue("git_commit_sha") + ")";
+        GeneralUtils::ReplaceInString(line, "__VERSION__", version);
         // Replace "__SOURCE__" with SOURCE
         GeneralUtils::ReplaceInString(line, "__SOURCE__", Game::config->GetValue("source"));
         // Replace "__LICENSE__" with LICENSE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,15 +6,8 @@ services:
     build:
       context: .
       dockerfile: ./docker/setup.Dockerfile
-    environment:
-      - DATABASE=${MARIADB_DATABASE:-darkflame}
-      - DATABASE_HOST=database
-      - DATABASE_USER=${MARIADB_USER:-darkflame}
-      - DATABASE_PASSWORD=${MARIADB_PASSWORD:-darkflame}
-      - EXTERNAL_IP=${EXTERNAL_IP:-darkflame}
     volumes:
       - ${CLIENT_PATH:?missing_client_path}:/client
-      - shared_configs:/docker/
 
   database:
     container_name: DarkflameDatabase
@@ -44,9 +37,14 @@ services:
       args:
         - BUILD_THREADS=${BUILD_THREADS:-1}
         - BUILD_VERSION=${BUILD_VERSION:-171022}
+    environment:
+      - DATABASE=${MARIADB_DATABASE:-darkflame}
+      - DATABASE_HOST=database
+      - DATABASE_USER=${MARIADB_USER:-darkflame}
+      - DATABASE_PASSWORD=${MARIADB_PASSWORD:-darkflame}
+      - EXTERNAL_IP=${EXTERNAL_IP:-darkflame}
     volumes:
       - ${CLIENT_PATH:?missing_client_path}:/client:ro
-      - shared_configs:/shared_configs:ro
     depends_on:
       - database
     ports:
@@ -100,4 +98,3 @@ networks:
 
 volumes:
   database:
-  shared_configs:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -27,6 +27,8 @@ COPY thirdparty/ /build/thirdparty
 COPY vanity /build/vanity
 COPY tests/ /build/tests
 COPY .clang-* CMake* LICENSE /build/
+# Copy Git data to be able to get revision information
+COPY .git /build/.git
 
 ARG BUILD_THREADS=1
 ARG BUILD_VERSION=171022

--- a/docker/setup.Dockerfile
+++ b/docker/setup.Dockerfile
@@ -13,7 +13,6 @@ RUN apk add sqlite bash --no-cache
 WORKDIR /setup
 
 # copy needed files from repo
-COPY resources/ resources/
 COPY migrations/cdserver/ migrations/cdserver
 COPY --from=LUnpack /build_LUnpack/target/release/lunpack /usr/local/bin/lunpack
 ADD thirdparty/docker-utils/utils/*.py utils/

--- a/docker/setup.sh
+++ b/docker/setup.sh
@@ -3,46 +3,6 @@
 # fail on first error
 set -e
 
-function update_ini() {
-    FILE="/docker/configs/$1"
-    KEY=$2
-    NEW_VALUE=$3
-    sed -i "/^$KEY=/s/=.*/=$NEW_VALUE/" $FILE
-}
-
-function update_database_ini_values_for() {
-    INI_FILE=$1
-
-    update_ini $INI_FILE mysql_host $DATABASE_HOST
-    update_ini $INI_FILE mysql_database $DATABASE
-    update_ini $INI_FILE mysql_username $DATABASE_USER
-    update_ini $INI_FILE mysql_password $DATABASE_PASSWORD
-    if [[ "$INI_FILE" != "worldconfig.ini" ]]; then
-        update_ini $INI_FILE external_ip $EXTERNAL_IP
-    fi
-}
-
-function update_ini_values() {
-    echo "Copying and updating config files"
-
-    mkdir -p /docker/configs
-    cp resources/masterconfig.ini /docker/configs/
-    cp resources/authconfig.ini /docker/configs/
-    cp resources/chatconfig.ini /docker/configs/
-    cp resources/worldconfig.ini /docker/configs/
-
-    update_ini worldconfig.ini chat_server_port $CHAT_SERVER_PORT
-    update_ini worldconfig.ini max_clients $MAX_CLIENTS
-
-    # always use the internal docker hostname
-    update_ini masterconfig.ini master_ip "darkflame"
-
-    update_database_ini_values_for masterconfig.ini
-    update_database_ini_values_for authconfig.ini
-    update_database_ini_values_for chatconfig.ini
-    update_database_ini_values_for worldconfig.ini
-}
-
 function fdb_to_sqlite() {
     echo "Run fdb_to_sqlite"
     python3 utils/fdb_to_sqlite.py /client/client/res/cdclient.fdb --sqlite_path /client/client/res/CDServer.sqlite
@@ -56,8 +16,6 @@ function fdb_to_sqlite() {
         done
     )
 }
-
-update_ini_values
 
 if [[ ! -d "/client" ]]; then
     echo "Client not found."

--- a/resources/worldconfig.ini
+++ b/resources/worldconfig.ini
@@ -7,6 +7,11 @@ mysql_password=
 # URL to the code repository for the hosted server
 # If you fork this repository and/or make changes to the code, reflect that here to comply with AGPLv3
 source=https://github.com/DarkflameUniverse/DarkflameServer
+# Used for display purposes
+server_name=DarkflameServer
+# These values are set by CMake
+server_version=@PROJECT_VERSION@
+git_commit_sha=@GIT_COMMIT_SHA@
 
 # Port to the chat server, same as in chatconfig.ini
 chat_server_port=2005


### PR DESCRIPTION
Adds a `/server-version` command which prints the server version as well as the Git commit SHA in chat:
![Chat screenshot](https://user-images.githubusercontent.com/11685886/153766939-7cb1d80c-0267-4550-83ac-04146b145c16.png)

The version and the Git commit SHA are stored in the `worldconfig.ini` file and are set during the CMake build.
This feature is not super useful because apparently you cannot copy text from chat (unless I am overlooking something), but maybe it is a bit helpful nonetheless. If you know a way to allow the user to copy the text (possibly with something other than the chat), please let me know; that might be helpful in combination with #419 to make it easier for the user to obtain the version information.

This pull request also changes the Docker setup a bit to use the `.ini` files prepared during build instead of having the DarkflameSetup container copy the originals and then share them with the server. I have marked this as draft to wait until #432 is merged.

This is mainly a proof of concept; no worries if you are not interested in this. Any feedback is appreciated.

Note: These changes might cause issues with existing local `CMakeCache.txt` files.