### PR TITLE
Add Venture Vision Behavior

### DIFF
--- a/dGame/dBehaviors/Behavior.cpp
+++ b/dGame/dBehaviors/Behavior.cpp
@@ -45,6 +45,7 @@
 #include "InterruptBehavior.h"
 #include "PlayEffectBehavior.h"
 #include "DamageAbsorptionBehavior.h"
+#include "VentureVisionBehavior.h"
 #include "BlockBehavior.h"
 #include "ClearTargetBehavior.h"
 #include "PullToPointBehavior.h"
@@ -176,7 +177,9 @@ Behavior* Behavior::CreateBehavior(const uint32_t behaviorId)
 	case BehaviorTemplates::BEHAVIOR_LOOT_BUFF: 
 		behavior = new LootBuffBehavior(behaviorId);
 		break;
-	case BehaviorTemplates::BEHAVIOR_VENTURE_VISION: break;
+	case BehaviorTemplates::BEHAVIOR_VENTURE_VISION:
+		behavior = new VentureVisionBehavior(behaviorId);
+		break;
 	case BehaviorTemplates::BEHAVIOR_SPAWN_OBJECT:
 		behavior = new SpawnBehavior(behaviorId);
 		break;

--- a/dGame/dBehaviors/VentureVisionBehavior.cpp
+++ b/dGame/dBehaviors/VentureVisionBehavior.cpp
@@ -1,0 +1,47 @@
+#include "VentureVisionBehavior.h"
+#include "BehaviorBranchContext.h"
+#include "CharacterComponent.h"
+#include "BehaviorContext.h"
+	
+void VentureVisionBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch){
+
+	const auto targetEntity = EntityManager::Instance()->GetEntity(branch.target);
+
+	if (targetEntity) {
+		auto characterComponent = targetEntity->GetComponent<CharacterComponent>();
+
+		if (characterComponent) {
+			if (m_show_collectibles) characterComponent->AddVentureVisionEffect(m_ShowCollectibles);
+			if (m_show_minibosses) characterComponent->AddVentureVisionEffect(m_ShowMiniBosses);
+			if (m_show_pet_digs) characterComponent->AddVentureVisionEffect(m_ShowPetDigs);
+		}
+
+		if (branch.duration > 0) context->RegisterTimerBehavior(this, branch);
+	}
+}
+
+void VentureVisionBehavior::UnCast(BehaviorContext* context, BehaviorBranchContext branch) {
+	const auto targetEntity = EntityManager::Instance()->GetEntity(branch.target);
+
+	if (targetEntity) {
+		auto characterComponent = targetEntity->GetComponent<CharacterComponent>();
+
+		if (characterComponent) {
+			if (m_show_collectibles) characterComponent->RemoveVentureVisionEffect(m_ShowCollectibles);
+			if (m_show_minibosses) characterComponent->RemoveVentureVisionEffect(m_ShowMiniBosses);
+			if (m_show_pet_digs) characterComponent->RemoveVentureVisionEffect(m_ShowPetDigs);
+		}
+	}
+}
+
+void VentureVisionBehavior::Timer(BehaviorContext* context, BehaviorBranchContext branch, LWOOBJID second) {
+	UnCast(context, branch);
+}
+
+void VentureVisionBehavior::Load(){
+	this->m_show_pet_digs = GetBoolean("show_pet_digs");
+
+	this->m_show_minibosses = GetBoolean("show_minibosses");
+
+	this->m_show_collectibles = GetBoolean("show_collectibles");
+}

--- a/dGame/dBehaviors/VentureVisionBehavior.h
+++ b/dGame/dBehaviors/VentureVisionBehavior.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#ifndef __VENTUREVISIONBEHAVIOR__H__
+#define __VENTUREVISIONBEHAVIOR__H__
+
+#include "Behavior.h"
+
+class VentureVisionBehavior final : public Behavior
+{
+public:
+	bool m_show_pet_digs;
+
+	bool m_show_minibosses;
+
+	bool m_show_collectibles;
+
+	const std::string m_ShowCollectibles = "bShowCollectibles";
+
+	const std::string m_ShowMiniBosses = "bShowMiniBosses";
+
+	const std::string m_ShowPetDigs = "bShowPetDigs";
+
+
+	/*
+	 * Inherited
+	 */
+
+	explicit VentureVisionBehavior(const uint32_t behaviorId) : Behavior(behaviorId)
+	{
+	}
+	
+	void Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) override;
+
+	void UnCast(BehaviorContext* context, BehaviorBranchContext branch) override;
+
+	void Timer(BehaviorContext* context, BehaviorBranchContext branch, LWOOBJID second) override;
+
+	void Load() override;
+};
+
+#endif  //!__VENTUREVISIONBEHAVIOR__H__

--- a/dGame/dComponents/CharacterComponent.h
+++ b/dGame/dComponents/CharacterComponent.h
@@ -275,11 +275,31 @@ public:
 	void UpdatePlayerStatistic(StatisticID updateID, uint64_t updateValue = 1);
 
     /**
+     * Add a venture vision effect to the player minimap.
+     */
+    void AddVentureVisionEffect(std::string ventureVisionType);
+
+    /**
+     * Remove a venture vision effect from the player minimap.
+     * When an effect hits 0 active effects, it is deactivated.
+     */
+    void RemoveVentureVisionEffect(std::string ventureVisionType);
+
+    /**
+     * Update the client minimap to reveal the specified factions
+     */
+    void UpdateClientMinimap(bool showFaction, std::string ventureVisionType) const;
+
+    /**
      * Character info regarding this character, including clothing styles, etc.
      */
     Character* m_Character;
 private:
     
+    /** 
+     * The map of active venture vision effects
+     */
+    std::map<std::string, uint32_t> m_ActiveVentureVisionEffects;
 
     /**
      * Whether this character is racing


### PR DESCRIPTION
Add the Venture Vision behavior and associated functionality.  Pet digs still do not show up however.

The Kit bonus for factions have been tested and properly grant and take away the buff when it is casted and uncasted.  Tested as well using multiple Venture Vision behaviors at once and the vision only went away when there were zero equipped at once.

Fixes #165 
Fixes #287 