### PR TITLE
Addressed hard coded character create values for shirts and pants

### DIFF
--- a/dGame/UserManager.cpp
+++ b/dGame/UserManager.cpp
@@ -6,6 +6,7 @@
 
 #include "Database.h"
 #include "Game.h"
+#include "dLogger.h"
 #include "User.h"
 #include <WorldPackets.h>
 #include "Character.h"
@@ -572,28 +573,26 @@ uint32_t GetShirtColorId(uint32_t color) {
 	auto colorId = std::find(shirtColorVector.begin(), shirtColorVector.end(), color);
 	return color = std::distance(shirtColorVector.begin(), colorId);
 }
-
+// the correct query
+/**
+ * select obj.id, obj.name, obj._internalnotes, icc.color1, icc.decal from Objects as obj JOIN (select * from ComponentsRegistry as cr JOIN ItemComponent as ic on ic.id = cr.component_id where cr.component_type == 11) as icc on icc.id = obj.id where lower(obj._internalNotes) == "character create shirt";
+ */
 uint32_t FindCharShirtID(uint32_t shirtColor, uint32_t shirtStyle) {
-	
-	shirtStyle--; // to start at 0 instead of 1
-	uint32_t stylesCount = 34;
-	uint32_t colorId = GetShirtColorId(shirtColor);
-	
-	uint32_t startID = 4049; // item ID of the shirt with color 0 (red) and style 0 (plain)
-	
-    // For some reason, if the shirt style is 34 - 39,
-	// The ID is different than the original... Was this because
-	// these shirts were added later?
-	if (shirtStyle >= 34) {
-		startID = 5730; // item ID of the shirt with color 0 (red) and style 34 (butterflies)
-        shirtStyle -= stylesCount; //change style from range 35-40 to range 0-5
-		stylesCount = 6;
+	try {
+		std::string shirtQuery = "select obj.id from Objects as obj JOIN (select * from ComponentsRegistry as cr JOIN ItemComponent as ic on ic.id = cr.component_id where cr.component_type == 11) as icc on icc.id = obj.id where lower(obj._internalNotes) == \"character create shirt\" AND icc.color1 == ";
+		shirtQuery += std::to_string(shirtColor);
+		shirtQuery += " AND icc.decal == ";
+		shirtQuery = shirtQuery + std::to_string(shirtStyle);
+		auto tableData = CDClientDatabase::ExecuteQuery(shirtQuery);
+		auto shirtLOT = tableData.getIntField(0, -1);
+		tableData.finalize();
+		return shirtLOT;
 	}
-	
-    // Get the final ID of the shirt
-	uint32_t shirtID = startID + (colorId * stylesCount) + shirtStyle;
-
-	return shirtID;
+	catch (const std::exception&){
+		Game::logger->Log("Character Create", "Failed to use query! Using backup...");
+		// in case of no shirt found in CDServer, return problematic red vest.
+		return 4069;
+	}
 }
 
 uint32_t FindCharPantsID(uint32_t pantsColor) {

--- a/dGame/UserManager.cpp
+++ b/dGame/UserManager.cpp
@@ -569,7 +569,7 @@ uint32_t FindCharShirtID(uint32_t shirtColor, uint32_t shirtStyle) {
 		return shirtLOT;
 	}
 	catch (const std::exception&){
-		Game::logger->Log("Character Create", "Failed to use query! Using backup...");
+		Game::logger->Log("Character Create", "Failed to execute query! Using backup...");
 		// in case of no shirt found in CDServer, return problematic red vest.
 		return 4069;
 	}
@@ -585,7 +585,7 @@ uint32_t FindCharPantsID(uint32_t pantsColor) {
 		return pantsLOT;
 	}
 	catch (const std::exception&){
-		Game::logger->Log("Character Create", "Failed to use query! Using backup...");
+		Game::logger->Log("Character Create", "Failed to execute query! Using backup...");
 		// in case of no pants color found in CDServer, return red pants.
 		return 2508;
 	}

--- a/dGame/UserManager.cpp
+++ b/dGame/UserManager.cpp
@@ -577,9 +577,9 @@ uint32_t FindCharShirtID(uint32_t shirtColor, uint32_t shirtStyle) {
 
 uint32_t FindCharPantsID(uint32_t pantsColor) {
 	try {
-		std::string shirtQuery = "select obj.id from Objects as obj JOIN (select * from ComponentsRegistry as cr JOIN ItemComponent as ic on ic.id = cr.component_id where cr.component_type == 11) as icc on icc.id = obj.id where lower(obj._internalNotes) == \"cc pants\" AND icc.color1 == ";
-		shirtQuery += std::to_string(pantsColor);
-		auto tableData = CDClientDatabase::ExecuteQuery(shirtQuery);
+		std::string pantsQuery = "select obj.id from Objects as obj JOIN (select * from ComponentsRegistry as cr JOIN ItemComponent as ic on ic.id = cr.component_id where cr.component_type == 11) as icc on icc.id = obj.id where lower(obj._internalNotes) == \"cc pants\" AND icc.color1 == ";
+		pantsQuery += std::to_string(pantsColor);
+		auto tableData = CDClientDatabase::ExecuteQuery(pantsQuery);
 		auto pantsLOT = tableData.getIntField(0, -1);
 		tableData.finalize();
 		return pantsLOT;

--- a/dGame/UserManager.h
+++ b/dGame/UserManager.h
@@ -44,7 +44,6 @@ public:
 
 private:
 	static UserManager* m_Address; //Singleton
-	//std::vector<User*> m_Users;
 	std::map<SystemAddress, User*> m_Users;
 	std::vector<User*> m_UsersToDelete;
 	
@@ -52,45 +51,6 @@ private:
 	std::vector<std::string> m_MiddleNames;
 	std::vector<std::string> m_LastNames;
 	std::vector<std::string> m_PreapprovedNames;
-};
-
-enum CharCreatePantsColor : uint32_t {
-	PANTS_BRIGHT_RED = 2508,
-	PANTS_BRIGHT_ORANGE = 2509,
-	PANTS_BRICK_YELLOW = 2511,
-	PANTS_MEDIUM_BLUE = 2513,
-	PANTS_SAND_GREEN = 2514,
-	PANTS_DARK_GREEN = 2515,
-	PANTS_EARTH_GREEN = 2516,
-	PANTS_EARTH_BLUE = 2517,
-	PANTS_BRIGHT_BLUE = 2519,
-	PANTS_SAND_BLUE = 2520,
-	PANTS_DARK_STONE_GRAY = 2521,
-	PANTS_MEDIUM_STONE_GRAY = 2522,
-	PANTS_WHITE = 2523,
-	PANTS_BLACK = 2524,
-	PANTS_REDDISH_BROWN = 2526,
-	PANTS_DARK_RED = 2527
-};
-
-const std::vector<uint32_t> shirtColorVector {
-	0, // BRIGHT_RED
-	1, // BRIGHT_BLUE
-	2, // BRIGHT_YELLOW
-	3, // DARK_GREEN
-	5, // BRIGHT_ORANGE
-	6, // BLACK
-	7, // DARK_STONE_GRAY
-	8, // MEDIUM_STONE_GRAY
-	9, // REDDISH_BROWN
-	10, // WHITE
-	11, // MEDIUM_BLUE
-	13, // DARK_RED
-	14, // EARTH_BLUE
-	15, // EARTH_GREEN
-	16, // BRICK_YELLOW
-	84, // SAND_BLUE
-	96 // SAND_GREEN
 };
 
 #endif // USERMANAGER_H


### PR DESCRIPTION
Previously, character create used hard coded vectors and ids to get the LOTs for items to be used for character creation.  With this PR the CDServer is queried and the resulting LOT from the query returns the LOT of the shirt that is requested.  This is done by merging the ItemComponent and ComponentsRegistry tables together and getting all LOTs with an ItemComponent of 11.  Then this table is merged with the Objects table where we get the LOT which has an internal note of, for shirts, character create shirt, or for pants, cc pants, and the requested decal and/or color1 the client had chosen.  Should this query return nothing or fail, a default shirt and pants are chosen.  This allows users to add new shirts and pants to the CDServer/cdclient without needing to hard code them.

If this query can be cached for efficiency I'll happily do so.  

Tested creating characters with various shirts, pants and colors.  Server created the character with the correct shirt and pants and did not fall into the fail case.