### PR TITLE
Quickbuilds jump fix

### DIFF
--- a/dGame/dComponents/RebuildComponent.cpp
+++ b/dGame/dComponents/RebuildComponent.cpp
@@ -45,7 +45,14 @@ void RebuildComponent::Serialize(RakNet::BitStream* outBitStream, bool bIsInitia
 
 		outBitStream->Write(false);
 	}
-
+	// If build state is completed and we've already serialized once in the completed state, 
+	// don't serializing this component anymore as this will cause the build to jump again.
+	// If state changes, serialization will begin again.
+	if (!m_StateDirty && m_State == REBUILD_COMPLETED) {
+		outBitStream->Write0();
+		outBitStream->Write0();
+		return;
+	}
 	// BEGIN Scripted Activity
 	outBitStream->Write1();
 
@@ -79,6 +86,7 @@ void RebuildComponent::Serialize(RakNet::BitStream* outBitStream, bool bIsInitia
 		outBitStream->Write(m_ActivatorPosition);
 		outBitStream->Write(m_RepositionPlayer);
 	}
+	m_StateDirty = false;
 }
 
 void RebuildComponent::Update(float deltaTime) {
@@ -139,7 +147,6 @@ void RebuildComponent::Update(float deltaTime) {
             }
 
             if (m_Timer >= m_ResetTime) {
-				m_Builder = LWOOBJID_EMPTY;
 
                 GameMessages::SendDieNoImplCode(m_Parent, LWOOBJID_EMPTY, LWOOBJID_EMPTY, eKillType::VIOLENT, u"", 0.0f, 0.0f, 0.0f, false, true);
 
@@ -384,7 +391,7 @@ void RebuildComponent::StartRebuild(Entity* user) {
 		GameMessages::SendEnableRebuild(m_Parent, true, false, false, eFailReason::REASON_NOT_GIVEN, 0.0f, user->GetObjectID());
 
 		m_State = eRebuildState::REBUILD_BUILDING;
-		
+		m_StateDirty = true;
 		EntityManager::Instance()->SerializeEntity(m_Parent);
 
 		auto* movingPlatform = m_Parent->GetComponent<MovingPlatformComponent>();
@@ -427,6 +434,7 @@ void RebuildComponent::CompleteRebuild(Entity* user) {
 	
 
 	m_State = eRebuildState::REBUILD_COMPLETED;
+	m_StateDirty = true;
 	m_Timer = 0.0f;
 	m_DrainedImagination = 0;
 
@@ -454,8 +462,6 @@ void RebuildComponent::CompleteRebuild(Entity* user) {
 
 		LootGenerator::Instance().DropActivityLoot(builder, m_Parent, m_ActivityId, 1);
 	}
-
-	m_Builder = LWOOBJID_EMPTY;
 
 	// Notify scripts
 	for (auto* script : CppScripts::GetEntityScripts(m_Parent)) {
@@ -501,12 +507,11 @@ void RebuildComponent::ResetRebuild(bool failed) {
 	GameMessages::SendRebuildNotifyState(m_Parent, m_State, eRebuildState::REBUILD_RESETTING, LWOOBJID_EMPTY);
 
 	m_State = eRebuildState::REBUILD_RESETTING;
+	m_StateDirty = true;
 	m_Timer = 0.0f;
 	m_TimerIncomplete = 0.0f;
 	m_ShowResetEffect = false;
 	m_DrainedImagination = 0;
-
-	m_Builder = LWOOBJID_EMPTY;
 	
 	EntityManager::Instance()->SerializeEntity(m_Parent);
 
@@ -541,6 +546,7 @@ void RebuildComponent::CancelRebuild(Entity* entity, eFailReason failReason, boo
 
 		// Now update the component itself
 		m_State = eRebuildState::REBUILD_INCOMPLETE;
+		m_StateDirty = true;
 
         // Notify scripts and possible subscribers
         for (auto* script : CppScripts::GetEntityScripts(m_Parent))

--- a/dGame/dComponents/RebuildComponent.h
+++ b/dGame/dComponents/RebuildComponent.h
@@ -216,7 +216,11 @@ public:
      */
 	void CancelRebuild(Entity* builder, eFailReason failReason, bool skipChecks = false);
 private:
-
+    /**
+     * Whether or not the quickbuild state has been changed since we last serialized it.
+     */
+    bool m_StateDirty = true;
+    
     /**
      * The state the rebuild is currently in
      */
@@ -235,7 +239,7 @@ private:
     /**
      * The position that the rebuild activator is spawned at
      */
-	NiPoint3 m_ActivatorPosition {};
+	NiPoint3 m_ActivatorPosition = NiPoint3::ZERO;
 
     /**
      * The entity that represents the rebuild activator


### PR DESCRIPTION
Corrected an error where the builder was erronously changed to an empty lwoobjid when a quickbuild was completed, causing the builds to no longer jump on completion (if configured to do so.)  Packet captures from live show that we do not want to get rid of the builder during resetting or during completion of the build so the file has been changed to not clear the builder in those cases.

Tested on a few quickbuilds on Avant Gardens and all jumped when completed as expected.  Will be testing other builds as well to see how they work now.

Edit: Tested various builds across Crux Prime and Nexus Tower and the ones that are configured to jump on completion now do so.  Fairly certain there isn't more to test so will merge this in the morning.

Fixes #446 