### PR TITLE
Fix child entities not being removed from their parents correctly on deletion

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -125,6 +125,9 @@ Entity::~Entity() {
 
 		m_Components.erase(pair.first);
 	}
+	if (m_ParentEntity) {
+		m_ParentEntity->RemoveChild(this);
+	}
 }
 
 void Entity::Initialize()
@@ -1654,6 +1657,17 @@ void Entity::RegisterCoinDrop(uint64_t count) {
 void Entity::AddChild(Entity* child) {
 	m_IsParentChildDirty = true;
 	m_ChildEntities.push_back(child);
+}
+
+void Entity::RemoveChild(Entity* child) {
+	if (!child) return;
+	for (auto entity = m_ChildEntities.begin(); entity != m_ChildEntities.end(); entity++) {
+		if (*entity && (*entity)->GetObjectID() == child->GetObjectID()) {
+			m_IsParentChildDirty = true;
+			m_ChildEntities.erase(entity);
+			return;
+		}
+	}
 }
 
 void Entity::AddTimer(std::string name, float time) {

--- a/dGame/Entity.h
+++ b/dGame/Entity.h
@@ -143,6 +143,7 @@ public:
 	void SetProximityRadius(dpEntity* entity, std::string name);
 
 	void AddChild(Entity* child);
+	void RemoveChild(Entity* child);
 	void AddTimer(std::string name, float time);
 	void AddCallbackTimer(float time, std::function<void()> callback);
 	bool HasTimer(const std::string& name);


### PR DESCRIPTION
We need to make sure we are actually deleting children from the vector of children when they are deleted as entities.  From my observations this caused the second bug with builds where they would be attached to the player for some reason.  Tested regression vs new head and out of 999 imagination no builds broke with engineer helmets on head and many broke on regression  testing.