### PR TITLE
fixed out of context log for launching to properties

### DIFF
--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -3238,11 +3238,11 @@ void GameMessages::HandleClientTradeRequest(RakNet::BitStream* inStream, Entity*
 
 void GameMessages::HandleClientTradeCancel(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr)
 {
-	Game::logger->Log("GameMessages", "Trade canceled from (%llu)\n", entity->GetObjectID());
-
 	auto* trade = TradingManager::Instance()->GetPlayerTrade(entity->GetObjectID());
 	
 	if (trade == nullptr) return;
+
+	Game::logger->Log("GameMessages", "Trade canceled from (%llu)\n", entity->GetObjectID());
 
 	TradingManager::Instance()->CancelTrade(trade->GetTradeId());
 }


### PR DESCRIPTION
For some reason when entering a property, the client send a cancelled trade GM to the server which causes a log to be printed out of context. This PR just moved the log so it happens after we check if a trade exists.