### PR TITLE
Address incorrect stun played by growl speakers

### DIFF
--- a/dScripts/QbEnemyStunner.cpp
+++ b/dScripts/QbEnemyStunner.cpp
@@ -13,16 +13,32 @@ void QbEnemyStunner::OnRebuildComplete(Entity* self, Entity* target)
         destroyable->SetFaction(115);
     }
 
-    auto* skillComponent = self->GetComponent<SkillComponent>();
+    auto skillComponent = self->GetComponent<SkillComponent>();
+    if (!skillComponent) return;
 
-    if (skillComponent != nullptr)
-    {
-        skillComponent->CalculateBehavior(499, 6095, LWOOBJID_EMPTY);
+    // Get the skill IDs of this object.
+    CDObjectSkillsTable* skillsTable = CDClientManager::Instance()->GetTable<CDObjectSkillsTable>("ObjectSkills");
+    auto skills = skillsTable->Query([=](CDObjectSkills entry) {return (entry.objectTemplate == self->GetLOT()); });
+    std::map<uint32_t, uint32_t> skillBehaviorMap;
+    // For each skill, cast it with the associated behavior ID.
+    for (auto skill : skills) {
+        CDSkillBehaviorTable* skillBehaviorTable = CDClientManager::Instance()->GetTable<CDSkillBehaviorTable>("SkillBehavior");
+		CDSkillBehavior behaviorData = skillBehaviorTable->GetSkillByID(skill.skillID);
+
+        skillBehaviorMap.insert(std::make_pair(skill.skillID, behaviorData.behaviorID));
     }
 
-    self->AddTimer("TickTime", 1);
+    // If there are no skills found, insert a default skill to use.
+    if (skillBehaviorMap.size() == 0) {
+        skillBehaviorMap.insert(std::make_pair(499U, 6095U));
+    }
+
+    // Start all skills associated with the object next tick
+    self->AddTimer("TickTime", 0);
 
     self->AddTimer("PlayEffect", 20);
+
+    self->SetVar<std::map<uint32_t, uint32_t>>(u"skillBehaviorMap", skillBehaviorMap);
 }
 
 void QbEnemyStunner::OnTimerDone(Entity* self, std::string timerName) 
@@ -45,9 +61,16 @@ void QbEnemyStunner::OnTimerDone(Entity* self, std::string timerName)
 
         if (skillComponent != nullptr)
         {
-            skillComponent->CalculateBehavior(499, 6095, LWOOBJID_EMPTY);
+            auto skillBehaviorMap = self->GetVar<std::map<uint32_t, uint32_t>>(u"skillBehaviorMap");
+            if (skillBehaviorMap.size() == 0) {
+                // Should no skills have been found, default to the mermaid stunner
+                skillComponent->CalculateBehavior(499U, 6095U, LWOOBJID_EMPTY);
+            } else {
+            for (auto pair : skillBehaviorMap) {
+                skillComponent->CalculateBehavior(pair.first, pair.second, LWOOBJID_EMPTY);
+            }
+            }
         }
-        
         self->AddTimer("TickTime", 1);
     }
 }


### PR DESCRIPTION
This PR fixes an issue where the growl speakers would play the incorrect skill stun.  Each object that has this script is supposed to get this from the Happy Flower config but the values there are incorrect and need to be collected from the objectSkills table.  

Tested the Growl speaker and the skeletons now dance as intended and the siren still plays the correct animation.  