### PR TITLE
Addressed vault issues

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -2173,3 +2173,15 @@ void Entity::AddToGroup(const std::string& group) {
         m_Groups.push_back(group);
     }
 }
+
+void Entity::RetroactiveVaultSize() {
+	auto inventoryComponent = GetComponent<InventoryComponent>();
+	if (!inventoryComponent) return;
+
+	auto itemsVault = inventoryComponent->GetInventory(eInventoryType::VAULT_ITEMS);
+	auto modelVault = inventoryComponent->GetInventory(eInventoryType::VAULT_MODELS);
+
+	if (itemsVault->GetSize() == modelVault->GetSize()) return;
+
+	modelVault->SetSize(itemsVault->GetSize());
+}

--- a/dGame/Entity.h
+++ b/dGame/Entity.h
@@ -220,7 +220,11 @@ public:
 	/*
 	 * Utility
 	 */
-
+	/**
+	 * Retroactively corrects the model vault size due to incorrect initialization in a previous patch.
+	 * 
+	 */
+	void RetroactiveVaultSize();
 	bool GetBoolean(const std::u16string& name) const;
 	int32_t GetI32(const std::u16string& name) const;
 	int64_t GetI64(const std::u16string& name) const;

--- a/dGame/UserManager.cpp
+++ b/dGame/UserManager.cpp
@@ -291,7 +291,7 @@ void UserManager::CreateCharacter(const SystemAddress& sysAddr, Packet* packet) 
         xml << "ls=\"0\" lzx=\"-626.5847\" lzy=\"613.3515\" lzz=\"-28.6374\" lzrx=\"0.0\" lzry=\"0.7015\" lzrz=\"0.0\" lzrw=\"0.7126\" ";
         xml << "stt=\"0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;0;\"></char>";
         xml << "<dest hm=\"4\" hc=\"4\" im=\"0\" ic=\"0\" am=\"0\" ac=\"0\" d=\"0\"/>";
-        xml << "<inv><bag><b t=\"0\" m=\"20\"/><b t=\"1\" m=\"240\"/><b t=\"2\" m=\"240\"/><b t=\"3\" m=\"240\"/></bag><items><in t=\"0\">";
+        xml << "<inv><bag><b t=\"0\" m=\"20\"/><b t=\"1\" m=\"40\"/><b t=\"2\" m=\"240\"/><b t=\"3\" m=\"240\"/><b t=\"14\" m=\"40\"/></bag><items><in t=\"0\">";
         std::string xmlSave1 = xml.str();
         
         ObjectIDManager::Instance()->RequestPersistentID([=](uint32_t idforshirt) {

--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -84,6 +84,7 @@ Inventory* InventoryComponent::GetInventory(const eInventoryType type)
 	case eInventoryType::ITEMS:
 		size = 20u;
 		break;
+	case eInventoryType::VAULT_MODELS:
 	case eInventoryType::VAULT_ITEMS:
 		size = 40u;
 		break;

--- a/dGame/dMission/Mission.cpp
+++ b/dGame/dMission/Mission.cpp
@@ -511,9 +511,11 @@ void Mission::YieldRewards() {
     }
 
     if (info->reward_bankinventory > 0) {
-        auto* inventory = inventoryComponent->GetInventory(VAULT_ITEMS);
+        auto* inventory = inventoryComponent->GetInventory(eInventoryType::VAULT_ITEMS);
+        auto modelInventory = inventoryComponent->GetInventory(eInventoryType::VAULT_MODELS);
 
         inventory->SetSize(inventory->GetSize() + info->reward_bankinventory);
+        modelInventory->SetSize(modelInventory->GetSize() + info->reward_bankinventory);
     }
 
     if (info->reward_reputation > 0) {

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -975,6 +975,8 @@ void HandlePacket(Packet* packet) {
 					player->GetComponent<CharacterComponent>()->SetLastRocketConfig(u"");
 					
 					c->SetRetroactiveFlags();
+					
+					player->RetroactiveVaultSize();
 
 					player->GetCharacter()->SetTargetScene("");
 


### PR DESCRIPTION
Addressed a couple of issues with vaults:
1) The players item vault was being initialized to the incorrect size.  According to live data, the player started with 40 slots in the vault for models and items, not 240 for items and 40 for models.
2) Earning bank inventory slots previously did not increase the number of model vault space you had.  This has been corrected and the player now correctly earns model inventory slots for completing bank missions.
3) A retroactive check has been added to ensure the the model vault size matches the item vault size.  

Tested creating a new character and opening the vault and then completing various vault missions that granted size to the vault and the size was updated to all correctly.