### PR TITLE
Added item precondition checks

### DIFF
--- a/dGame/dInventory/Item.cpp
+++ b/dGame/dInventory/Item.cpp
@@ -311,7 +311,9 @@ bool Item::UseNonEquip()
 
 	const auto success = !packages.empty();
 
-	Game::logger->Log("Item", "Used (%i) with (%d)\n", lot, success);
+	auto inventoryComponent = inventory->GetComponent();
+
+	auto playerEntity = inventoryComponent->GetParent();
 
 	if (subKey != LWOOBJID_EMPTY)
 	{
@@ -324,8 +326,7 @@ bool Item::UseNonEquip()
 			return true;
 		}
 	}
-
-	if (success)
+	if (success && (playerEntity->GetGMLevel() >= eGameMasterLevel::GAME_MASTER_LEVEL_JUNIOR_DEVELOPER || this->GetPreconditionExpression()->Check(playerEntity)))
 	{
 		auto* entityParent = inventory->GetComponent()->GetParent();
 
@@ -342,7 +343,7 @@ bool Item::UseNonEquip()
 
 			LootGenerator::Instance().GiveLoot(inventory->GetComponent()->GetParent(), result, eLootSourceType::LOOT_SOURCE_CONSUMPTION);
 		}
-
+		Game::logger->Log("Item", "Used (%i)\n", lot);
 		inventory->GetComponent()->RemoveItem(lot, 1);
 	}
 


### PR DESCRIPTION
Added item precondition checks for items so players who do not meet the conditions cannot use the items.  tested with the faction bag tokens and they only gave the tokens when a player met all the preconditions or was a Game Master of level 6+

Fixes #374 