### PR TITLE
Serialize ape when changing armor value

### DIFF
--- a/dScripts/BaseEnemyApe.cpp
+++ b/dScripts/BaseEnemyApe.cpp
@@ -49,7 +49,7 @@ void BaseEnemyApe::OnTimerDone(Entity *self, std::string timerName) {
         if (destroyableComponent != nullptr) {
             destroyableComponent->SetArmor(destroyableComponent->GetMaxArmor() / timesStunned);
         }
-
+        EntityManager::Instance()->SerializeEntity(self);
         self->SetVar<uint32_t>(u"timesStunned", timesStunned + 1);
         StunApe(self, false);
 


### PR DESCRIPTION
When apes were stunned they were not being serialized immediately after getting their armor back, which would cause some de-syncs on the client.  We simply serialize the entity after changing its armor value so the clients know it was changed and dont phantom kill an ape.

Tested on a couple apes on Crux Prime and Gnarled forest and they got their armor back faster than the default (every 5 seconds update from base combat AI component)