### PR TITLE
Added animation

### DIFF
--- a/dScripts/NtParadoxPanelServer.cpp
+++ b/dScripts/NtParadoxPanelServer.cpp
@@ -38,10 +38,11 @@ void NtParadoxPanelServer::OnUse(Entity* self, Entity* user)
 			GameMessages::SendPlayAnimation(player, u"rebuild-celebrate");
 			
 			GameMessages::SendNotifyClientObject(self->GetObjectID(), u"SparkStop", 0, 0, player->GetObjectID(), "", player->GetSystemAddress());
-
+			GameMessages::SendSetStunned(player->GetObjectID(), eStunState::POP, player->GetSystemAddress(), LWOOBJID_EMPTY, false, false, true, false, true, true, false, false, true);
 			self->SetVar(u"bActive", false);
 		});
-
+		GameMessages::SendPlayAnimation(user, u"nexus-powerpanel", 6.0f);
+		GameMessages::SendSetStunned(user->GetObjectID(), eStunState::PUSH, user->GetSystemAddress(), LWOOBJID_EMPTY, false, false, true, false, true, true, false, false, true);
 		return;
 	}
 


### PR DESCRIPTION
Added the GM animation and stun for the Nexus Tower Paradox Panels for mission 1281.  

Tested on local instance and animation played correctly when having the mission and did not play at all before or after completing the mission.  Other player was able to see the player do the animation as well.

Fixes #514 