### PR TITLE
Addressed special case in GameMessage for interacting with a mailbox

### DIFF
--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -4980,17 +4980,6 @@ void GameMessages::HandleRequestUse(RakNet::BitStream* inStream, Entity* entity,
 
 	missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_MISSION_INTERACTION, interactedObject->GetLOT(), interactedObject->GetObjectID());
 	missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_NON_MISSION_INTERACTION, interactedObject->GetLOT(), interactedObject->GetObjectID());
-
-	//Do mail stuff:
-	if (interactedObject->GetLOT() == 3964) {
-		AMFStringValue* value = new AMFStringValue();
-		value->SetStringValue("Mail");
-
-		AMFArrayValue args;
-		args.InsertValue("state", value);
-		GameMessages::SendUIMessageServerToSingleClient(entity, sysAddr, "pushGameState", &args);
-		delete value;
-	}
 }
 
 void GameMessages::HandlePlayEmote(RakNet::BitStream* inStream, Entity* entity) {

--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -162,6 +162,7 @@
 #include "GrowingFlower.h"
 #include "BaseFootRaceManager.h"
 #include "PropertyPlatform.h"
+#include "MailBoxServer.h"
 
 // Racing Scripts
 #include "RaceImagineCrateServer.h"
@@ -580,6 +581,8 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
         script = new PropertyPlatform();
     else if (scriptName == "scripts\\02_server\\Map\\VE\\L_VE_BRICKSAMPLE_SERVER.lua")
         return new VeBricksampleServer();
+	else if (scriptName == "scripts\\02_server\\Map\\General\\L_MAIL_BOX_SERVER.lua")
+		script = new MailBoxServer();
 
 	//Racing:
 	else if (scriptName == "scripts\\ai\\RACING\\OBJECTS\\RACE_IMAGINE_CRATE_SERVER.lua")

--- a/dScripts/MailBoxServer.cpp
+++ b/dScripts/MailBoxServer.cpp
@@ -1,0 +1,12 @@
+#include "MailBoxServer.h"
+#include "AMFFormat.h"
+#include "GameMessages.h"
+
+void MailBoxServer::OnUse(Entity* self, Entity* user) {
+    AMFStringValue* value = new AMFStringValue();
+	value->SetStringValue("Mail");
+	AMFArrayValue args;
+	args.InsertValue("state", value);
+	GameMessages::SendUIMessageServerToSingleClient(user, user->GetSystemAddress(), "pushGameState", &args);
+	delete value;
+}

--- a/dScripts/MailBoxServer.h
+++ b/dScripts/MailBoxServer.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "CppScripts.h"
+
+class MailBoxServer : public CppScripts::Script {
+public:
+    /**
+     * When a mailbox is interacted with, this method updates the player game state
+     * to be in a mailbox.
+     *
+     * @param self The object that owns this script.
+     * @param user The user that interacted with this Entity.
+     */
+    void OnUse(Entity* self, Entity* user) override;
+};


### PR DESCRIPTION
Addresses an issue brought up by @Xiphoseer where the GameMessage for HandleRequestUse had a special case for mailboxes.  This has been addressed and the script for the MailBoxServer has been implemented.  

Tested changes on local ubuntu instance.  No issues were found when interacting with an empty mailbox.