### PR TITLE
Exclude space blizzard from Zone ghosting

### DIFF
--- a/dGame/EntityManager.cpp
+++ b/dGame/EntityManager.cpp
@@ -24,12 +24,13 @@ EntityManager* EntityManager::m_Address = nullptr;
 std::vector<LWOMAPID> EntityManager::m_GhostingExcludedZones = {
 	// Small zones
 	1000,
-	
+
 	// Racing zones
 	1203,
+	1261,
 	1303,
 	1403,
-	
+
 	// Property zones
 	1150,
 	1151,


### PR DESCRIPTION
Simple PR, noticed this while working on the rocket holding one.
Whitespace in here is so inconsistent, please send help.