### PR TITLE
Address order of deletion of entities on server to allow scripted activities to properly remove players

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -99,22 +99,6 @@ Entity::~Entity() {
 		m_Character->SaveXMLToDatabase();
 	}
 
-	if (IsPlayer()) {
-        Entity* zoneControl = EntityManager::Instance()->GetZoneControlEntity();
-        for (CppScripts::Script* script : CppScripts::GetEntityScripts(zoneControl)) {
-            script->OnPlayerExit(zoneControl, this);
-        }
-
-        std::vector<Entity*> scriptedActs = EntityManager::Instance()->GetEntitiesByComponent(COMPONENT_TYPE_SCRIPTED_ACTIVITY);
-        for (Entity* scriptEntity : scriptedActs) {
-            if (scriptEntity->GetObjectID() != zoneControl->GetObjectID()) { // Don't want to trigger twice on instance worlds
-                for (CppScripts::Script* script : CppScripts::GetEntityScripts(scriptEntity)) {
-                    script->OnPlayerExit(scriptEntity, this);
-                }
-            }
-        }
-	}
-
 	CancelAllTimers();
 	CancelCallbackTimers();
 

--- a/dGame/EntityManager.cpp
+++ b/dGame/EntityManager.cpp
@@ -226,7 +226,7 @@ void EntityManager::UpdateEntities(const float deltaTime) {
 
 		const auto& ghostingToDelete = std::find(m_EntitiesToGhost.begin(), m_EntitiesToGhost.end(), entityToDelete);
 
-		if (entityToDelete != nullptr)
+		if (entityToDelete)
 		{
 			// If we are a player run through the player destructor.
 			if (entityToDelete->IsPlayer())

--- a/dGame/EntityManager.cpp
+++ b/dGame/EntityManager.cpp
@@ -217,37 +217,42 @@ void EntityManager::UpdateEntities(const float deltaTime) {
 
 	m_EntitiesToKill.clear();
 
-	for (const auto& entry : m_EntitiesToDelete)
+	for (const auto entry : m_EntitiesToDelete)
 	{
-		auto* entity = GetEntity(entry);
+		// Get all this info first before we delete the player.
+		auto entityToDelete = GetEntity(entry);
 
-		m_Entities.erase(entry);
+		auto networkIdToErase = entityToDelete->GetNetworkId();
 
-		const auto& iter = std::find(m_EntitiesToGhost.begin(), m_EntitiesToGhost.end(), entity);
+		const auto& ghostingToDelete = std::find(m_EntitiesToGhost.begin(), m_EntitiesToGhost.end(), entityToDelete);
 
-		if (iter != m_EntitiesToGhost.end())
+		if (entityToDelete != nullptr)
 		{
-			m_EntitiesToGhost.erase(iter);
-		}
-
-		if (entity != nullptr)
-		{
-			if (entity->GetNetworkId() != 0)
+			// If we are a player run through the player destructor.
+			if (entityToDelete->IsPlayer())
 			{
-				m_LostNetworkIds.push(entity->GetNetworkId());
-			}
-
-			if (entity->IsPlayer())
-			{
-				delete dynamic_cast<Player*>(entity);
+				delete dynamic_cast<Player*>(entityToDelete);
 			}
 			else
 			{
-				delete entity;
+				delete entityToDelete;
 			}
 
-			entity = nullptr;
+			entityToDelete = nullptr;
+
+			if (networkIdToErase != 0)
+			{
+				m_LostNetworkIds.push(networkIdToErase);
+			}
 		}
+
+		if (ghostingToDelete != m_EntitiesToGhost.end())
+		{
+			m_EntitiesToGhost.erase(ghostingToDelete);
+		}
+
+		m_Entities.erase(entry);
+		
 	}
 
 	m_EntitiesToDelete.clear();

--- a/dGame/Player.cpp
+++ b/dGame/Player.cpp
@@ -13,6 +13,7 @@
 #include "dZoneManager.h"
 #include "CharacterComponent.h"
 #include "Mail.h"
+#include "CppScripts.h"
 
 std::vector<Player*> Player::m_Players = {};
 
@@ -327,6 +328,22 @@ Player::~Player()
 	if (iter == m_Players.end())
 	{
 		return;
+	}
+
+	if (IsPlayer()) {
+        Entity* zoneControl = EntityManager::Instance()->GetZoneControlEntity();
+        for (CppScripts::Script* script : CppScripts::GetEntityScripts(zoneControl)) {
+            script->OnPlayerExit(zoneControl, this);
+        }
+
+        std::vector<Entity*> scriptedActs = EntityManager::Instance()->GetEntitiesByComponent(COMPONENT_TYPE_SCRIPTED_ACTIVITY);
+        for (Entity* scriptEntity : scriptedActs) {
+            if (scriptEntity->GetObjectID() != zoneControl->GetObjectID()) { // Don't want to trigger twice on instance worlds
+                for (CppScripts::Script* script : CppScripts::GetEntityScripts(scriptEntity)) {
+                    script->OnPlayerExit(scriptEntity, this);
+                }
+            }
+        }
 	}
 
 	m_Players.erase(iter);

--- a/dScripts/SGCannon.cpp
+++ b/dScripts/SGCannon.cpp
@@ -144,8 +144,9 @@ void SGCannon::OnMessageBoxResponse(Entity *self, Entity *sender, int32_t button
     if (player != nullptr) {
         if (button == 1 && identifier == u"Shooting_Gallery_Stop")
         {
-            static_cast<Player*>(player)->SendToZone(1300);
-
+            UpdatePlayer(self, player->GetObjectID(), true);
+            RemovePlayer(player->GetObjectID());
+            StopGame(self, true);
             return;
         }
 


### PR DESCRIPTION
Fixes #464 

Addresses an issue where leaving instances would not call their respective OnPlayerExit methods.  This was due to an error with the order of destroying the entity due to the player being destroyed before the entity class called the methods, causing them to always be false.  This change also resolves and issue where instanced activities would continue running even after all their players would leave.  

Tested leaving Battle of Nimbus Station and Frakjaw and the methods and actions specified in them have been called as expected.  Instances stop script functionality when all players leave and properly resize their variables to allow teams of smaller sizes to ready up and not need to wait for phantom players.