### PR TITLE
Make Kraken speed live accurate

### DIFF
--- a/dScripts/SGCannon.cpp
+++ b/dScripts/SGCannon.cpp
@@ -989,8 +989,8 @@ std::vector<std::vector<SGEnemy>> SGCannon::GetWaves() {
             {
                 std::vector<std::string> { "Wave_1_Ness_1", "Wave_1_Ness_2", "Wave_2_Ness_1" },
                 2565, 10.0, 15.0, true, 10.0, 15.0,
-                2.0, 10000, false, 0.0, 1.0,
-                1.0, true, true
+                7.0, 10000, false, 0.0, 7.0,
+                7.0, true, true
             },
 
             // Friendly 1


### PR DESCRIPTION
Resolves issue #119 
Made the speed match the simple physics speed, since the speed in the script was not correct.
Tested with all three krakens, and they move as fast as the did in live.

This may be indicative of a larger issue with SG movement speeds, but other things looked normal in comparison to live