### PR TITLE
Address issue with Inventor Beehive and Buccaneer Monkey ability on valiant weapon

### DIFF
--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -165,6 +165,7 @@
 #include "PropertyPlatform.h"
 #include "MailBoxServer.h"
 #include "ActMine.h"
+#include "FireFirstSkillonStartup.h"
 
 // Racing Scripts
 #include "RaceImagineCrateServer.h"
@@ -804,7 +805,8 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 		script = new LegoDieRoll();
   	else if (scriptName == "scripts\\EquipmentScripts\\BuccaneerValiantShip.lua")
     	script = new BuccaneerValiantShip();
-
+	else if (scriptName == "scripts\\EquipmentScripts\\FireFirstSkillonStartup.lua")
+	    script = new FireFirstSkillonStartup();
 	// FB
 	else if (scriptName == "scripts\\ai\\NS\\WH\\L_ROCKHYDRANT_BROKEN.lua")
 		script = new RockHydrantBroken();

--- a/dScripts/FireFirstSkillonStartup.cpp
+++ b/dScripts/FireFirstSkillonStartup.cpp
@@ -1,0 +1,22 @@
+#include "FireFirstSkillonStartup.h"
+#include "Entity.h"
+#include "SkillComponent.h"
+#include "CDClientDatabase.h"
+#include "CDObjectSkillsTable.h"
+
+void FireFirstSkillonStartup::OnStartup(Entity* self) {
+    auto skillComponent = self->GetComponent<SkillComponent>();
+    if (!skillComponent) return;
+
+    CDObjectSkillsTable* skillsTable = CDClientManager::Instance()->GetTable<CDObjectSkillsTable>("ObjectSkills");
+    std::vector<CDObjectSkills> skills = skillsTable->Query([=](CDObjectSkills entry) {return (entry.objectTemplate == self->GetLOT()); });
+
+    for (auto skill : skills) {
+        CDSkillBehaviorTable* skillBehaviorTable = CDClientManager::Instance()->GetTable<CDSkillBehaviorTable>("SkillBehavior");
+		CDSkillBehavior behaviorData = skillBehaviorTable->GetSkillByID(skill.skillID);
+
+        // Should parent entity be null, make the originator self.
+        const auto target = self->GetParentEntity() ? self->GetParentEntity()->GetObjectID() : self->GetObjectID();
+        skillComponent->CalculateBehavior(skill.skillID, behaviorData.behaviorID, LWOOBJID_EMPTY, false, false, target);
+    }
+}

--- a/dScripts/FireFirstSkillonStartup.cpp
+++ b/dScripts/FireFirstSkillonStartup.cpp
@@ -8,9 +8,11 @@ void FireFirstSkillonStartup::OnStartup(Entity* self) {
     auto skillComponent = self->GetComponent<SkillComponent>();
     if (!skillComponent) return;
 
+    // Get the skill IDs of this object.
     CDObjectSkillsTable* skillsTable = CDClientManager::Instance()->GetTable<CDObjectSkillsTable>("ObjectSkills");
     std::vector<CDObjectSkills> skills = skillsTable->Query([=](CDObjectSkills entry) {return (entry.objectTemplate == self->GetLOT()); });
 
+    // For each skill, cast it with the associated behavior ID.
     for (auto skill : skills) {
         CDSkillBehaviorTable* skillBehaviorTable = CDClientManager::Instance()->GetTable<CDSkillBehaviorTable>("SkillBehavior");
 		CDSkillBehavior behaviorData = skillBehaviorTable->GetSkillByID(skill.skillID);

--- a/dScripts/FireFirstSkillonStartup.h
+++ b/dScripts/FireFirstSkillonStartup.h
@@ -1,0 +1,12 @@
+#pragma once
+#ifndef __FIREFIRSTSKILLONSTARTUP__H__
+#define __FIREFIRSTSKILLONSTARTUP__H__
+
+#include "CppScripts.h"
+
+class FireFirstSkillonStartup : public CppScripts::Script {
+    public:
+        void OnStartup(Entity* self) override;
+};
+
+#endif  //!__FIREFIRSTSKILLONSTARTUP__H__


### PR DESCRIPTION
Adds the FireFirstSkillonStartup script to allow for scripts that use this to function.  This change addresses an issue where the valiant weapons ability would do no damage.  This is due to its skill being cast by the script and not by the object itself.  This PR implements the script and allows items that use this script to function correctly.

Fixes #241 

Tested that the monkey and beehive now correctly deal the damage they dealt in live and properly function without crashes, as well as making sure loot drops for the player who owns the monkey.