### PR TITLE
Address issue with bricks selling 1 at a time

### DIFF
--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -208,7 +208,8 @@ void InventoryComponent::AddItem(
 
 	auto stack = static_cast<uint32_t>(info.stackSize);
 
-	if (inventoryType == eInventoryType::BRICKS)
+	// info.itemType of 1 is item type brick
+	if (inventoryType == eInventoryType::BRICKS || (stack == 0 && info.itemType == 1))
 	{
 		stack = 999;
 	}


### PR DESCRIPTION
Bricks have a stack size of zero in the cdclient so we need to make sure to give them a full stack size of 999 as we do for the bricks inventory with the selling inventory. Tested selling a stack of bricks and only 1 stack was generated on the vendors inventory. Taking the bricks back correctly put them in a stack. Tested buying and selling a full stack as well and all behaved correctly.