### PR TITLE
Reputation now saved in charxml 

### DIFF
--- a/dGame/dComponents/CharacterComponent.cpp
+++ b/dGame/dComponents/CharacterComponent.cpp
@@ -256,7 +256,11 @@ void CharacterComponent::LoadFromXML() {
 		Game::logger->Log("CharacterComponent", "Failed to find char tag while loading XML!\n");
 		return;
 	}
-
+    if (character->QueryAttribute("rpt", &m_Reputation) == tinyxml2::XML_NO_ATTRIBUTE) {
+        SetReputation(0);
+    }
+    
+    Game::logger->Log("CharacterComponent", "error is %i", character->QueryAttribute("rpt", &m_Reputation));
 	character->QueryInt64Attribute("ls", &m_Uscore);
 
 	// Load the statistics
@@ -378,6 +382,8 @@ void CharacterComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
 	}
 
 	character->SetAttribute("ls", m_Uscore);
+    // Custom attribute to keep track of reputation.
+    character->SetAttribute("rpt", GetReputation());
 	character->SetAttribute("stt", StatisticsToString().c_str());
 
 	// Set the zone statistics of the form <zs><s/> ... <s/></zs>

--- a/dGame/dComponents/CharacterComponent.cpp
+++ b/dGame/dComponents/CharacterComponent.cpp
@@ -261,7 +261,6 @@ void CharacterComponent::LoadFromXML() {
         SetReputation(0);
     }
     
-    Game::logger->Log("CharacterComponent", "error is %i", character->QueryAttribute("rpt", &m_Reputation));
 	character->QueryInt64Attribute("ls", &m_Uscore);
 
 	// Load the statistics

--- a/dGame/dComponents/CharacterComponent.cpp
+++ b/dGame/dComponents/CharacterComponent.cpp
@@ -32,6 +32,7 @@ CharacterComponent::CharacterComponent(Entity* parent, Character* character) : C
 
 	m_EditorEnabled = false;
 	m_EditorLevel = m_GMLevel;
+    m_Reputation = 0;
 
 	m_CurrentActivity = 0;
 	m_CountryCode = 0;

--- a/dGame/dComponents/CharacterComponent.h
+++ b/dGame/dComponents/CharacterComponent.h
@@ -147,6 +147,18 @@ public:
 	bool GetPvpEnabled() const;
 
     /**
+     * Returns the characters lifetime reputation
+     * @return The lifetime reputation of this character.
+     */
+    int64_t GetReputation() { return m_Reputation; };
+
+    /**
+     * Sets the lifetime reputation of the character to newValue
+     * @param newValue the value to set reputation to
+     */
+    void SetReputation(int64_t newValue) { m_Reputation = newValue; };
+
+    /**
      * Sets the current value of PvP combat being enabled
      * @param value whether to enable PvP combat
      */
@@ -290,6 +302,11 @@ private:
      * Universe score of the entity
      */
 	int64_t m_Uscore;
