### PR TITLE
Prevent integer underflow in item removal

### DIFF
--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -5441,7 +5441,7 @@ void GameMessages::HandleRemoveItemFromInventory(RakNet::BitStream* inStream, En
 			}
 		}
 
-		item->SetCount(item->GetCount() - iStackCount, true);
+		item->SetCount(item->GetCount() - std::min<uint32_t>(item->GetCount(), iStackCount), true);
 		EntityManager::Instance()->SerializeEntity(entity);
 
 		auto* missionComponent = entity->GetComponent<MissionComponent>();

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -5433,6 +5433,8 @@ void GameMessages::HandleRemoveItemFromInventory(RakNet::BitStream* inStream, En
 		return;
 	}
 	
+	iStackCount = std::min<uint32_t>(item->GetCount(), iStackCount);
+	
 	if (bConfirmed) {
 		for (auto i = 0; i < iStackCount; ++i) {
 			if (eInvType == eInventoryType::MODELS)
@@ -5441,14 +5443,14 @@ void GameMessages::HandleRemoveItemFromInventory(RakNet::BitStream* inStream, En
 			}
 		}
 
-		item->SetCount(item->GetCount() - std::min<uint32_t>(item->GetCount(), iStackCount), true);
+		item->SetCount(item->GetCount() - iStackCount, true);
 		EntityManager::Instance()->SerializeEntity(entity);
 
 		auto* missionComponent = entity->GetComponent<MissionComponent>();
 		
 		if (missionComponent != nullptr)
 		{
-			missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_ITEM_COLLECTION, item->GetLot(), LWOOBJID_EMPTY, "", -std::min<uint32_t>(item->GetCount(), iStackCount));
+			missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_ITEM_COLLECTION, item->GetLot(), LWOOBJID_EMPTY, "", -iStackCount);
 		}
 	}
 }

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -5448,7 +5448,7 @@ void GameMessages::HandleRemoveItemFromInventory(RakNet::BitStream* inStream, En
 		
 		if (missionComponent != nullptr)
 		{
-			missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_ITEM_COLLECTION, item->GetLot(), LWOOBJID_EMPTY, "", -iStackCount);
+			missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_ITEM_COLLECTION, item->GetLot(), LWOOBJID_EMPTY, "", -std::min<uint32_t>(item->GetCount(), iStackCount);
 		}
 	}
 }

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -5448,7 +5448,7 @@ void GameMessages::HandleRemoveItemFromInventory(RakNet::BitStream* inStream, En
 		
 		if (missionComponent != nullptr)
 		{
-			missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_ITEM_COLLECTION, item->GetLot(), LWOOBJID_EMPTY, "", -std::min<uint32_t>(item->GetCount(), iStackCount);
+			missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_ITEM_COLLECTION, item->GetLot(), LWOOBJID_EMPTY, "", -std::min<uint32_t>(item->GetCount(), iStackCount));
 		}
 	}
 }


### PR DESCRIPTION
Previously, the only check that the user wasn't trashing more items than they had was clientsided, and this could be bypassed by contacting the server to remove items via a console or the like, and then trashing them before the server could respond, resulting in the count for the items being less than iStackCount. This check prevents that underflow.