### PR TITLE
Update Docker.md with buildkit and submodule notes.

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -4,7 +4,7 @@
 
 - [Docker](https://docs.docker.com/get-docker/) (Docker Desktop or on Linux normal Docker)
 - [Docker Compose](https://docs.docker.com/compose/install/) (Included in Docker Desktop)
-- LEGO® Universe Client packed client. Check the main [README](./README.md) for details on this.
+- LEGO® Universe packed Client. Check the main [README](./README.md) for details on this.
 
 ## Run server inside Docker
 

--- a/Docker.md
+++ b/Docker.md
@@ -21,6 +21,14 @@
 
 **NOTE #2**: To stop the server simply run `docker compose down` and to restart it just run `docker compose up -d` again. No need to run all the steps above every time.
 
+**NOTE #3**: Docker buildkit needs to be enabled. https://docs.docker.com/develop/develop-images/build_enhancements/#to-enable-buildkit-builds
+
+**NOTE #4**: Make sure to run the following in the repo root directory after cloning so submodules are also downloaded.
+```
+git submodule init
+git submodule update
+```
+
 ## Disable brickbuildfix
 
 If you don't need the http server running on port 80 do this:

--- a/Docker.md
+++ b/Docker.md
@@ -4,7 +4,7 @@
 
 - [Docker](https://docs.docker.com/get-docker/) (Docker Desktop or on Linux normal Docker)
 - [Docker Compose](https://docs.docker.com/compose/install/) (Included in Docker Desktop)
-- LEGO® Universe Client (packed or unpacked). Check the main [README](./README.md) for details on this.
+- LEGO® Universe Client packed client. Check the main [README](./README.md) for details on this.
 
 ## Run server inside Docker
 

--- a/Docker.md
+++ b/Docker.md
@@ -28,6 +28,7 @@
 git submodule init
 git submodule update
 ```
+**NOTE #5**: If DarkflameSetup fails due to not having cdclient.fdb, rename CDClient.fdb (in the same folder) to cdclient.fdb
 
 ## Disable brickbuildfix
 


### PR DESCRIPTION
Add link to enabling docker buildkit. Add note to remember to clone submodules.

Cloning submodules note addresses this issue: https://github.com/DarkflameUniverse/DarkflameServer/issues/454

Docker buildkit is required when running this docker compose and will fail without it.