### PR TITLE
Typo in NsConcertInstruments

### DIFF
--- a/dScripts/NsConcertInstrument.cpp
+++ b/dScripts/NsConcertInstrument.cpp
@@ -195,7 +195,7 @@ void NsConcertInstrument::EquipInstruments(Entity *self, Entity *player) {
         // Equip the left hand instrument
         const auto leftInstrumentLot = instrumentLotLeft.find(GetInstrumentLot(self))->second;
         if (leftInstrumentLot != LOT_NULL) {
-            inventory->AddItem(leftInstrumentLot, 1, eLootSourceType::LOOT_SOURCE_ACTIVITY);
+            inventory->AddItem(leftInstrumentLot, 1, eLootSourceType::LOOT_SOURCE_NONE, TEMP_ITEMS, {}, LWOOBJID_EMPTY, false);
             auto* leftInstrument = inventory->FindItemByLot(leftInstrumentLot, TEMP_ITEMS);
             leftInstrument->Equip();
         }
@@ -203,7 +203,7 @@ void NsConcertInstrument::EquipInstruments(Entity *self, Entity *player) {
         // Equip the right hand instrument
         const auto rightInstrumentLot = instrumentLotRight.find(GetInstrumentLot(self))->second;
         if (rightInstrumentLot != LOT_NULL) {
-            inventory->AddItem(rightInstrumentLot, 1, eLootSourceType::LOOT_SOURCE_ACTIVITY);
+            inventory->AddItem(rightInstrumentLot, 1, eLootSourceType::LOOT_SOURCE_NONE, TEMP_ITEMS, {}, LWOOBJID_EMPTY, false);
             auto* rightInstrument = inventory->FindItemByLot(rightInstrumentLot, TEMP_ITEMS);
             rightInstrument->Equip();
         }


### PR DESCRIPTION
Small typo with the AddItem updates.  Caused a crash in NS when using the instruments.