### PR TITLE
Added migration for plunger gun

### DIFF
--- a/migrations/cdserver/3_plunger_gun_fix.sql
+++ b/migrations/cdserver/3_plunger_gun_fix.sql
@@ -1,1 +1,2 @@
+-- File added April 9th, 2022
 UPDATE ItemComponent SET itemType = 5 where id = 7082;

--- a/migrations/cdserver/3_plunger_gun_fix.sql
+++ b/migrations/cdserver/3_plunger_gun_fix.sql
@@ -1,0 +1,1 @@
+UPDATE ItemComponent SET itemType = 5 where id = 7082;


### PR DESCRIPTION
The plunger gun in the database states it currently is a "RightHand" item type however its equipLocation is stated as "special_l".  After discussion with @Xiphoseer we determined this is likely a cdclient error and have created a migration in the cdserver migrations to address the issue.  Tested change with #496 and the plunger gun correctly acted as a left hand item and was put into the correct usage slot.