### PR TITLE
Fix issue with dropship computer

### DIFF
--- a/dScripts/AmDropshipComputer.cpp
+++ b/dScripts/AmDropshipComputer.cpp
@@ -27,12 +27,12 @@ void AmDropshipComputer::OnUse(Entity* self, Entity* user)
         return;
     }
 
-    if (inventoryComponent->GetLotCount(12323) != 0)
+    if (inventoryComponent->GetLotCount(m_NexusTalonDataCard) != 0 || missionComponent->GetMission(979)->GetMissionState() == MissionState::MISSION_STATE_COMPLETE)
     {
         return;
     }
 
-    inventoryComponent->AddItem(12323, 1, eLootSourceType::LOOT_SOURCE_NONE);
+    inventoryComponent->AddItem(m_NexusTalonDataCard, 1, eLootSourceType::LOOT_SOURCE_NONE);
 }
 
 void AmDropshipComputer::OnDie(Entity* self, Entity* killer) 

--- a/dScripts/AmDropshipComputer.h
+++ b/dScripts/AmDropshipComputer.h
@@ -8,4 +8,6 @@ public:
     void OnUse(Entity* self, Entity* user) override;
     void OnDie(Entity* self, Entity* killer) override;
     void OnTimerDone(Entity* self, std::string timerName) override;
+private:
+    const LOT m_NexusTalonDataCard = 12323;
 };


### PR DESCRIPTION
The dropship computer now no longer gives a player a second mission item should they interact with it again after mission completion.  Tested a player with the mission and after the mission completed and the item is only earned once during the mission and never otherwise.