### PR TITLE
Corrected action for OverTimeBehavior

### DIFF
--- a/dGame/dBehaviors/OverTimeBehavior.cpp
+++ b/dGame/dBehaviors/OverTimeBehavior.cpp
@@ -7,62 +7,26 @@
 #include "SkillComponent.h"
 #include "DestroyableComponent.h"
 
-/**
- * The OverTime behavior is very inconsistent in how it appears in the skill tree vs. how it should behave.
- * 
- * Items like "Doc in a Box" use an overtime behavior which you would expect have health & armor regen, but is only fallowed by a stun.
- * 
- * Due to this inconsistency, we have to implement a special case for some items.
- */
-
 void OverTimeBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) 
 {
     const auto originator = context->originator;
 
     auto* entity = EntityManager::Instance()->GetEntity(originator);
 
-    if (entity == nullptr)
-    {
-        return;
-    }
+    if (entity == nullptr) return;
 
     for (size_t i = 0; i < m_NumIntervals; i++)
     {
         entity->AddCallbackTimer((i + 1) * m_Delay, [originator, branch, this]() {
             auto* entity = EntityManager::Instance()->GetEntity(originator);
 
-            if (entity == nullptr)
-            {
-                return;
-            }
+            if (entity == nullptr) return;
 
             auto* skillComponent = entity->GetComponent<SkillComponent>();
 
-            if (skillComponent == nullptr)
-            {
-                return;
-            }
+            if (skillComponent == nullptr) return;
 
-            skillComponent->CalculateBehavior(0, m_Action->m_behaviorId, branch.target, true, true);
-
-            auto* destroyableComponent = entity->GetComponent<DestroyableComponent>();
-
-            if (destroyableComponent == nullptr)
-            {
-                return;
-            }
-            
-            /**
-             * Special cases for inconsistent behavior.
-             */
-
-            switch (m_behaviorId)
-            {
-            case 26253: // "Doc in a Box", heal up to 6 health and regen up to 18 armor.
-                destroyableComponent->Heal(1);
-                destroyableComponent->Repair(3);
-                break;
-            }
+            skillComponent->CalculateBehavior(m_Action, m_ActionBehaviorId, branch.target, true, true);
         });
     }
 }
@@ -74,7 +38,12 @@ void OverTimeBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bi
 
 void OverTimeBehavior::Load() 
 {
-    m_Action = GetAction("action");
+    m_Action = GetInt("action");
+    // Since m_Action is a skillID and not a behavior, get is correlated behaviorID.
+
+    CDSkillBehaviorTable* skillTable = CDClientManager::Instance()->GetTable<CDSkillBehaviorTable>("SkillBehavior");
+    m_ActionBehaviorId = skillTable->GetSkillByID(m_Action).behaviorID;
+
     m_Delay = GetFloat("delay");
     m_NumIntervals = GetInt("num_intervals");
 }

--- a/dGame/dBehaviors/OverTimeBehavior.h
+++ b/dGame/dBehaviors/OverTimeBehavior.h
@@ -4,7 +4,8 @@
 class OverTimeBehavior final : public Behavior
 {
 public:
-    Behavior* m_Action;
+    uint32_t m_Action;
+	uint32_t m_ActionBehaviorId;
     float m_Delay;
     int32_t m_NumIntervals;
 


### PR DESCRIPTION
It was recently discovered by Krysto that the OverTime behaviors' action is actually a skillID and not a behaviorID.  This is addressed and corrects the behaviors for all items that use OverTime behaviors.

Tested the following items and they all functioned as expected
Samurai bow 3
Daredevil flareguns 3 (Fig on Fire and DareDevil bullet)
clod chucking shovel
net of bees
bag of glitter
Sorcerer hat 3

These items all now function as expected.