### PR TITLE
Pop up now appears for life containers

### DIFF
--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -215,6 +215,8 @@ void DestroyableComponent::SetHealth(int32_t value) {
 
 void DestroyableComponent::SetMaxHealth(float value, bool playAnim) {
 	m_DirtyHealth = true;
+	// Used for playAnim if opted in for.
+	int32_t difference = static_cast<int32_t>(std::abs(m_fMaxHealth - value));
 	m_fMaxHealth = value;
 
 	if (m_iHealth > m_fMaxHealth) {
@@ -225,22 +227,21 @@ void DestroyableComponent::SetMaxHealth(float value, bool playAnim) {
 		// Now update the player bar
 		if (!m_Parent->GetParentUser()) return;
 		AMFStringValue* amount = new AMFStringValue();
-		amount->SetStringValue(std::to_string(value));
+		amount->SetStringValue(std::to_string(difference));
 		AMFStringValue* type = new AMFStringValue();
 		type->SetStringValue("health");
 
 		AMFArrayValue args;
 		args.InsertValue("amount", amount);
 		args.InsertValue("type", type);
-
+		Game::logger->Log("DestComp", "Setting max health diff %i\n", difference);
 		GameMessages::SendUIMessageServerToSingleClient(m_Parent, m_Parent->GetParentUser()->GetSystemAddress(), "MaxPlayerBarUpdate", &args);
 	
 		delete amount;
 		delete type;
 	}
-	else {
-		EntityManager::Instance()->SerializeEntity(m_Parent);
-	}
+
+	EntityManager::Instance()->SerializeEntity(m_Parent);
 }
 
 void DestroyableComponent::SetArmor(int32_t value) {
@@ -287,9 +288,8 @@ void DestroyableComponent::SetMaxArmor(float value, bool playAnim) {
 		delete amount;
 		delete type;
 	}
-	else {
-		EntityManager::Instance()->SerializeEntity(m_Parent);
-	}
+
+	EntityManager::Instance()->SerializeEntity(m_Parent);
 }
 
 void DestroyableComponent::SetImagination(int32_t value) {
@@ -310,6 +310,8 @@ void DestroyableComponent::SetImagination(int32_t value) {
 
 void DestroyableComponent::SetMaxImagination(float value, bool playAnim) {
     m_DirtyHealth = true;
+	// Used for playAnim if opted in for.
+	int32_t difference = static_cast<int32_t>(std::abs(m_fMaxImagination - value));
     m_fMaxImagination = value;
 
 	if (m_iImagination > m_fMaxImagination) {
@@ -320,22 +322,20 @@ void DestroyableComponent::SetMaxImagination(float value, bool playAnim) {
 		// Now update the player bar
 		if (!m_Parent->GetParentUser()) return;
 		AMFStringValue* amount = new AMFStringValue();
-		amount->SetStringValue(std::to_string(value));
+		amount->SetStringValue(std::to_string(difference));
 		AMFStringValue* type = new AMFStringValue();
 		type->SetStringValue("imagination");
 
 		AMFArrayValue args;
 		args.InsertValue("amount", amount);
 		args.InsertValue("type", type);
-
+		Game::logger->Log("DestComp", "Setting max imagiantion diff %i\n", difference);
 		GameMessages::SendUIMessageServerToSingleClient(m_Parent, m_Parent->GetParentUser()->GetSystemAddress(), "MaxPlayerBarUpdate", &args);
 	
 		delete amount;
 		delete type;
 	}
-	else {
-		EntityManager::Instance()->SerializeEntity(m_Parent);
-	}
+	EntityManager::Instance()->SerializeEntity(m_Parent);
 }
 
 void DestroyableComponent::SetDamageToAbsorb(int32_t value)

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -234,7 +234,6 @@ void DestroyableComponent::SetMaxHealth(float value, bool playAnim) {
 		AMFArrayValue args;
 		args.InsertValue("amount", amount);
 		args.InsertValue("type", type);
-		Game::logger->Log("DestComp", "Setting max health diff %i\n", difference);
 		GameMessages::SendUIMessageServerToSingleClient(m_Parent, m_Parent->GetParentUser()->GetSystemAddress(), "MaxPlayerBarUpdate", &args);
 	
 		delete amount;
@@ -329,7 +328,6 @@ void DestroyableComponent::SetMaxImagination(float value, bool playAnim) {
 		AMFArrayValue args;
 		args.InsertValue("amount", amount);
 		args.InsertValue("type", type);
-		Game::logger->Log("DestComp", "Setting max imagiantion diff %i\n", difference);
 		GameMessages::SendUIMessageServerToSingleClient(m_Parent, m_Parent->GetParentUser()->GetSystemAddress(), "MaxPlayerBarUpdate", &args);
 	
 		delete amount;

--- a/dGame/dMission/Mission.cpp
+++ b/dGame/dMission/Mission.cpp
@@ -528,11 +528,11 @@ void Mission::YieldRewards() {
     }
 
     if (info->reward_maxhealth > 0) {
-        destroyableComponent->SetMaxHealth(destroyableComponent->GetMaxHealth() + static_cast<float>(info->reward_maxhealth));
+        destroyableComponent->SetMaxHealth(destroyableComponent->GetMaxHealth() + static_cast<float>(info->reward_maxhealth), true);
     }
 
     if (info->reward_maximagination > 0) {
-        destroyableComponent->SetMaxImagination(destroyableComponent->GetMaxImagination() + static_cast<float>(info->reward_maximagination));
+        destroyableComponent->SetMaxImagination(destroyableComponent->GetMaxImagination() + static_cast<float>(info->reward_maximagination), true);
     }
 
     EntityManager::Instance()->SerializeEntity(entity);


### PR DESCRIPTION
The popup for earning a life container in live now shows up.  The one for imagination does as well, however due to a client bug it doesnt show up on re-logs.