### PR TITLE
Added LootBuff behavior and serialization

### DIFF
--- a/dGame/dBehaviors/AndBehavior.cpp
+++ b/dGame/dBehaviors/AndBehavior.cpp
@@ -19,6 +19,12 @@ void AndBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitStre
 	}
 }
 
+void AndBehavior::UnCast(BehaviorContext* context, const BehaviorBranchContext branch) {
+	for (auto behavior : this->m_behaviors) {
+		behavior->UnCast(context, branch);
+	}
+}
+
 void AndBehavior::Load()
 {
 	const auto parameters = GetParameterNames();

--- a/dGame/dBehaviors/AndBehavior.h
+++ b/dGame/dBehaviors/AndBehavior.h
@@ -20,5 +20,7 @@ public:
 
 	void Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) override;
 	
+	void UnCast(BehaviorContext* context, BehaviorBranchContext branch) override;
+
 	void Load() override;
 };

--- a/dGame/dBehaviors/Behavior.cpp
+++ b/dGame/dBehaviors/Behavior.cpp
@@ -18,6 +18,7 @@
 #include "AreaOfEffectBehavior.h"
 #include "DurationBehavior.h"
 #include "TacArcBehavior.h"
+#include "LootBuffBehavior.h"
 #include "AttackDelayBehavior.h"
 #include "BasicAttackBehavior.h"
 #include "ChainBehavior.h"
@@ -172,7 +173,9 @@ Behavior* Behavior::CreateBehavior(const uint32_t behaviorId)
 		behavior = new SpeedBehavior(behaviorId);
 		break;
 	case BehaviorTemplates::BEHAVIOR_DARK_INSPIRATION: break;
-	case BehaviorTemplates::BEHAVIOR_LOOT_BUFF: break;
+	case BehaviorTemplates::BEHAVIOR_LOOT_BUFF: 
+		behavior = new LootBuffBehavior(behaviorId);
+		break;
 	case BehaviorTemplates::BEHAVIOR_VENTURE_VISION: break;
 	case BehaviorTemplates::BEHAVIOR_SPAWN_OBJECT:
 		behavior = new SpawnBehavior(behaviorId);

--- a/dGame/dBehaviors/BehaviorContext.cpp
+++ b/dGame/dBehaviors/BehaviorContext.cpp
@@ -64,8 +64,8 @@ void BehaviorContext::RegisterSyncBehavior(const uint32_t syncId, Behavior* beha
 
 void BehaviorContext::RegisterTimerBehavior(Behavior* behavior, const BehaviorBranchContext& branchContext, const LWOOBJID second)
 {
-	BehaviorTimerEntry entry
-;
+	BehaviorTimerEntry entry;
+	
 	entry.time = branchContext.duration;
 	entry.behavior = behavior;
 	entry.branchContext = branchContext;

--- a/dGame/dBehaviors/LootBuffBehavior.cpp
+++ b/dGame/dBehaviors/LootBuffBehavior.cpp
@@ -1,0 +1,38 @@
+#include "LootBuffBehavior.h"
+
+void LootBuffBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {    
+    auto target = EntityManager::Instance()->GetEntity(context->caster);
+    if (!target) return;
+
+    auto controllablePhysicsComponent = target->GetComponent<ControllablePhysicsComponent>();
+    if (!controllablePhysicsComponent) return;
+
+    controllablePhysicsComponent->AddPickupRadiusScale(m_Scale);
+    EntityManager::Instance()->SerializeEntity(target);
+
+    if (branch.duration > 0) context->RegisterTimerBehavior(this, branch);
+
+}
+
+void LootBuffBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
+    Handle(context, bitStream, branch);
+}
+
+void LootBuffBehavior::UnCast(BehaviorContext* context, BehaviorBranchContext branch) {
+    auto target = EntityManager::Instance()->GetEntity(context->caster);
+    if (!target) return;
+
+    auto controllablePhysicsComponent = target->GetComponent<ControllablePhysicsComponent>();
+    if (!controllablePhysicsComponent) return;
+
+    controllablePhysicsComponent->RemovePickupRadiusScale(m_Scale);
+    EntityManager::Instance()->SerializeEntity(target);
+}
+
+void LootBuffBehavior::Timer(BehaviorContext* context, BehaviorBranchContext branch, LWOOBJID second) {
+    UnCast(context, branch);
+}
+
+void LootBuffBehavior::Load() {
+    this->m_Scale = GetFloat("scale");
+}

--- a/dGame/dBehaviors/LootBuffBehavior.h
+++ b/dGame/dBehaviors/LootBuffBehavior.h
@@ -1,0 +1,32 @@
+#pragma once
+#include "Behavior.h"
+#include "BehaviorBranchContext.h"
+#include "BehaviorContext.h"
+#include "ControllablePhysicsComponent.h"
+
+/**
+ * @brief This is the behavior class to be used for all Loot Buff behavior nodes in the Behavior tree.
+ * 
+ */
+class LootBuffBehavior final : public Behavior
+{
+public:
+
+	float m_Scale;
+
+	/*
+	 * Inherited
+	 */
+	
+	explicit LootBuffBehavior(const uint32_t behaviorId) : Behavior(behaviorId) {}
+
+	void Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) override;
+
+	void Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) override;
+	
+	void UnCast(BehaviorContext* context, BehaviorBranchContext branch) override;
+
+	void Timer(BehaviorContext* context, BehaviorBranchContext branch, LWOOBJID second) override;
+
+	void Load() override;
+};

--- a/dGame/dComponents/ControllablePhysicsComponent.h
+++ b/dGame/dComponents/ControllablePhysicsComponent.h
@@ -227,6 +227,24 @@ public:
 
     dpEntity* GetdpEntity() const { return m_dpEntity; }
 
+    /**
+     * I store this in a vector because if I have 2 separate pickup radii being applied to the player, I dont know which one is correctly active.
+     * This method adds the pickup radius to the vector of active radii and if its larger than the current one, is applied as the new pickup radius.
+     */
+    void AddPickupRadiusScale(float value) ;
+
+    /**
+     * Removes the provided pickup radius scale from our list of buffs
+     * The recalculates what our pickup radius is.
+     */
+    void RemovePickupRadiusScale(float value) ;
+
+    /**
+     * The pickup radii of this component.
+     * @return All active radii scales for this component.
+     */
+    std::vector<float> GetActivePickupRadiusScales() { return m_ActivePickupRadiusScales; };
+
 private:
     /**
      * The entity that owns this component
@@ -322,6 +340,21 @@ private:
      * Whether this entity is static, making it unable to move
      */
     bool m_Static;
+
+    /**
+     * Whether the pickup scale is dirty.
+     */
+    bool m_DirtyPickupRadiusScale;
+
+    /**
+     * The list of pickup radius scales for this entity
+     */
+    std::vector<float> m_ActivePickupRadiusScales;
+
+    /**
+     * The active pickup radius for this entity
+     */
+    float m_PickupRadius;
 };
 
 #endif // CONTROLLABLEPHYSICSCOMPONENT_H


### PR DESCRIPTION
This PR adds the functionality for the LootBuff behavior for passive abilities and for items / item skills.  Details can be found in commit comments

Tested equipping all variations of the LootBuff behavior (passive skills, items, item skills) and all functioned as intended. Tested equipping multiple items with a loot buff and then unequipping them in different orders. Tested adding pickup radii of different values and the server correctly adjusted the pickup radius to the largest one currently equipped.

Fixes #423 