### PR TITLE
Added more specific bug reporting

### DIFF
--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -5900,6 +5900,13 @@ void GameMessages::HandleReportBug(RakNet::BitStream* inStream, Entity* entity) 
 		body.push_back(character);
 	}
 
+	auto character = entity->GetCharacter();
+	if (character) {
+		body.append(GeneralUtils::ASCIIToUTF16(" charID: "));
+		body.append(GeneralUtils::ASCIIToUTF16(std::to_string(character->GetID())));
+		body.push_back(' ');
+	}
+
 	uint32_t clientVersionLength;
 	inStream->Read(clientVersionLength);
 	for (unsigned int k = 0; k < clientVersionLength; k++) {
@@ -5915,7 +5922,19 @@ void GameMessages::HandleReportBug(RakNet::BitStream* inStream, Entity* entity) 
 		inStream->Read(character);
 		nOtherPlayerID.push_back(character);
 	}
-
+	// Convert other player id from LWOOBJID to the database id.
+	std::istringstream iss(nOtherPlayerID);
+	LWOOBJID nOtherPlayerLWOOBJID;
+	iss >> nOtherPlayerLWOOBJID;
+	if (nOtherPlayerLWOOBJID != LWOOBJID_EMPTY) {
+		auto otherPlayer = EntityManager::Instance()->GetEntity(nOtherPlayerLWOOBJID);
+		if (otherPlayer) {
+			auto character = otherPlayer->GetCharacter();
+			if (character) {
+				nOtherPlayerID = std::to_string(character->GetID());
+			}
+		}
+	}
 	uint32_t selectionLength;
 	inStream->Read(selectionLength);
 	for (unsigned int k = 0; k < selectionLength; k++) {

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -5890,6 +5890,7 @@ void GameMessages::HandleReportBug(RakNet::BitStream* inStream, Entity* entity) 
 	std::string nOtherPlayerID;
 	std::string selection;
 	uint32_t messageLength;
+	int32_t reporterID;
 
 	//Reading:
 	inStream->Read(messageLength);
@@ -5901,11 +5902,7 @@ void GameMessages::HandleReportBug(RakNet::BitStream* inStream, Entity* entity) 
 	}
 
 	auto character = entity->GetCharacter();
-	if (character) {
-		body.append(GeneralUtils::ASCIIToUTF16(" charID: "));
-		body.append(GeneralUtils::ASCIIToUTF16(std::to_string(character->GetID())));
-		body.push_back(' ');
-	}
+	if (character) reporterID = character->GetID();
 
 	uint32_t clientVersionLength;
 	inStream->Read(clientVersionLength);
@@ -5944,11 +5941,12 @@ void GameMessages::HandleReportBug(RakNet::BitStream* inStream, Entity* entity) 
 	}
 
 	try {
-		sql::PreparedStatement* insertBug = Database::CreatePreppedStmt("INSERT INTO `bug_reports`(body, client_version, other_player_id, selection) VALUES (?, ?, ?, ?)");
+		sql::PreparedStatement* insertBug = Database::CreatePreppedStmt("INSERT INTO `bug_reports`(body, client_version, other_player_id, selection, reporter_id) VALUES (?, ?, ?, ?, ?)");
 		insertBug->setString(1, GeneralUtils::UTF16ToWTF8(body));
 		insertBug->setString(2, clientVersion);
 		insertBug->setString(3, nOtherPlayerID);
 		insertBug->setString(4, selection);
+		insertBug->setInt(5, reporterID);
 		insertBug->execute();
 		delete insertBug;
 	}

--- a/migrations/dlu/0_initial.sql
+++ b/migrations/dlu/0_initial.sql
@@ -150,6 +150,7 @@ CREATE TABLE activity_log (
 DROP TABLE IF EXISTS bug_reports;
 CREATE TABLE bug_reports (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    reporter_id INT NOT NULL DEFAULT 0,
     body TEXT NOT NULL,
     client_version TEXT NOT NULL,
     other_player_id TEXT NOT NULL,

--- a/migrations/dlu/0_initial.sql
+++ b/migrations/dlu/0_initial.sql
@@ -150,7 +150,6 @@ CREATE TABLE activity_log (
 DROP TABLE IF EXISTS bug_reports;
 CREATE TABLE bug_reports (
     id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-    reporter_id INT NOT NULL DEFAULT 0,
     body TEXT NOT NULL,
     client_version TEXT NOT NULL,
     other_player_id TEXT NOT NULL,

--- a/migrations/dlu/2_reporter_id.sql
+++ b/migrations/dlu/2_reporter_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bug_reports ADD reporter_id INT NOT NULL DEFAULT 0;


### PR DESCRIPTION
Fixes #355 
Made bug reporting more specific by adding a reporter_id column that contains the characterID of the reporting player.  Added a migration to add the column to the existing bug_reports table.  Also changed the stored OtherPlayerID from the LWOOBJID to the characterID.

Tested changed by reporting general bugs through the drop down and reporting other players and had no exceptions and bugs were reported correctly.