### PR TITLE
Addressed proxy items removing skills

### DIFF
--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -1229,18 +1229,18 @@ void InventoryComponent::AddItemSkills(const LOT lot)
 	
 	const auto index = m_Skills.find(slot);
 
-	if (index != m_Skills.end())
-	{
-		const auto old = index->second;
-		
-		GameMessages::SendRemoveSkill(m_Parent, old);
-	}
-
 	const auto skill = FindSkill(lot);
 
 	if (skill == 0)
 	{
 		return;
+	}
+
+	if (index != m_Skills.end())
+	{
+		const auto old = index->second;
+		
+		GameMessages::SendRemoveSkill(m_Parent, old);
 	}
 	
 	GameMessages::SendAddSkill(m_Parent, skill, static_cast<int>(slot));


### PR DESCRIPTION
When equipping an item that has proxies, previously, we would check if the slot had a skill and remove it first, before even checking if we have a skill to overwrite that slot.  Now we check that we have a skill to put in a slot _first_ before checking if we should remove the skill from a slot.
Fixes #168 
Fixes #438 
Tested by equipping and unequipping the following items:
equipped all trial faction sets 1 after another, then equipping various faction gear sets 1 piece at a time.  Also tested travelling between worlds with proxy items equipped to make sure we were given the skills correctly.  Had no issues on my end and was able to use skills as intended