### PR TITLE
Address players leaving Battle of Nimbus Station causing a crash that won't save

### DIFF
--- a/dScripts/BaseWavesServer.cpp
+++ b/dScripts/BaseWavesServer.cpp
@@ -60,8 +60,11 @@ void BaseWavesServer::BaseStartup(Entity* self) {
 
 // Done
 void BaseWavesServer::BasePlayerExit(Entity* self, Entity* player) {
-    state.waitingPlayers.erase(std::find(state.waitingPlayers.begin(), state.waitingPlayers.end(), player->GetObjectID()));
-    state.players.erase(std::find(state.players.begin(), state.players.end(), player->GetObjectID()));
+    auto waitingPlayerToErase = std::find(state.waitingPlayers.begin(), state.waitingPlayers.end(), player->GetObjectID());
+    if (waitingPlayerToErase != state.waitingPlayers.end()) state.waitingPlayers.erase(waitingPlayerToErase);
+
+    auto playerToErase = std::find(state.players.begin(), state.players.end(), player->GetObjectID());
+    if (playerToErase != state.players.end()) state.players.erase(playerToErase);
 
     if (!self->GetNetworkVar<bool>(WavesStartedVariable)) {
         PlayerConfirmed(self);


### PR DESCRIPTION
Address an issue in Battle of Nimbus Station where if a player were to click the ready button and then leave via the exit button, the WorldServer would crash.  This was due to no bounds check being in place when attempting to find a player in the waiting players iterator.  Since the player was no longer waiting, attempting to find them in the vector caused the iterator to point the the end of the vector, which the server would attempt to erase.  This has been replaced with proper bounds checks to ensure the iterator erases a valid element.

Tested the repro that caused the crash does not happen anymore as well as ensured the previous methods of leaving do not also cause a crash.  No crash is exhibitted when a player leaves the instance after readying up.