### PR TITLE
Added support to soft delete mail

### DIFF
--- a/migrations/dlu/4_mail_is_deleted_flag.sql
+++ b/migrations/dlu/4_mail_is_deleted_flag.sql
@@ -1,0 +1,1 @@
+ALTER TABLE mail ADD COLUMN is_deleted bool DEFAULT 0;


### PR DESCRIPTION
Added support through a column in the MySQL database to soft delete mail from players so it is kept for moderation purposes.  System mail is still hard deleted however so as to not clog up the database.

Tested sending mail to an offline player, deleting mail from a player, deleting system mail and recieving mail from system and players.  All worked as intended.  

Another migration has been added as well for the DLU database to make the column available.