### PR TITLE
Fix an issue where quickbuilds were sometimes unbuildable

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -562,19 +562,6 @@ void Entity::Initialize()
 			comp->SetPostImaginationCost(rebCompData[0].post_imagination_cost);
 			comp->SetTimeBeforeSmash(rebCompData[0].time_before_smash);
 
-			const auto rebuildActivatorValue = GetVarAsString(u"rebuild_activators");
-
-			if (!rebuildActivatorValue.empty()) {
-				std::vector<std::string> split = GeneralUtils::SplitString(rebuildActivatorValue, 0x1f);
-				NiPoint3 pos;
-
-				pos.x = std::stof(split[0]);
-				pos.y = std::stof(split[1]);
-				pos.z = std::stof(split[2]);
-
-				comp->SetActivatorPosition(pos);
-			}
-
 			const auto rebuildResetTime = GetVar<float>(u"rebuild_reset_time");
 
 			if (rebuildResetTime != 0.0f) {
@@ -977,8 +964,8 @@ void Entity::WriteBaseReplicaData(RakNet::BitStream* outBitStream, eReplicaPacke
 	}
 	
 	// Only serialize parent / child info should the info be dirty (changed) or if this is the construction of the entity.
-	outBitStream->Write((m_ParentEntity != nullptr || m_ChildEntities.size() > 0) && (m_IsParentChildDirty || packetType == PACKET_TYPE_CONSTRUCTION));
-	if ((m_ParentEntity != nullptr || m_ChildEntities.size() > 0) && (m_IsParentChildDirty || packetType == PACKET_TYPE_CONSTRUCTION)) {
+	outBitStream->Write(m_IsParentChildDirty || packetType == PACKET_TYPE_CONSTRUCTION);
+	if (m_IsParentChildDirty || packetType == PACKET_TYPE_CONSTRUCTION) {
 		m_IsParentChildDirty = false;
 		outBitStream->Write(m_ParentEntity != nullptr);
 		if (m_ParentEntity) {

--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -975,6 +975,8 @@ void Entity::WriteBaseReplicaData(RakNet::BitStream* outBitStream, eReplicaPacke
 		}
 		else outBitStream->Write0(); //No GM Level
 	}
+	
+	// Only serialize parent / child info should the info be dirty (changed) or if this is the construction of the entity.
 	outBitStream->Write((m_ParentEntity != nullptr || m_ChildEntities.size() > 0) && (m_IsParentChildDirty || packetType == PACKET_TYPE_CONSTRUCTION));
 	if ((m_ParentEntity != nullptr || m_ChildEntities.size() > 0) && (m_IsParentChildDirty || packetType == PACKET_TYPE_CONSTRUCTION)) {
 		m_IsParentChildDirty = false;

--- a/dGame/Entity.h
+++ b/dGame/Entity.h
@@ -322,6 +322,8 @@ protected:
 
 	int8_t m_Observers = 0;
 
+	bool m_IsParentChildDirty = true;
+
 	/*
 	 * Collision
 	 */

--- a/dGame/dComponents/RebuildComponent.cpp
+++ b/dGame/dComponents/RebuildComponent.cpp
@@ -22,6 +22,16 @@ RebuildComponent::RebuildComponent(Entity* entity) : Component(entity) {
 	{
 		m_Precondition = new PreconditionExpression(GeneralUtils::UTF16ToWTF8(checkPreconditions));
 	}
+
+	auto positionAsVector = GeneralUtils::SplitString(m_Parent->GetVarAsString(u"rebuild_activators"), 31);
+	if (positionAsVector.size() == 3) {
+		m_ActivatorPosition.x = std::stof(positionAsVector[0]);
+		m_ActivatorPosition.y = std::stof(positionAsVector[1]);
+		m_ActivatorPosition.z = std::stof(positionAsVector[2]);
+	} else {
+		m_ActivatorPosition = m_Parent->GetPosition();
+	}
+	SpawnActivator();
 }
 
 RebuildComponent::~RebuildComponent() {

--- a/dGame/dComponents/RebuildComponent.cpp
+++ b/dGame/dComponents/RebuildComponent.cpp
@@ -24,15 +24,17 @@ RebuildComponent::RebuildComponent(Entity* entity) : Component(entity) {
 	}
 
 	// Should a setting that has the build activator position exist, fetch that setting here and parse it for position.
-	// It is assumed that the user who sets this setting uses the correct character delimiter (character 31)
-	auto positionAsVector = GeneralUtils::SplitString(m_Parent->GetVarAsString(u"rebuild_activators"), 31);
-	if (positionAsVector.size() == 3) {
-		m_ActivatorPosition.x = std::stof(positionAsVector[0]);
-		m_ActivatorPosition.y = std::stof(positionAsVector[1]);
-		m_ActivatorPosition.z = std::stof(positionAsVector[2]);
+	// It is assumed that the user who sets this setting uses the correct character delimiter (character 31 or in hex 0x1F)
+	auto positionAsVector = GeneralUtils::SplitString(m_Parent->GetVarAsString(u"rebuild_activators"), 0x1F);
+	if (positionAsVector.size() == 3 && 
+		GeneralUtils::TryParse(positionAsVector[0], m_ActivatorPosition.x) &&
+		GeneralUtils::TryParse(positionAsVector[1], m_ActivatorPosition.y) && 
+		GeneralUtils::TryParse(positionAsVector[2], m_ActivatorPosition.z)) {
 	} else {
+		Game::logger->Log("RebuildComponent", "Failed to find activator position for lot %i.  Defaulting to parents position.\n", m_Parent->GetLOT());
 		m_ActivatorPosition = m_Parent->GetPosition();
 	}
+
 	SpawnActivator();
 }
 

--- a/dGame/dComponents/RebuildComponent.cpp
+++ b/dGame/dComponents/RebuildComponent.cpp
@@ -23,6 +23,8 @@ RebuildComponent::RebuildComponent(Entity* entity) : Component(entity) {
 		m_Precondition = new PreconditionExpression(GeneralUtils::UTF16ToWTF8(checkPreconditions));
 	}
 
+	// Should a setting that has the build activator position exist, fetch that setting here and parse it for position.
+	// It is assumed that the user who sets this setting uses the correct character delimiter (character 31)
 	auto positionAsVector = GeneralUtils::SplitString(m_Parent->GetVarAsString(u"rebuild_activators"), 31);
 	if (positionAsVector.size() == 3) {
 		m_ActivatorPosition.x = std::stof(positionAsVector[0]);


### PR DESCRIPTION
Address an issue where quickbuilds would become unbuildable.  The main issue lied within serializing parent/child info too often for some reason / serializing it when the info wasnt dirty.  Only serializing this info when it is actually dirty and has changed has addressed the issue and allows quickbuilds to never break.

Since this PR changes how Parents and Children work the following was tested.

First I tested the 100% consistent reproduction in Avant Gardens (finish a build, spawn a build, finish the spawned build, original build respawns, serialize spawned build) and the build never became unbuildable.  The engineers turret that is spawned with the helmet with the 50% consistent reproduction had never encountered the issue where it was unbuildable.  Racing still works as well as spawning a car from your backpack.  Pets still spawn and set their owner correctly and taming them still builds the item as intended.

Fixes #122 