### PR TITLE
Address issue with player spawned abilities not getting team

### DIFF
--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -696,9 +696,9 @@ void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType
 
 	if (owner != nullptr)
 	{
-		auto* team = TeamManager::Instance()->GetTeam(owner->GetObjectID());
-
 		owner = owner->GetOwner(); // If the owner is overwritten, we collect that here
+
+		auto* team = TeamManager::Instance()->GetTeam(owner->GetObjectID());
 
 		const auto isEnemy = m_Parent->GetComponent<BaseCombatAIComponent>() != nullptr;
 


### PR DESCRIPTION
Mover owner override to be earlier so that we dont try to get the team of an entity that doesnt have a team and may be a child entity of a player.  Tested changes with a team of two players and players were correctly given credit for kills