### PR TITLE
Fixed Racing Missions Try, Try again and Race Series 1

### DIFF
--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -410,10 +410,13 @@ void RacingControlComponent::HandleMessageBoxResponse(Entity *player,
         // If solo racing is enabled OR if there are 3 players in the race, progress placement tasks.
         if(m_SoloRacing || m_LoadedPlayers > 2) {
             missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_RACING, data->finished, (LWOOBJID)RacingTaskParam::RACING_TASK_PARAM_FINISH_WITH_PLACEMENT); // Finish in 1st place on a race
-            missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_RACING, data->finished, (LWOOBJID)RacingTaskParam::RACING_TASK_PARAM_FIRST_PLACE_MULTIPLE_TRACKS); // Finish in 1st place on multiple tracks.
-            if(m_Finished != 1) return;
-            missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_RACING, dZoneManager::Instance()->GetZone()->GetWorldID(), (LWOOBJID)RacingTaskParam::RACING_TASK_PARAM_WIN_RACE_IN_WORLD); // Finished first place in specific world.
-            
+            if(data->finished == 1) {
+                missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_RACING, dZoneManager::Instance()->GetZone()->GetWorldID(), (LWOOBJID)RacingTaskParam::RACING_TASK_PARAM_FIRST_PLACE_MULTIPLE_TRACKS); // Finish in 1st place on multiple tracks.
+                missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_RACING, dZoneManager::Instance()->GetZone()->GetWorldID(), (LWOOBJID)RacingTaskParam::RACING_TASK_PARAM_WIN_RACE_IN_WORLD); // Finished first place in specific world.
+            }
+            if (data->finished == m_LoadedPlayers) {
+                missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_RACING, dZoneManager::Instance()->GetZone()->GetWorldID(), (LWOOBJID)RacingTaskParam::RACING_TASK_PARAM_LAST_PLACE_FINISH); // Finished first place in specific world.
+            }
         }
     } else if (id == "ACT_RACE_EXIT_THE_RACE?" || id == "Exit") {
         auto *vehicle = EntityManager::Instance()->GetEntity(data->vehicleID);

--- a/dGame/dMission/MissionTask.cpp
+++ b/dGame/dMission/MissionTask.cpp
@@ -183,7 +183,13 @@ bool MissionTask::InParameters(const uint32_t value) const
 
 bool MissionTask::IsComplete() const
 {
-	return progress >= info->targetValue;
+	// Mission 668 has task uid 984 which is a bit mask.  Its completion value is 3.
+	if (info->uid == 984) {
+		return progress >= 3;
+	}
+	else {
+		return progress >= info->targetValue;
+	}
 }
 
 
@@ -423,11 +429,22 @@ void MissionTask::Progress(int32_t value, LWOOBJID associate, const std::string&
 
 		if (parameters[0] != associate) break;
 
-		if (associate == 1 || associate == 15 || associate == 2 || associate == 3)
+		if (associate == 1 || associate == 2 || associate == 3)
 		{
 			if (value > info->targetValue) break;
 
 			AddProgress(info->targetValue);
+		}
+		// task 15 is a bit mask!
+		else if (associate == 15) {
+			if (!InAllTargets(value)) break;
+
+			auto tempProgress = GetProgress();
+			// If we won at Nimbus Station, set bit 0
+			if (value == 1203) SetProgress(tempProgress |= 1 << 0);
+			// If we won at Gnarled Forest, set bit 1
+			else if (value == 1303) SetProgress(tempProgress |= 1 << 1);
+			// If both bits are set, then the client sees the mission as complete.
 		}
 		else if (associate == 10)
 		{


### PR DESCRIPTION
* Try, Try Again achievement now progresses when the player gets last place in a race of 3 or more players, or when solo racing is enabled.
* Race Series 1 mission from Velocity Lane now progresses correctly.

Tested all changes on a local WSL instance.  Missions progressed as intended from my testing.  Try, Try again checks whether your placing is equal to the number of players loaded(aka last place) Race Series 1 is a bitmask and has some funky checks and logic to make it work, but it works now.
Fixes #501 