### PR TITLE
Address issue with selling/moving items grabbing a "random" item

### DIFF
--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -353,8 +353,6 @@ void InventoryComponent::MoveItemToInventory(Item* item, const eInventoryType in
 
 		while (left > 0)
 		{
-			item = origin->FindItemByLot(lot, ignoreEquipped);
-
 			if (item == nullptr)
 			{
 				item = origin->FindItemByLot(lot, false);


### PR DESCRIPTION
This fixes an issue where the item would get overwritten and would effectively fetch a "random" item in the inventory to move instead of the requested one.  Tested moving various items of various stack sizes to and from a vault and the sell inventory and the expected count of items was correctly moved.