### PR TITLE
Skill Task changes (also fixes Spinjitzu Initiate)

### DIFF
--- a/dGame/dBehaviors/BasicAttackBehavior.cpp
+++ b/dGame/dBehaviors/BasicAttackBehavior.cpp
@@ -14,7 +14,7 @@ void BasicAttackBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bi
 		auto* destroyableComponent = entity->GetComponent<DestroyableComponent>();
 		if (destroyableComponent != nullptr) {
 			PlayFx(u"onhit", entity->GetObjectID());
-			destroyableComponent->Damage(this->m_maxDamage, context->originator);
+			destroyableComponent->Damage(this->m_maxDamage, context->originator, context->skillID);
 		}
 
 		this->m_onSuccess->Handle(context, bitStream, branch);
@@ -56,7 +56,7 @@ void BasicAttackBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bi
 		    auto* destroyableComponent = entity->GetComponent<DestroyableComponent>();
 			if (destroyableComponent != nullptr) {
 				PlayFx(u"onhit", entity->GetObjectID());
-				destroyableComponent->Damage(damageDealt, context->originator);
+				destroyableComponent->Damage(damageDealt, context->originator, context->skillID);
 			}
 		}
 	}
@@ -113,7 +113,7 @@ void BasicAttackBehavior::Calculate(BehaviorContext* context, RakNet::BitStream*
 			auto* destroyableComponent = entity->GetComponent<DestroyableComponent>();
 			if (damage != 0 && destroyableComponent != nullptr) {
 				PlayFx(u"onhit", entity->GetObjectID(), 1);
-                destroyableComponent->Damage(damage, context->originator, false);
+                destroyableComponent->Damage(damage, context->originator, context->skillID, false);
 				context->ScheduleUpdate(branch.target);
 			}
 		}

--- a/dGame/dBehaviors/BehaviorContext.h
+++ b/dGame/dBehaviors/BehaviorContext.h
@@ -58,6 +58,8 @@ struct BehaviorContext
 
 	float skillTime = 0;
 
+	uint32_t skillID = 0;
+
 	uint32_t skillUId = 0;
 
 	bool failed = false;

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -593,7 +593,7 @@ void DestroyableComponent::Repair(const uint32_t armor)
 }
 
 
-void DestroyableComponent::Damage(uint32_t damage, const LWOOBJID source, bool echo)
+void DestroyableComponent::Damage(uint32_t damage, const LWOOBJID source, uint32_t skillID, bool echo)
 {
 	if (GetHealth() <= 0)
 	{
@@ -677,11 +677,10 @@ void DestroyableComponent::Damage(uint32_t damage, const LWOOBJID source, bool e
 
 		return;
 	}
-
-	Smash(source);
+	Smash(source, eKillType::VIOLENT, u"", skillID);
 }
 
-void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType, const std::u16string& deathType)
+void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType, const std::u16string& deathType, uint32_t skillID)
 {
 	if (m_iHealth > 0)
 	{
@@ -727,31 +726,20 @@ void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType
 					if (memberMissions == nullptr) continue;
 
 					memberMissions->Progress(MissionTaskType::MISSION_TASK_TYPE_SMASH, m_Parent->GetLOT());
+					memberMissions->Progress(MissionTaskType::MISSION_TASK_TYPE_SKILL, m_Parent->GetLOT(), skillID);
 				}
 			}
 			else
 			{
 				missions->Progress(MissionTaskType::MISSION_TASK_TYPE_SMASH, m_Parent->GetLOT());
+				missions->Progress(MissionTaskType::MISSION_TASK_TYPE_SKILL, m_Parent->GetLOT(), skillID);
 			}
 		}
 	}
 	
 	const auto isPlayer = m_Parent->IsPlayer();
 
-	GameMessages::SendDie(
-		m_Parent,
-		source,
-		source,
-		true,
-		killType,
-		deathType,
-		0,
-		0,
-		0,
-		isPlayer,
-		false,
-		1
-	);
+	GameMessages::SendDie(m_Parent, source, source, true, killType, deathType, 0, 0, 0, isPlayer, false, 1);
 
 	//NANI?!
 	if (!isPlayer)

--- a/dGame/dComponents/DestroyableComponent.h
+++ b/dGame/dComponents/DestroyableComponent.h
@@ -377,17 +377,19 @@ public:
      * Attempt to damage this entity, handles everything from health and armor to absorption, immunity and callbacks.
      * @param damage the damage to attempt to apply
      * @param source the attacker that caused this damage
