### PR TITLE
Corrected ambiguous string to number conversion 

### DIFF
--- a/dCommon/LDFFormat.cpp
+++ b/dCommon/LDFFormat.cpp
@@ -54,7 +54,7 @@ LDFBaseData * LDFBaseData::DataFromString(const std::string& format) {
                 }
                     
                 case LDF_TYPE_S32: {
-                    int32_t data = static_cast<int32_t>(stol(dataArray[1]));
+                    int32_t data = static_cast<int32_t>(stoull(dataArray[1]));
                     return new LDFData<int32_t>(key, data);
                 }
                     

--- a/dDatabase/Tables/CDItemComponentTable.cpp
+++ b/dDatabase/Tables/CDItemComponentTable.cpp
@@ -168,7 +168,7 @@ std::map<LOT, uint32_t> CDItemComponentTable::ParseCraftingCurrencies(const CDIt
             // Checking for 2 here, not sure what to do when there's more stuff than expected
             if (amountSplit.size() == 2) {
                 currencies.insert({
-                    std::stol(amountSplit[0]),
+                    std::stoull(amountSplit[0]),
                     std::stoi(amountSplit[1])
                 });
             }

--- a/dScripts/BaseFootRaceManager.cpp
+++ b/dScripts/BaseFootRaceManager.cpp
@@ -12,7 +12,7 @@ void BaseFootRaceManager::OnFireEventServerSide(Entity *self, Entity *sender, st
     if (splitArguments.size() > 1) {
 
         const auto eventName = splitArguments[0];
-        const auto player = EntityManager::Instance()->GetEntity(std::stol(splitArguments[1]));
+        const auto player = EntityManager::Instance()->GetEntity(std::stoull(splitArguments[1]));
 
         if (player != nullptr) {
             if (eventName == "updatePlayer") {

--- a/dScripts/NjMonastryBossInstance.cpp
+++ b/dScripts/NjMonastryBossInstance.cpp
@@ -99,7 +99,7 @@ void NjMonastryBossInstance::OnPlayerExit(Entity *self, Entity *player) {
 void NjMonastryBossInstance::OnActivityTimerDone(Entity *self, const std::string &name) {
     auto split = GeneralUtils::SplitString(name, TimerSplitChar);
     auto timerName = split[0];
-    auto objectID = split.size() > 1 ? (LWOOBJID) std::stol(split[1]) : LWOOBJID_EMPTY;
+    auto objectID = split.size() > 1 ? (LWOOBJID) std::stoull(split[1]) : LWOOBJID_EMPTY;
 
     if (timerName == WaitingForPlayersTimer) {
         StartFight(self);

--- a/dScripts/SpawnPetBaseServer.cpp
+++ b/dScripts/SpawnPetBaseServer.cpp
@@ -55,7 +55,7 @@ bool SpawnPetBaseServer::CheckNumberOfPets(Entity *self, Entity* user) {
         if (petID.empty())
             continue;
 
-        const auto* spawnedPet = EntityManager::Instance()->GetEntity(std::stol(petID));
+        const auto* spawnedPet = EntityManager::Instance()->GetEntity(std::stoull(petID));
         if (spawnedPet == nullptr)
             continue;
 


### PR DESCRIPTION
For Windows, the definition for a long is 32 bits, not 64 bits like on other operating systems.  This caused an issue on Windows only where a number larger than 32 bits was attempted to be converted to a long, the WorldServer would crash.  This commit replaces all instances of `stol` with `stoull` to further define a long and reduce ambiguity of number length.

Tested changes on Windows and WSL servers and no issues were found.

Fixes #572 

If one of the two requested reviewers could review these conversions to make sure I interpreted the types correctly and am correctly converting them, that'd be great.