### PR TITLE
Fixed mission progression for item proxies

### DIFF
--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -195,13 +195,13 @@ public:
      * Adds a buff related to equipping a lot to the entity
      * @param lot the lot to find buffs for
      */
-	void ApplyBuff(LOT lot) const;
+	void ApplyBuff(Item* item) const;
 
     /**
      * Removes buffs related to equipping a lot from the entity
      * @param lot the lot to find buffs for
      */
-	void RemoveBuff(LOT lot) const;
+	void RemoveBuff(Item* item) const;
 
     /**
      * Saves the equipped items into a temp state
@@ -244,7 +244,7 @@ public:
      * @param castOnEquip if true, the skill missions for these buffs will be progressed
      * @return the buffs related to the specified lot
      */
-	std::vector<uint32_t> FindBuffs(LOT lot, bool castOnEquip) const;
+	std::vector<uint32_t> FindBuffs(Item* item, bool castOnEquip) const;
 
     /**
      * Initializes the equipped items with a list of items

--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -193,13 +193,13 @@ public:
 
     /**
      * Adds a buff related to equipping a lot to the entity
-     * @param lot the lot to find buffs for
+     * @param item the item to find buffs for
      */
 	void ApplyBuff(Item* item) const;
 
     /**
      * Removes buffs related to equipping a lot from the entity
-     * @param lot the lot to find buffs for
+     * @param item the item to find buffs for
      */
 	void RemoveBuff(Item* item) const;
 

--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -240,7 +240,7 @@ public:
 
     /**
      * Finds all the buffs related to a lot
-     * @param lot the lot to get the buffs for
+     * @param item the item to get the buffs for
      * @param castOnEquip if true, the skill missions for these buffs will be progressed
      * @return the buffs related to the specified lot
      */


### PR DESCRIPTION
Fixes an issue where missions that would progress when equipping item proxies would not progress.  Proxies still do not give extra bonuses as intended however missions like [Borrowed Gear](https://explorer.lu/missions/1935) now progress when a proxy is equipped.  This also fixes an issue introduced in #441 where calling new Item() for proxies would incorrectly pass parent->getID() for the isModMoveAndEquip parameter.  @Xiphoseer for review

Tested the following for functionality and bugs:
Mission 1950 and 1935 progress correctly.
Maelstrom infused hoods give the correct bonuses
Imagination Backpack only gives 3 imagination
[Trial Venture Gear](https://explorer.lu/objects/14359) correctly gives only 4 life, 10 armor, 12 imagination
The Serratorizor correctly gives 2 armor and 5 imagination.
Unequipping any item with proxies resets stats to the correct previous values.  
Equipping an item with a proxy while having a proxy item equipped correctly adjusts stats accordingly.