### PR TITLE
Corrected faction for Buff Station

### DIFF
--- a/dScripts/AgSurvivalBuffStation.cpp
+++ b/dScripts/AgSurvivalBuffStation.cpp
@@ -9,7 +9,7 @@
 void AgSurvivalBuffStation::OnRebuildComplete(Entity* self, Entity* target) {
     auto destroyableComponent = self->GetComponent<DestroyableComponent>();
     // We set the faction to 6 so that the buff station sees players as friendly targets to buff
-    if (destroyableComponent != nullptr) destroyableComponent->SetFaction(6);
+    if (destroyableComponent != nullptr) destroyableComponent->SetFaction(1);
 
     auto skillComponent = self->GetComponent<SkillComponent>();
 

--- a/dScripts/AgSurvivalBuffStation.cpp
+++ b/dScripts/AgSurvivalBuffStation.cpp
@@ -8,7 +8,7 @@
 
 void AgSurvivalBuffStation::OnRebuildComplete(Entity* self, Entity* target) {
     auto destroyableComponent = self->GetComponent<DestroyableComponent>();
-    // We set the faction to 6 so that the buff station sees players as friendly targets to buff
+    // We set the faction to 1 so that the buff station sees players as friendly targets to buff
     if (destroyableComponent != nullptr) destroyableComponent->SetFaction(1);
 
     auto skillComponent = self->GetComponent<SkillComponent>();


### PR DESCRIPTION
For some reason, the faction that I used in testing on my test branch was 6 and this allowed the buff station to work and buff the player as intended however, when testing the merge on live dlu, the correct faction was 1 and not 6.  

Tested the buff station in survival with an instance size of 1 and 2 players on a local server and it correctly healed the player and not enemies.
Edit: this was because between the time that branch was updated and the buff station PRs being made, aoe behaviors was changed.  