### PR TITLE
Don't give activity loot for Battle of Nimbus Station

### DIFF
--- a/dScripts/ActivityManager.cpp
+++ b/dScripts/ActivityManager.cpp
@@ -48,7 +48,7 @@ float_t ActivityManager::GetActivityValue(Entity *self, const LWOOBJID playerID,
 }
 
 void ActivityManager::StopActivity(Entity *self, const LWOOBJID playerID, const uint32_t score,
-                                   const uint32_t value1, const uint32_t value2, bool quit) {
+                                   const uint32_t value1, const uint32_t value2, bool quit, bool givingActivityLoot) {
     int32_t gameID = 0;
     
     auto* sac = self->GetComponent<ScriptedActivityComponent>();
@@ -70,7 +70,7 @@ void ActivityManager::StopActivity(Entity *self, const LWOOBJID playerID, const 
         SetActivityValue(self, playerID, 1, value1);
         SetActivityValue(self, playerID, 2, value2);
 
-        LootGenerator::Instance().GiveActivityLoot(player, self, gameID, CalculateActivityRating(self, playerID));
+        if (givingActivityLoot) LootGenerator::Instance().GiveActivityLoot(player, self, gameID, CalculateActivityRating(self, playerID));
 
         // Save the new score to the leaderboard and show the leaderboard to the player
         LeaderboardManager::SaveScore(playerID, gameID, score, value1);

--- a/dScripts/ActivityManager.h
+++ b/dScripts/ActivityManager.h
@@ -17,7 +17,7 @@ public:
     static float_t GetActivityValue(Entity *self, LWOOBJID playerID, uint32_t valueIndex) ;
     static bool TakeActivityCost(const Entity* self, LWOOBJID playerID);
     static uint32_t GetActivityID(const Entity* self);
-    void StopActivity(Entity *self, LWOOBJID playerID, uint32_t score, uint32_t value1 = 0, uint32_t value2 = 0, bool quit = false);
+    void StopActivity(Entity *self, LWOOBJID playerID, uint32_t score, uint32_t value1 = 0, uint32_t value2 = 0, bool quit = false, bool givingActivityLoot = true);
     virtual uint32_t CalculateActivityRating(Entity* self, LWOOBJID playerID);
     static void GetLeaderboardData(Entity *self, LWOOBJID playerID, uint32_t activityID, uint32_t numResults = 0);
 //    void FreezePlayer(Entity *self, const LWOOBJID playerID, const bool state) const;

--- a/dScripts/BaseWavesServer.cpp
+++ b/dScripts/BaseWavesServer.cpp
@@ -371,7 +371,7 @@ void BaseWavesServer::GameOver(Entity *self, bool won) {
             missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_MINIGAME, time, self->GetObjectID(), self->GetVar<std::string>(MissionTypeVariable));
         }
 
-        StopActivity(self, playerID, wave, time, score);
+        StopActivity(self, playerID, wave, time, score, false, false);
     }
 }
 


### PR DESCRIPTION
Address an issue on Brick Mesa where Battle of Nimbus Station was dropping activity loot.  Tested completing Battle of Nimbus Station and ending early and was not given loot as is expected.