### PR TITLE
Fix nested preconditions not evaluating costs

### DIFF
--- a/dGame/dUtilities/Preconditions.cpp
+++ b/dGame/dUtilities/Preconditions.cpp
@@ -317,7 +317,7 @@ bool PreconditionExpression::Check(Entity* player, bool evaluateCosts) const
 		GameMessages::SendNotifyClientFailedPrecondition(player->GetObjectID(), player->GetSystemAddress(), u"", condition);
 	}
 
-	const auto b = next == nullptr ? true : next->Check(player);
+	const auto b = next == nullptr ? true : next->Check(player, evaluateCosts);
 
 	return m_or ? a || b : a && b;
 }


### PR DESCRIPTION
Fixed an issue with some builds that had preconditions not taking items from the players due to the evaluate costs parameter not being passed to nested conditions.

Tested the build in Avant Gardens and it now correctly takes items from the player upon completion.