+
+    /**
+     * The lifetime reputation earned by the entity
+     */
+    int64_t m_Reputation;
 
     /**
      * Whether the character is landing by rocket

--- a/dGame/dMission/Mission.cpp
+++ b/dGame/dMission/Mission.cpp
@@ -518,24 +518,11 @@ void Mission::YieldRewards() {
 
     if (info->reward_reputation > 0) {
         missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_EARN_REPUTATION, 0, 0L, "", info->reward_reputation);
-        auto character = entity->GetCharacter();
-        if (!character) return;
-
-        auto charId = character->GetID();
-        auto propertyCloneId = character->GetPropertyCloneID();
-
-        auto reputationUpdate = Database::CreatePreppedStmt("UPDATE properties SET reputation = reputation + ? where owner_id = ? AND clone_id = ?");
-
-        reputationUpdate->setInt64(1, info->reward_reputation);
-        reputationUpdate->setInt(2, charId);
-        reputationUpdate->setInt64(3, propertyCloneId);
-
-        reputationUpdate->executeUpdate();
-
-        delete reputationUpdate;
-        reputationUpdate = nullptr;
-
-        GameMessages::SendUpdateReputation(entity->GetObjectID(), info->reward_reputation, entity->GetSystemAddress());
+        auto character = entity->GetComponent<CharacterComponent>();
+        if (character) {
+            character->SetReputation(character->GetReputation() + info->reward_reputation);
+            GameMessages::SendUpdateReputation(entity->GetObjectID(), character->GetReputation(), entity->GetSystemAddress());
+        }
     }
 
     if (info->reward_maxhealth > 0) {

--- a/dNet/WorldPackets.cpp
+++ b/dNet/WorldPackets.cpp
@@ -131,7 +131,7 @@ void WorldPackets::SendCreateCharacter(const SystemAddress& sysAddr, const LWOOB
     PacketUtils::WriteHeader(bitStream, CLIENT, MSG_CLIENT_CREATE_CHARACTER);
     
     RakNet::BitStream data;
-    data.Write<uint32_t>(6); //LDF key count
+    data.Write<uint32_t>(7); //LDF key count
 
     LDFData<LWOOBJID>* objid = new LDFData<LWOOBJID>(u"objid", objectID);
     LDFData<LOT>* lot = new LDFData<LOT>(u"template", 1);
@@ -139,13 +139,15 @@ void WorldPackets::SendCreateCharacter(const SystemAddress& sysAddr, const LWOOB
     LDFData<std::u16string>* name = new LDFData<std::u16string>(u"name", username);
     LDFData<int32_t>* gmlevel = new LDFData<int32_t>(u"gmlevel", gm);
     LDFData<int32_t>* chatmode = new LDFData<int32_t>(u"chatmode", gm);
-    
+    LDFData<int64_t>* reputation = new LDFData<int64_t>(u"reputation", 400);
+
     objid->WriteToPacket(&data);
     lot->WriteToPacket(&data);
     name->WriteToPacket(&data);
     gmlevel->WriteToPacket(&data);
     chatmode->WriteToPacket(&data);
     xmlConfigData->WriteToPacket(&data);
+    reputation->WriteToPacket(&data);
     
     delete objid;
     delete lot;
@@ -153,7 +155,8 @@ void WorldPackets::SendCreateCharacter(const SystemAddress& sysAddr, const LWOOB
     delete gmlevel;
     delete chatmode;
     delete name;
-    
+    delete reputation;
+
 #ifdef _WIN32
     bitStream.Write<uint32_t>(data.GetNumberOfBytesUsed() + 1);
     bitStream.Write<uint8_t>(0);

--- a/dNet/WorldPackets.h
+++ b/dNet/WorldPackets.h
@@ -4,6 +4,7 @@
 #include "dCommonVars.h"
 #include <string>
 #include <unordered_map>
+#include "Entity.h"
 
 class User;
 struct SystemAddress;
@@ -16,7 +17,7 @@ namespace WorldPackets {
     void SendCharacterDeleteResponse(const SystemAddress& sysAddr, bool response);
 	void SendTransferToWorld(const SystemAddress& sysAddr, const std::string& serverIP, uint32_t serverPort, bool mythranShift);
 	void SendServerState(const SystemAddress& sysAddr);
-    void SendCreateCharacter(const SystemAddress& sysAddr, const LWOOBJID& objectID, const std::string& xmlData, const std::u16string& username, int32_t gm);
+    void SendCreateCharacter(const SystemAddress& sysAddr, Entity* entity, const std::string& xmlData, const std::u16string& username, int32_t gm);
 	void SendChatModerationResponse(const SystemAddress& sysAddr, bool requestAccepted, uint32_t requestID, const std::string& receiver, std::unordered_map<char, char> unacceptedItems);
     void SendGMLevelChange(const SystemAddress& sysAddr, bool success, uint8_t highestLevel, uint8_t prevLevel, uint8_t newLevel);
 }

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -1013,14 +1013,14 @@ void HandlePacket(Packet* packet) {
                 Character* c = user->GetLastUsedChar();
                 if (c != nullptr) { 
                     std::u16string username = GeneralUtils::ASCIIToUTF16(c->GetName());
-                    WorldPackets::SendCreateCharacter(packet->systemAddress, c->GetObjectID(), c->GetXMLData(), username, c->GetGMLevel());
-                    WorldPackets::SendServerState(packet->systemAddress);
-
 					Game::server->GetReplicaManager()->AddParticipant(packet->systemAddress);
                     
                     EntityInfo info {};
                     info.lot = 1;
 					Entity* player = EntityManager::Instance()->CreateEntity(info, UserManager::Instance()->GetUser(packet->systemAddress));
+
+                    WorldPackets::SendCreateCharacter(packet->systemAddress, player, c->GetXMLData(), username, c->GetGMLevel());
+                    WorldPackets::SendServerState(packet->systemAddress);
 
 					const auto respawnPoint = player->GetCharacter()->GetRespawnPoint(dZoneManager::Instance()->GetZone()->GetWorldID());
 					


### PR DESCRIPTION
This PR allows for reputation to be saved in the charxml and adds backwards compatible checks to initialize the save for old characters that did not have the system.  

Tested the following:
new character doesnt crash when loading in
when saving the attribute is added correctly
when loading a character the reputation is updated in passport
when earning reputation the GM correctly updates it on the client side.