### PR TITLE
Fix solo_racing for Frostburgh's Space Blizzard Racetrack

### DIFF
--- a/dGame/dComponents/ScriptedActivityComponent.cpp
+++ b/dGame/dComponents/ScriptedActivityComponent.cpp
@@ -28,7 +28,7 @@ ScriptedActivityComponent::ScriptedActivityComponent(Entity* parent, int activit
 
         const auto mapID = m_ActivityInfo.instanceMapID;
 
-        if ((mapID == 1203 || mapID == 1303 || mapID == 1403) && Game::config->GetValue("solo_racing") == "1") {
+        if ((mapID == 1203 || mapID == 1261 || mapID == 1303 || mapID == 1403) && Game::config->GetValue("solo_racing") == "1") {
             m_ActivityInfo.minTeamSize = 1;
             m_ActivityInfo.minTeams = 1;
         }


### PR DESCRIPTION
This pull request fixes solo_racing for Frostburgh's Space Blizzard Racetrack by adding the mapID 1261 to line 31 in ScriptedActivityComponent.cpp. The mapID was taken from here: https://github.com/DarkflameUniverse/DarkflameServer/pull/508/files#diff-37c34a25fc8323cfd31309141b8efee4e67be125b7b0f51fe41b08c244a5f82bR56. Previously enabling solo_racing only affected all other racetracks and not Frostburgh's Space Blizzard Racetrack.

The pull request was tested on a remote Ubuntu server with Frostburgh and Space Blizzard added to cdclient.fdb and CDServer.sqlite.

![image](https://user-images.githubusercontent.com/35848058/163989220-5ab13c4b-473b-409b-90d0-682573362eac.png)