+     * @param skillID the skill that damaged this entity
      * @param echo whether or not to serialize the damage
      */
-	void Damage(uint32_t damage, LWOOBJID source, bool echo = true);
+	void Damage(uint32_t damage, LWOOBJID source, uint32_t skillID = 0, bool echo = true);
 
     /**
      * Smashes this entity, notifying all clients
      * @param source the source that smashed this entity
+     * @param skillID the skill that killed this entity
      * @param killType the way this entity was killed, determines if a client animation is played
      * @param deathType the animation to play when killed
      */
-    void Smash(LWOOBJID source, eKillType killType = eKillType::VIOLENT, const std::u16string& deathType = u"");
+    void Smash(LWOOBJID source, eKillType killType = eKillType::VIOLENT, const std::u16string& deathType = u"", uint32_t skillID = 0);
 
     /**
      * Pushes a layer of immunity to this entity, making it immune for longer

--- a/dGame/dComponents/SkillComponent.cpp
+++ b/dGame/dComponents/SkillComponent.cpp
@@ -25,11 +25,13 @@ ProjectileSyncEntry::ProjectileSyncEntry()
 {
 }
 
-bool SkillComponent::CastPlayerSkill(const uint32_t behaviorId, const uint32_t skillUid, RakNet::BitStream* bitStream, const LWOOBJID target)
+bool SkillComponent::CastPlayerSkill(const uint32_t behaviorId, const uint32_t skillUid, RakNet::BitStream* bitStream, const LWOOBJID target, uint32_t skillID)
 {
 	auto* context = new BehaviorContext(this->m_Parent->GetObjectID());
 
 	context->caster = m_Parent->GetObjectID();
+
+	context->skillID = skillID;
 
 	this->m_managedBehaviors.insert_or_assign(skillUid, context);
 

--- a/dGame/dComponents/SkillComponent.h
+++ b/dGame/dComponents/SkillComponent.h
@@ -92,7 +92,7 @@ public:
      * @param bitStream the bitSteam given by the client to determine the behavior path
      * @param target the explicit target of the skill
      */
-    bool CastPlayerSkill(uint32_t behaviorId, uint32_t skillUid, RakNet::BitStream* bitStream, LWOOBJID target);
+    bool CastPlayerSkill(uint32_t behaviorId, uint32_t skillUid, RakNet::BitStream* bitStream, LWOOBJID target, uint32_t skillID = 0);
 
     /**
      * Continues a player skill. Should only be called when the server receives a sync message from the client.

--- a/dGame/dGameMessages/GameMessageHandler.cpp
+++ b/dGame/dGameMessages/GameMessageHandler.cpp
@@ -285,7 +285,7 @@ void GameMessageHandler::HandleMessage(RakNet::BitStream* inStream, const System
 
 				auto* skillComponent = entity->GetComponent<SkillComponent>();
 
-				success = skillComponent->CastPlayerSkill(behaviorId, startSkill.uiSkillHandle, bs, startSkill.optionalTargetID);
+				success = skillComponent->CastPlayerSkill(behaviorId, startSkill.uiSkillHandle, bs, startSkill.optionalTargetID, startSkill.skillID);
 
 				if (success && entity->GetCharacter()) {
 					DestroyableComponent* destComp = entity->GetComponent<DestroyableComponent>();

--- a/dGame/dMission/MissionTask.cpp
+++ b/dGame/dMission/MissionTask.cpp
@@ -326,10 +326,12 @@ void MissionTask::Progress(int32_t value, LWOOBJID associate, const std::string&
 		
 	case MissionTaskType::MISSION_TASK_TYPE_SKILL:
 	{
-		if (!InParameters(value)) break;
-
-		AddProgress(count);
-		
+		// This is a complicated check because for some missions we need to check for the associate being in the parameters instead of the value being in the parameters.
+		if (associate == LWOOBJID_EMPTY && GetAllTargets().size() == 1 && GetAllTargets()[0] == -1) {
+			if (InParameters(value)) AddProgress(count);
+		} else {
+			if (InParameters(associate) && InAllTargets(value)) AddProgress(count);
+		}	
 		break;
 	}
 


### PR DESCRIPTION
Addressed an issue where the Spinjitzu Initiate achievement would not progress.  This also allows mission tasks that specify that the player must get a kill on an enemy with a skill to progress.  
Tested mission 1935 (Equip trial faction gear) and 1139 (Spinjitzu Initiate) and both missions progressed and completed as intended and did not progress each other incorrectly.
Fixes #517 