### PR TITLE
Only make teams for minigames if we have more than one participant

### DIFF
--- a/dGame/dComponents/ScriptedActivityComponent.cpp
+++ b/dGame/dComponents/ScriptedActivityComponent.cpp
@@ -487,22 +487,24 @@ void ActivityInstance::StartZone() {
 	    return;
 
 	auto* leader = participants[0];
-
-	CBITSTREAM;
-	PacketUtils::WriteHeader(bitStream, CHAT_INTERNAL, MSG_CHAT_INTERNAL_CREATE_TEAM);
-
-	bitStream.Write(leader->GetObjectID());
-	bitStream.Write(m_Participants.size());
-
-	for (const auto& participant : m_Participants) {
-		bitStream.Write(participant);
-	}
-
 	LWOZONEID zoneId = LWOZONEID(m_ActivityInfo.instanceMapID, 0, leader->GetCharacter()->GetPropertyCloneID());
 
-	bitStream.Write(zoneId);
+	// only make a team if we have more than one participant
+	if (participants.size() > 1){
+		CBITSTREAM;
+		PacketUtils::WriteHeader(bitStream, CHAT_INTERNAL, MSG_CHAT_INTERNAL_CREATE_TEAM);
 
-	Game::chatServer->Send(&bitStream, SYSTEM_PRIORITY, RELIABLE, 0, Game::chatSysAddr, false);
+		bitStream.Write(leader->GetObjectID());
+		bitStream.Write(m_Participants.size());
+
+		for (const auto& participant : m_Participants) {
+			bitStream.Write(participant);
+		}
+
+		bitStream.Write(zoneId);
+
+		Game::chatServer->Send(&bitStream, SYSTEM_PRIORITY, RELIABLE, 0, Game::chatSysAddr, false);
+	}
 
 	const auto cloneId = GeneralUtils::GenerateRandomNumber<uint32_t>(1, UINT32_MAX);
 	for (Entity* player : participants) {


### PR DESCRIPTION
Resolves #467 

Tested with mini-games where
 * you can enter as one player (no team made)
 * Enter with multiple players (with 2 or more a team was made)
 * multiplayer racing (with 2 or more a team was made)
 * single player racing (no team made)


Things behaved as expected and the minigames played as expected