### PR TITLE
resolved MacOS compilation warnings

### DIFF
--- a/dGame/TradingManager.cpp
+++ b/dGame/TradingManager.cpp
@@ -60,7 +60,7 @@ void Trade::SetCoins(LWOOBJID participant, uint64_t coins)
     {
         m_CoinsA = coins;
     }
-    else if (participant = m_ParticipantB)
+    else if (participant == m_ParticipantB)
     {
         m_CoinsB = coins;
     }
@@ -72,7 +72,7 @@ void Trade::SetItems(LWOOBJID participant, std::vector<TradeItem> items)
     {
         m_ItemsA = items;
     }
-    else if (participant = m_ParticipantB)
+    else if (participant == m_ParticipantB)
     {
         m_ItemsB = items;
     }

--- a/dGame/dComponents/BuffComponent.h
+++ b/dGame/dComponents/BuffComponent.h
@@ -51,7 +51,7 @@ public:
 
     void LoadFromXML(tinyxml2::XMLDocument* doc);
 
-    void UpdateXml(tinyxml2::XMLDocument* doc);
+    void UpdateXml(tinyxml2::XMLDocument* doc) override;
     
     void Serialize(RakNet::BitStream* outBitStream, bool bIsInitialUpdate, unsigned int& flags);
 

--- a/dGame/dComponents/ControllablePhysicsComponent.h
+++ b/dGame/dComponents/ControllablePhysicsComponent.h
@@ -23,7 +23,7 @@ public:
     ControllablePhysicsComponent(Entity* entity);
     ~ControllablePhysicsComponent() override;
     
-    void Update(float deltaTime);
+    void Update(float deltaTime) override;
     void Serialize(RakNet::BitStream* outBitStream, bool bIsInitialUpdate, unsigned int& flags);
     void LoadFromXML(tinyxml2::XMLDocument* doc);
     void ResetFlags();

--- a/dGame/dComponents/MissionComponent.h
+++ b/dGame/dComponents/MissionComponent.h
@@ -29,8 +29,8 @@ public:
 	explicit MissionComponent(Entity* parent);
     ~MissionComponent() override;
     void Serialize(RakNet::BitStream* outBitStream, bool bIsInitialUpdate, unsigned int& flags);
-    void LoadFromXml(tinyxml2::XMLDocument* doc);
-    void UpdateXml(tinyxml2::XMLDocument* doc);
+    void LoadFromXml(tinyxml2::XMLDocument* doc) override;
+    void UpdateXml(tinyxml2::XMLDocument* doc) override;
 
     /**
      * Returns all the missions for this entity, mapped by mission ID

--- a/dGame/dComponents/ModuleAssemblyComponent.h
+++ b/dGame/dComponents/ModuleAssemblyComponent.h
@@ -17,7 +17,7 @@ public:
 	~ModuleAssemblyComponent() override;
 
     void Serialize(RakNet::BitStream* outBitStream, bool bIsInitialUpdate, unsigned int& flags);
-    void Update(float deltaTime);
+    void Update(float deltaTime) override;
 
     /**
      * Sets the subkey of this entity

--- a/dGame/dComponents/MovementAIComponent.h
+++ b/dGame/dComponents/MovementAIComponent.h
@@ -61,7 +61,7 @@ public:
 	MovementAIComponent(Entity* parentEntity, MovementAIInfo info);
 	~MovementAIComponent() override;
 	
-	void Update(float deltaTime);
+	void Update(float deltaTime) override;
 
     /**
      * Returns the basic settings that this entity uses to move around

--- a/dGame/dComponents/VendorComponent.h
+++ b/dGame/dComponents/VendorComponent.h
@@ -19,7 +19,7 @@ public:
 
 	void Serialize(RakNet::BitStream* outBitStream, bool bIsInitialUpdate, unsigned int& flags);
 	
-	void OnUse(Entity* originator);
+	void OnUse(Entity* originator) override;
 	
 	/**
 	 * Gets the buy scaler

--- a/dScripts/AmDrawBridge.h
+++ b/dScripts/AmDrawBridge.h
@@ -7,7 +7,7 @@ public:
     void OnStartup(Entity* self) override;
     void OnUse(Entity* self, Entity* user) override;
     void OnTimerDone(Entity* self, std::string timerName) override;
-    void OnNotifyObject(Entity *self, Entity *sender, const std::string& name, int32_t param1 = 0, int32_t param2 = 0);
+    void OnNotifyObject(Entity *self, Entity *sender, const std::string& name, int32_t param1 = 0, int32_t param2 = 0) override;
 
     void MoveBridgeDown(Entity* self, Entity* bridge, bool down);
     void NotifyDie(Entity* self, Entity* other);

--- a/dScripts/BaseConsoleTeleportServer.cpp
+++ b/dScripts/BaseConsoleTeleportServer.cpp
@@ -25,7 +25,7 @@ void BaseConsoleTeleportServer::BaseOnMessageBoxResponse(Entity* self, Entity* s
 
             if (rocketLaunchComponent == nullptr)
             {
-                rocketLaunchComponent;
+                return;
             }
 
             const auto& teleportZone = self->GetVar<std::u16string>(u"transferZoneID");

--- a/dScripts/GfCampfire.h
+++ b/dScripts/GfCampfire.h
@@ -4,11 +4,11 @@
 class GfCampfire : public CppScripts::Script 
 {
 public:
-	void OnStartup(Entity* self);
+	void OnStartup(Entity* self) override;
 	void OnFireEventServerSide(Entity *self, Entity *sender, std::string args, int32_t param1, int32_t param2,
-                               int32_t param3);
-	void OnProximityUpdate(Entity* self, Entity* entering, std::string name, std::string status);
-	void OnTimerDone(Entity* self, std::string timerName);
+                               int32_t param3) override;
+	void OnProximityUpdate(Entity* self, Entity* entering, std::string name, std::string status) override;
+	void OnTimerDone(Entity* self, std::string timerName) override;
 	void OnSkillEventFired(Entity *self, Entity *caster, const std::string &message) override;
 private:
 	int32_t m_skillCastId = 43;


### PR DESCRIPTION
Resolved numerous compilation warnings on MacOS and also fixed a couple of errors:
Numerous missing overrides for overridden functions
Trading manager was doing an assignment instead of a comparison for some reason so this has been fixed.
BaseConsoleTeleportServer was not returning should the RocketLaunchpadComponents be null.  This has been resolved.