### PR TITLE
Dramatically speed up server shutdown and specify database destruction source in logging message

### DIFF
--- a/dAuthServer/AuthServer.cpp
+++ b/dAuthServer/AuthServer.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
         Database::Connect(mysql_host, mysql_database, mysql_username, mysql_password);
     } catch (sql::SQLException& ex) {
 		Game::logger->Log("AuthServer", "Got an error while connecting to the database: %s\n", ex.what());
-		Database::Destroy();
+		Database::Destroy("AuthServer");
 		delete Game::server;
 		delete Game::logger;
 		return 0;
@@ -143,7 +143,7 @@ int main(int argc, char** argv) {
 	}
 
 	//Delete our objects here:
-	Database::Destroy();
+	Database::Destroy("AuthServer");
 	delete Game::server;
 	delete Game::logger;
 

--- a/dAuthServer/AuthServer.cpp
+++ b/dAuthServer/AuthServer.cpp
@@ -147,7 +147,8 @@ int main(int argc, char** argv) {
 	delete Game::server;
 	delete Game::logger;
 
-	return 0;
+	exit(EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }
 
 dLogger * SetupLogger() {

--- a/dChatServer/ChatServer.cpp
+++ b/dChatServer/ChatServer.cpp
@@ -61,7 +61,7 @@ int main(int argc, char** argv) {
 	}
 	catch (sql::SQLException& ex) {
 		Game::logger->Log("ChatServer", "Got an error while connecting to the database: %s\n", ex.what());
-		Database::Destroy();
+		Database::Destroy("ChatServer");
 		delete Game::server;
 		delete Game::logger;
 		return 0;
@@ -150,7 +150,7 @@ int main(int argc, char** argv) {
 	}
 
 	//Delete our objects here:
-	Database::Destroy();
+	Database::Destroy("ChatServer");
 	delete Game::server;
 	delete Game::logger;
 

--- a/dChatServer/ChatServer.cpp
+++ b/dChatServer/ChatServer.cpp
@@ -154,7 +154,8 @@ int main(int argc, char** argv) {
 	delete Game::server;
 	delete Game::logger;
 
-	return 0;
+	exit(EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }
 
 dLogger * SetupLogger() {

--- a/dDatabase/Database.cpp
+++ b/dDatabase/Database.cpp
@@ -26,9 +26,10 @@ void Database::Connect(const string& host, const string& database, const string&
 	con->setClientOption("MYSQL_OPT_RECONNECT", &myTrue);
 } //Connect
 
-void Database::Destroy() {
+void Database::Destroy(std::string source) {
 	if (!con) return;
-	Game::logger->Log("Database", "Destroying MySQL connection!\n");
+	if (source != "") Game::logger->Log("Database", "Destroying MySQL connection from %s!\n", source.c_str());
+	else Game::logger->Log("Database", "Destroying MySQL connection!\n");
 	con->close();
 	delete con;
 } //Destroy

--- a/dDatabase/Database.h
+++ b/dDatabase/Database.h
@@ -22,7 +22,7 @@ private:
 
 public:
 	static void Connect(const std::string& host, const std::string& database, const std::string& username, const std::string& password);
-	static void Destroy();
+	static void Destroy(std::string source="");
 	static sql::Statement* CreateStmt();
 	static sql::PreparedStatement* CreatePreppedStmt(const std::string& query);
 };

--- a/dGame/dComponents/PropertyManagementComponent.h
+++ b/dGame/dComponents/PropertyManagementComponent.h
@@ -161,6 +161,8 @@ public:
      */
 	const std::map<LWOOBJID, LWOOBJID>& GetModels() const;
 	
+    LWOCLONEID GetCloneId() { return clone_Id; };
+
 private:
     /**
      * This

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -47,6 +47,7 @@ namespace Game {
 
 bool shutdownSequenceStarted = false;
 void ShutdownSequence();
+int FinalizeShutdown();
 dLogger* SetupLogger();
 void StartAuthServer();
 void StartChatServer();
@@ -168,7 +169,7 @@ int main(int argc, char** argv) {
 
 		std::cout << "Account created successfully!\n";
 
-		Database::Destroy();
+		Database::Destroy("MasterServer");
 		delete Game::logger;
 
 		return EXIT_SUCCESS;
@@ -318,14 +319,8 @@ int main(int argc, char** argv) {
 		t += std::chrono::milliseconds(highFrameRate);
 		std::this_thread::sleep_until(t);
 	}
-
-	//Delete our objects here:
-	Database::Destroy();
-	delete Game::im;
-	delete Game::server;
-	delete Game::logger;
-
-	return EXIT_SUCCESS;
+	FinalizeShutdown();
+	exit(0);
 }
 
 dLogger* SetupLogger() {
@@ -786,6 +781,16 @@ void ShutdownSequence() {
 			break;
 		}
 	}
+
+	FinalizeShutdown();
+}
+
+int FinalizeShutdown() {
+	//Delete our objects here:
+	Database::Destroy("MasterServer");
+	delete Game::im;
+	delete Game::server;
+	delete Game::logger;
 
 	exit(0);
 }

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -320,7 +320,8 @@ int main(int argc, char** argv) {
 		std::this_thread::sleep_until(t);
 	}
 	FinalizeShutdown();
-	exit(0);
+	exit(EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }
 
 dLogger* SetupLogger() {
@@ -740,7 +741,7 @@ void ShutdownSequence() {
 	auto ticks = 0;
 
 	if (!Game::im) {
-		exit(0);
+		exit(EXIT_SUCCESS);
 	}
 
 	Game::logger->Log("MasterServer", "Attempting to shutdown instances, max 60 seconds...\n");
@@ -792,5 +793,6 @@ int FinalizeShutdown() {
 	delete Game::server;
 	delete Game::logger;
 
-	exit(0);
+	exit(EXIT_SUCCESS);
+	return EXIT_SUCCESS;
 }

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -660,7 +660,7 @@ void HandlePacket(Packet* packet) {
 			RakNet::BitStream inStream(packet->data, packet->length, false);
 			uint64_t header = inStream.Read(header);
 
-			auto* instance =Game::im->GetInstanceBySysAddr(packet->systemAddress);
+			auto* instance = Game::im->GetInstanceBySysAddr(packet->systemAddress);
 
 			if (instance == nullptr) {
 				return;

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -768,7 +768,7 @@ void ShutdownSequence() {
 		}
 
 		if (done) {
-			Game::logger->Log("MasterServer", "Finished shutting down naturally!\n");
+			Game::logger->Log("MasterServer", "Finished shutting down MasterServer!\n");
 			break;
 		}
 

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -751,6 +751,14 @@ void ShutdownSequence() {
 	Game::logger->Log("MasterServer", "Attempting to shutdown instances, max 60 seconds...\n");
 
 	while (true) {
+
+		auto packet = Game::server->Receive();
+		if (packet) {
+			HandlePacket(packet);
+			Game::server->DeallocatePacket(packet);
+			packet = nullptr;
+		}
+		
 		auto done = true;
 
 		for (auto* instance : Game::im->GetInstances()) {
@@ -764,6 +772,7 @@ void ShutdownSequence() {
 		}
 
 		if (done) {
+			Game::logger->Log("MasterServer", "Finished shutting down naturally!\n");
 			break;
 		}
 
@@ -773,6 +782,7 @@ void ShutdownSequence() {
 		ticks++;
 
 		if (ticks == 600 * 6) {
+			Game::logger->Log("MasterServer", "Finished shutting down by timeout!\n");
 			break;
 		}
 	}

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -1241,12 +1241,12 @@ void WorldShutdownProcess(uint32_t zoneId) {
     }
 
     if (PropertyManagementComponent::Instance() != nullptr) {
-        Game::logger->Log("WorldServer", "Saving ALL property data!\n");
+        Game::logger->Log("WorldServer", "Saving ALL property data for zone %i clone %i!\n", zoneId, PropertyManagementComponent::Instance()->GetCloneId());
         PropertyManagementComponent::Instance()->Save();
-        Game::logger->Log("WorldServer", "ALL property data saved!\n");
+        Game::logger->Log("WorldServer", "ALL property data saved for zone %i clone %i!\n", zoneId, PropertyManagementComponent::Instance()->GetCloneId());
     }
 
-    Game::logger->Log("WorldServer", "ALL DATA HAS BEEN SAVED!\n");
+    Game::logger->Log("WorldServer", "ALL DATA HAS BEEN SAVED FOR ZONE %i INSTANCE %i!\n", zoneId, instanceID);
 
     while (Game::server->GetReplicaManager()->GetParticipantCount() > 0) {
         const auto& player = Game::server->GetReplicaManager()->GetParticipantAtIndex(0);

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -522,10 +522,6 @@ int main(int argc, char** argv) {
 				CBITSTREAM;
 				PacketUtils::WriteHeader(bitStream, MASTER, MSG_MASTER_SHUTDOWN_RESPONSE);
 				Game::server->SendToMaster(&bitStream);
-			}
-			
-			if (framesSinceShutdownSequence == 300)
-			{
 				break;
 			}
 		}

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -1219,7 +1219,6 @@ void HandlePacket(Packet* packet) {
 }
 
 void WorldShutdownProcess(uint32_t zoneId) {
-    ChatPackets::SendSystemMessage(UNASSIGNED_SYSTEM_ADDRESS, u"Server shutting down...", true);
 	Game::logger->Log("WorldServer", "Saving map %i instance %i\n", zoneId, instanceID);
     for (auto i = 0; i < Game::server->GetReplicaManager()->GetParticipantCount(); ++i) {
         const auto& player = Game::server->GetReplicaManager()->GetParticipantAtIndex(i);
@@ -1263,7 +1262,7 @@ void WorldShutdownSequence() {
 
     worldShutdownSequenceStarted = true;
 
-    Game::logger->Log("WorldServer", "Attempting to shutdown world, zone (%i), instance (%i), max 10 seconds...\n", Game::server->GetZoneID(), instanceID);
+    Game::logger->Log("WorldServer", "Zone (%i) instance (%i) shutting down outside of main loop!\n", Game::server->GetZoneID(), instanceID);
     WorldShutdownProcess(Game::server->GetZoneID());
 	FinalizeShutdown();
 }

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -77,7 +77,7 @@ bool chatConnected = false;
 bool worldShutdownSequenceStarted = false;
 bool worldShutdownSequenceComplete = false;
 void WorldShutdownSequence();
-void WorldShutdownProcess(uint32_t cloneId);
+void WorldShutdownProcess(uint32_t zoneId);
 void FinalizeShutdown();
 void SendShutdownMessageToMaster();
 


### PR DESCRIPTION
This PRs main focus is to dramatically speed up server shutdown time.  The main issue was MasterServer was never listening for the packets from the spawned servers that they were finished shutting down, so MasterServer always shutdown via timeout.  WorldServer also was purposely delaying its shutdown by 10 seconds which does not seem necessary.  All servers now correctly shutdown as soon as they are able to without delay, speeding up development efforts.  
A smaller side addition is that when calling Database::Destroy();, a specifier is now passed to say what the source of the destruction is.  Example logs of a shutdown through ctrl + c on property while in edit mode are below.
Fixes #361
Tested shutting down the server with ctrl+c while being in edit mode on a property with newly earned items and all data was saved as expected.  No servers hard crashed and all exited gracefully.

```^C[09-04-22 16:10:04] [WorldServer] Attempting to shutdown world, zone (1000), instance (1), max 10 seconds...
[09-04-22 16:10:04] [WorldServer] Attempting to shutdown world, zone (0), instance (0), max 10 seconds...
[09-04-22 16:10:04] [WorldServer] Attempting to shutdown world, zone (1250), instance (2), max 10 seconds...
[09-04-22 16:10:04] [Instance] Triggered world shutdown
[09-04-22 16:10:04] [WorldServer] ALL DATA HAS BEEN SAVED!
[09-04-22 16:10:04] [Instance] Triggered world shutdown
[09-04-22 16:10:04] [WorldServer] Shutdown complete, zone (0), instance (0)
[09-04-22 16:10:04] [Instance] Triggered world shutdown
[09-04-22 16:10:04] [Database] Destroying MySQL connection from WorldServer!
[09-04-22 16:10:04] [MasterServer] Saved ObjectIDTracker to DB
[09-04-22 16:10:04] [MasterServer] Attempting to shutdown instances, max 60 seconds...
[09-04-22 16:10:04] [WorldServer] ALL DATA HAS BEEN SAVED!
[09-04-22 16:10:04] [WorldServer] Shutdown complete, zone (1000), instance (1)
[09-04-22 16:10:04] [Database] Destroying MySQL connection from WorldServer!
[09-04-22 16:10:04] [WorldServer] Saving data!
[09-04-22 16:10:04] [WorldServer] Saving character PrimJoyousGiant...
[09-04-22 16:10:04] [TotalTimePlayed] Time since last save: 13
[09-04-22 16:10:04] [MasterServer] Got shutdown response
[09-04-22 16:10:04] [Character] Saved character to Database in: 0.007616s
[09-04-22 16:10:04] [WorldServer] Character data for PrimJoyousGiant was saved!
[09-04-22 16:10:04] [WorldServer] Saving ALL property data!
[09-04-22 16:10:04] [WorldServer] ALL property data saved!
[09-04-22 16:10:04] [WorldServer] ALL DATA HAS BEEN SAVED!
[09-04-22 16:10:04] [WorldServer] Shutdown complete, zone (1250), instance (2)
[09-04-22 16:10:04] [Database] Destroying MySQL connection from WorldServer!
[09-04-22 16:10:04] [MasterServer] Got shutdown response
[09-04-22 16:10:04] [MasterServer] Got shutdown response
[09-04-22 16:10:04] [MasterServer] Finished shutting down MasterServer!
[09-04-22 16:10:04] [Database] Destroying MySQL connection from MasterServer!
emosewamc@DESKTOP-000000:/mnt/d/Documents/GitHub/DarkflameServer/build$ [09-04-22 16:10:04] [dServer] Lost our connection to master, shutting DOWN!
[09-04-22 16:10:04] [dServer] Lost our connection to master, shutting DOWN!
[09-04-22 16:10:05] [Database] Destroying MySQL connection from ChatServer!
[09-04-22 16:10:05] [Database] Destroying MySQL connection from AuthServer!```