### PR TITLE
Added caching for behavior parameter table

### DIFF
--- a/dDatabase/CDClientManager.cpp
+++ b/dDatabase/CDClientManager.cpp
@@ -8,7 +8,7 @@ void CDClientManager::Initialize(void) {
 	tables.insert(std::make_pair("ActivityRewards", new CDActivityRewardsTable()));
 	UNUSED(tables.insert(std::make_pair("Animations", new CDAnimationsTable())));
 	tables.insert(std::make_pair("BehaviorParameter", new CDBehaviorParameterTable()));
-	UNUSED(tables.insert(std::make_pair("BehaviorTemplate", new CDBehaviorTemplateTable())));
+	tables.insert(std::make_pair("BehaviorTemplate", new CDBehaviorTemplateTable()));
 	tables.insert(std::make_pair("ComponentsRegistry", new CDComponentsRegistryTable()));
 	tables.insert(std::make_pair("CurrencyTable", new CDCurrencyTableTable()));
 	tables.insert(std::make_pair("DestructibleComponent", new CDDestructibleComponentTable()));

--- a/dDatabase/Tables/CDBehaviorParameterTable.cpp
+++ b/dDatabase/Tables/CDBehaviorParameterTable.cpp
@@ -1,35 +1,28 @@
 #include "CDBehaviorParameterTable.h"
 #include "GeneralUtils.h"
+#include <iostream>
 
 //! Constructor
 CDBehaviorParameterTable::CDBehaviorParameterTable(void) {
-#ifdef CDCLIENT_CACHE_ALL
 	auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM BehaviorParameter");
+	size_t hash = 0;
 	while (!tableData.eof()) {
+		hash = 0;
 		CDBehaviorParameter entry;
 		entry.behaviorID = tableData.getIntField(0, -1);
 		entry.parameterID = tableData.getStringField(1, "");
 		entry.value = tableData.getFloatField(2, -1.0f);
 
-		//Check if we have an entry with this ID:
-		auto it = m_entries.find(entry.behaviorID);
-		if (it != m_entries.end()) {
-			it->second.insert(std::make_pair(entry.parameterID, entry.value));
-		}
-		else {
-			//Otherwise, insert it:
-			m_entries.insert(std::make_pair(entry.behaviorID, std::map<std::string, float>()));
-			auto jit = m_entries.find(entry.behaviorID);
+		GeneralUtils::hash_combine(hash, entry.behaviorID);
+		GeneralUtils::hash_combine(hash, entry.parameterID);
 
-			//Add our value as well:
-			jit->second.insert(std::make_pair(entry.parameterID, entry.value));
-		}
+		auto it = m_Entries.find(entry.behaviorID);
+		m_ParametersList.insert(entry.parameterID);
+		m_Entries.insert(std::make_pair(hash, entry));
 
 		tableData.nextRow();
 	}
-
 	tableData.finalize();
-#endif
 }
 
 //! Destructor
@@ -40,51 +33,33 @@ std::string CDBehaviorParameterTable::GetName(void) const {
 	return "BehaviorParameter";
 }
 
-float CDBehaviorParameterTable::GetEntry(const uint32_t behaviorID, const std::string& name, const float defaultValue) 
+CDBehaviorParameter CDBehaviorParameterTable::GetEntry(const uint32_t behaviorID, const std::string& name, const float defaultValue) 
 {
+	CDBehaviorParameter returnValue;
+	returnValue.behaviorID = 0;
+	returnValue.parameterID = "";
+	returnValue.value = defaultValue;
+
 	size_t hash = 0;
 	GeneralUtils::hash_combine(hash, behaviorID);
 	GeneralUtils::hash_combine(hash, name);
 
 	// Search for specific parameter
 	const auto& it = m_Entries.find(hash);
-	if (it != m_Entries.end()) {
-		return it->second;
+	return it != m_Entries.end() ? it->second : returnValue;
+}
+
+std::map<std::string, float> CDBehaviorParameterTable::GetParametersByBehaviorID(uint32_t behaviorID) {
+	size_t hash;
+	std::map<std::string, float> returnInfo;
+	for (auto parameterCandidate : m_ParametersList) {
+		hash = 0;
+		GeneralUtils::hash_combine(hash, behaviorID);
+		GeneralUtils::hash_combine(hash, parameterCandidate);
+		auto infoCandidate = m_Entries.find(hash);
+		if (infoCandidate != m_Entries.end()) {
+			returnInfo.insert(std::make_pair(infoCandidate->second.parameterID, infoCandidate->second.value));
+		}
 	}
-
-	// Check if this behavior has already been checked
-	const auto& itChecked = m_Entries.find(behaviorID);
-	if (itChecked != m_Entries.end()) {
-		return defaultValue;
-	}
-
-#ifndef CDCLIENT_CACHE_ALL
-	auto query = CDClientDatabase::CreatePreppedStmt(
-		"SELECT parameterID, value FROM BehaviorParameter WHERE behaviorID = ?;");
-	query.bind(1, (int) behaviorID);
-
-	auto tableData = query.execQuery();
-
-	m_Entries.insert_or_assign(behaviorID, 0);
-
-	while (!tableData.eof()) {
-		const std::string parameterID = tableData.getStringField(0, "");
-		const float value = tableData.getFloatField(1, 0);
-
-		size_t parameterHash = 0;
-		GeneralUtils::hash_combine(parameterHash, behaviorID);
-		GeneralUtils::hash_combine(parameterHash, parameterID);
-
-		m_Entries.insert_or_assign(parameterHash, value);
-
-		tableData.nextRow();
-	}
-
-	const auto& it2 = m_Entries.find(hash);
-	if (it2 != m_Entries.end()) {
-		return it2->second;
-	}
-#endif
-
-	return defaultValue;
+	return returnInfo;
 }

--- a/dDatabase/Tables/CDBehaviorParameterTable.h
+++ b/dDatabase/Tables/CDBehaviorParameterTable.h
@@ -2,7 +2,8 @@
 
 // Custom Classes
 #include "CDTable.h"
-#include <map>
+#include <unordered_map>
+#include <unordered_set>
 
 /*!
  \file CDBehaviorParameterTable.hpp
@@ -19,8 +20,8 @@ struct CDBehaviorParameter {
 //! BehaviorParameter table
 class CDBehaviorParameterTable : public CDTable {
 private:
-    std::map<size_t, float> m_Entries;
-    
+	std::unordered_map<size_t, CDBehaviorParameter> m_Entries;
+	std::unordered_set<std::string> m_ParametersList;
 public:
     
     //! Constructor
@@ -35,5 +36,7 @@ public:
      */
     std::string GetName(void) const override;
     
-	float GetEntry(const uint32_t behaviorID, const std::string& name, const float defaultValue = 0);
+	CDBehaviorParameter GetEntry(const uint32_t behaviorID, const std::string& name, const float defaultValue = 0);
+
+	std::map<std::string, float> GetParametersByBehaviorID(uint32_t behaviorID);
 };

--- a/dDatabase/Tables/CDBehaviorTemplateTable.cpp
+++ b/dDatabase/Tables/CDBehaviorTemplateTable.cpp
@@ -16,7 +16,7 @@ CDBehaviorTemplateTable::CDBehaviorTemplateTable(void) {
     
     // Reserve the size
     this->entries.reserve(size);
-    
+
     // Now get the data
     auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM BehaviorTemplate");
     while (!tableData.eof()) {
@@ -27,6 +27,7 @@ CDBehaviorTemplateTable::CDBehaviorTemplateTable(void) {
         entry.effectHandle = tableData.getStringField(3, "");
         
         this->entries.push_back(entry);
+        this->entriesMappedByBehaviorID.insert(std::make_pair(entry.behaviorID, entry));
         tableData.nextRow();
     }
 
@@ -54,4 +55,16 @@ std::vector<CDBehaviorTemplate> CDBehaviorTemplateTable::Query(std::function<boo
 //! Gets all the entries in the table
 std::vector<CDBehaviorTemplate> CDBehaviorTemplateTable::GetEntries(void) const {
     return this->entries;
+}
+
+const CDBehaviorTemplate CDBehaviorTemplateTable::GetByBehaviorID(uint32_t behaviorID) {
+    auto entry = this->entriesMappedByBehaviorID.find(behaviorID);
+    if (entry == this->entriesMappedByBehaviorID.end()) {
+        CDBehaviorTemplate entryToReturn;
+        entryToReturn.behaviorID = 0;
+        entryToReturn.effectHandle = "";
+        return entryToReturn;
+    } else {
+        return entry->second;
+    }
 }

--- a/dDatabase/Tables/CDBehaviorTemplateTable.h
+++ b/dDatabase/Tables/CDBehaviorTemplateTable.h
@@ -2,6 +2,7 @@
 
 // Custom Classes
 #include "CDTable.h"
+#include <unordered_map>
 
 /*!
  \file CDBehaviorTemplateTable.hpp
@@ -21,7 +22,7 @@ struct CDBehaviorTemplate {
 class CDBehaviorTemplateTable : public CDTable {
 private:
     std::vector<CDBehaviorTemplate> entries;
-    
+    std::unordered_map<uint32_t, CDBehaviorTemplate> entriesMappedByBehaviorID;
 public:
     
     //! Constructor
@@ -47,5 +48,6 @@ public:
        \return The entries
      */
     std::vector<CDBehaviorTemplate> GetEntries(void) const;
-    
+
+    const CDBehaviorTemplate GetByBehaviorID(uint32_t behaviorID);
 };

--- a/dGame/dBehaviors/Behavior.cpp
+++ b/dGame/dBehaviors/Behavior.cpp
@@ -288,7 +288,7 @@ Behavior* Behavior::CreateBehavior(const uint32_t behaviorId)
 BehaviorTemplates Behavior::GetBehaviorTemplate(const uint32_t behaviorId) {
 	auto behaviorTemplateTable = CDClientManager::Instance()->GetTable<CDBehaviorTemplateTable>("BehaviorTemplate");
 
-	BehaviorTemplates templateID = static_cast<BehaviorTemplates>(0);
+	BehaviorTemplates templateID = BehaviorTemplates::BEHAVIOR_EMPTY;
 	// Find behavior template by its behavior id.  Default to 0.
 	if (behaviorTemplateTable) {
 		auto templateEntry = behaviorTemplateTable->GetByBehaviorID(behaviorId);
@@ -297,7 +297,7 @@ BehaviorTemplates Behavior::GetBehaviorTemplate(const uint32_t behaviorId) {
 		}
 	}
 
-	if (templateID == static_cast<BehaviorTemplates>(0) && behaviorId != 0) {
+	if (templateID == BehaviorTemplates::BEHAVIOR_EMPTY && behaviorId != 0) {
 		Game::logger->Log("Behavior::GetBehaviorTemplate", "Failed to load behavior template with id (%i)!\n", behaviorId);
 	}
 

--- a/dGame/dBehaviors/Behavior.cpp
+++ b/dGame/dBehaviors/Behavior.cpp
@@ -452,6 +452,7 @@ Behavior::Behavior(const uint32_t behaviorId)
 float Behavior::GetFloat(const std::string& name, const float defaultValue) const
 {
 	// Get the behavior parameter entry and return its value.
+	if (!BehaviorParameterTable) BehaviorParameterTable = CDClientManager::Instance()->GetTable<CDBehaviorParameterTable>("BehaviorParameter");
 	return BehaviorParameterTable->GetEntry(this->m_behaviorId, name, defaultValue).value;
 }
 
@@ -484,6 +485,7 @@ std::map<std::string, float> Behavior::GetParameterNames() const
 {
 	std::map<std::string, float> templatesInDatabase;
 	// Find behavior template by its behavior id.
+	if (!BehaviorParameterTable) BehaviorParameterTable = CDClientManager::Instance()->GetTable<CDBehaviorParameterTable>("BehaviorParameter");
 	if (BehaviorParameterTable) {
 		templatesInDatabase = BehaviorParameterTable->GetParametersByBehaviorID(this->m_behaviorId);
 	}

--- a/dGame/dBehaviors/Behavior.cpp
+++ b/dGame/dBehaviors/Behavior.cpp
@@ -7,6 +7,7 @@
 #include "dLogger.h"
 #include "BehaviorTemplates.h"
 #include "BehaviorBranchContext.h"
+#include <unordered_map>
 
 /*
  * Behavior includes
@@ -69,7 +70,7 @@
 #include "RenderComponent.h"
 #include "DestroyableComponent.h"
 
-std::map<uint32_t, Behavior*> Behavior::Cache = {};
+std::unordered_map<uint32_t, Behavior*> Behavior::Cache = {};
 CDBehaviorParameterTable* Behavior::BehaviorParameterTable = nullptr;
 
 Behavior* Behavior::GetBehavior(const uint32_t behaviorId)
@@ -285,28 +286,22 @@ Behavior* Behavior::CreateBehavior(const uint32_t behaviorId)
 }
 
 BehaviorTemplates Behavior::GetBehaviorTemplate(const uint32_t behaviorId) {
-	auto query = CDClientDatabase::CreatePreppedStmt(
-		"SELECT templateID FROM BehaviorTemplate WHERE behaviorID = ?;");
-	query.bind(1, (int) behaviorId);
+	auto behaviorTemplateTable = CDClientManager::Instance()->GetTable<CDBehaviorTemplateTable>("BehaviorTemplate");
 
-	auto result = query.execQuery();
-
-	// Make sure we do not proceed if we are trying to load an invalid behavior
-	if (result.eof())
-	{
-		if (behaviorId != 0)
-		{
-			Game::logger->Log("Behavior::GetBehaviorTemplate", "Failed to load behavior template with id (%i)!\n", behaviorId);
+	BehaviorTemplates templateID = static_cast<BehaviorTemplates>(0);
+	// Find behavior template by its behavior id.  Default to 0.
+	if (behaviorTemplateTable) {
+		auto templateEntry = behaviorTemplateTable->GetByBehaviorID(behaviorId);
+		if (templateEntry.behaviorID == behaviorId) {
+			templateID = static_cast<BehaviorTemplates>(templateEntry.templateID);
 		}
-
-		return BehaviorTemplates::BEHAVIOR_EMPTY;
 	}
 
-	const auto id = static_cast<BehaviorTemplates>(result.getIntField(0));
+	if (templateID == static_cast<BehaviorTemplates>(0) && behaviorId != 0) {
+		Game::logger->Log("Behavior::GetBehaviorTemplate", "Failed to load behavior template with id (%i)!\n", behaviorId);
+	}
 
-	result.finalize();
-
-	return id;
+	return templateID;
 }
 
 // For use with enemies, to display the correct damage animations on the players
@@ -412,6 +407,17 @@ void Behavior::PlayFx(std::u16string type, const LWOOBJID target, const LWOOBJID
 
 Behavior::Behavior(const uint32_t behaviorId)
 {
+	auto behaviorTemplateTable = CDClientManager::Instance()->GetTable<CDBehaviorTemplateTable>("BehaviorTemplate");
+
+	CDBehaviorTemplate templateInDatabase;
+
+	if (behaviorTemplateTable) {
+		auto templateEntry = behaviorTemplateTable->GetByBehaviorID(behaviorId);
+		if (templateEntry.behaviorID == behaviorId) {
+			templateInDatabase = templateEntry;
+		}
+	}
+
 	this->m_behaviorId = behaviorId;
 
 	// Add to cache
@@ -423,14 +429,8 @@ Behavior::Behavior(const uint32_t behaviorId)
 		this->m_templateId = BehaviorTemplates::BEHAVIOR_EMPTY;
 	}
 
-	auto query = CDClientDatabase::CreatePreppedStmt(
-		"SELECT templateID, effectID, effectHandle FROM BehaviorTemplate WHERE behaviorID = ?;");
-	query.bind(1, (int) behaviorId);
-
-	auto result = query.execQuery();
-
 	// Make sure we do not proceed if we are trying to load an invalid behavior
-	if (result.eof())
+	if (templateInDatabase.behaviorID == 0)
 	{
 		Game::logger->Log("Behavior", "Failed to load behavior with id (%i)!\n", behaviorId);
 
@@ -441,34 +441,18 @@ Behavior::Behavior(const uint32_t behaviorId)
 		return;
 	}
 
-	this->m_templateId = static_cast<BehaviorTemplates>(result.getIntField(0));
+	this->m_templateId = static_cast<BehaviorTemplates>(templateInDatabase.templateID);
 
-	this->m_effectId = result.getIntField(1);
+	this->m_effectId = templateInDatabase.effectID;
 
-	if (!result.fieldIsNull(2))
-	{
-		const std::string effectHandle = result.getStringField(2);
-		if (effectHandle == "")
-		{
-			this->m_effectHandle = nullptr;
-		}
-		else
-		{
-			this->m_effectHandle = new std::string(effectHandle);
-		}
-	}
-	else
-	{
-		this->m_effectHandle = nullptr;
-	}
-
-	result.finalize();
+	this->m_effectHandle = templateInDatabase.effectHandle != "" ? new std::string(templateInDatabase.effectHandle) : nullptr;
 }
 
 
 float Behavior::GetFloat(const std::string& name, const float defaultValue) const
 {
-	return BehaviorParameterTable->GetEntry(this->m_behaviorId, name, defaultValue);
+	auto entry = BehaviorParameterTable->GetEntry(this->m_behaviorId, name, defaultValue);
+	return entry.value;
 }
 
 
@@ -498,24 +482,15 @@ Behavior* Behavior::GetAction(float value) const
 
 std::map<std::string, float> Behavior::GetParameterNames() const
 {
-	std::map<std::string, float> parameters;
+	auto behaviorParameterTable = CDClientManager::Instance()->GetTable<CDBehaviorParameterTable>("BehaviorParameter");
 
-	auto query = CDClientDatabase::CreatePreppedStmt(
-		"SELECT parameterID, value FROM BehaviorParameter WHERE behaviorID = ?;");
-	query.bind(1, (int) this->m_behaviorId);
-
-	auto tableData = query.execQuery();
-
-	while (!tableData.eof())
-	{
-		parameters.insert_or_assign(tableData.getStringField(0, ""), tableData.getFloatField(1, 0));
-
-		tableData.nextRow();
+	std::map<std::string, float> templatesInDatabase;
+	// Find behavior template by its behavior id.
+	if (behaviorParameterTable) {
+		templatesInDatabase = behaviorParameterTable->GetParametersByBehaviorID(this->m_behaviorId);
 	}
 
-	tableData.finalize();
-
-	return parameters;
+	return templatesInDatabase;
 }
 
 void Behavior::Load()

--- a/dGame/dBehaviors/Behavior.cpp
+++ b/dGame/dBehaviors/Behavior.cpp
@@ -298,7 +298,7 @@ BehaviorTemplates Behavior::GetBehaviorTemplate(const uint32_t behaviorId) {
 	}
 
 	if (templateID == BehaviorTemplates::BEHAVIOR_EMPTY && behaviorId != 0) {
-		Game::logger->Log("Behavior::GetBehaviorTemplate", "Failed to load behavior template with id (%i)!\n", behaviorId);
+		Game::logger->Log("Behavior", "Failed to load behavior template with id (%i)!\n", behaviorId);
 	}
 
 	return templateID;
@@ -451,8 +451,8 @@ Behavior::Behavior(const uint32_t behaviorId)
 
 float Behavior::GetFloat(const std::string& name, const float defaultValue) const
 {
-	auto entry = BehaviorParameterTable->GetEntry(this->m_behaviorId, name, defaultValue);
-	return entry.value;
+	// Get the behavior parameter entry and return its value.
+	return BehaviorParameterTable->GetEntry(this->m_behaviorId, name, defaultValue).value;
 }
 
 

--- a/dGame/dBehaviors/Behavior.cpp
+++ b/dGame/dBehaviors/Behavior.cpp
@@ -482,12 +482,10 @@ Behavior* Behavior::GetAction(float value) const
 
 std::map<std::string, float> Behavior::GetParameterNames() const
 {
-	auto behaviorParameterTable = CDClientManager::Instance()->GetTable<CDBehaviorParameterTable>("BehaviorParameter");
-
 	std::map<std::string, float> templatesInDatabase;
 	// Find behavior template by its behavior id.
-	if (behaviorParameterTable) {
-		templatesInDatabase = behaviorParameterTable->GetParametersByBehaviorID(this->m_behaviorId);
+	if (BehaviorParameterTable) {
+		templatesInDatabase = BehaviorParameterTable->GetParametersByBehaviorID(this->m_behaviorId);
 	}
 
 	return templatesInDatabase;

--- a/dGame/dBehaviors/Behavior.h
+++ b/dGame/dBehaviors/Behavior.h
@@ -19,7 +19,7 @@ public:
 	/*
 	 * Static
 	 */
-	static std::map<uint32_t, Behavior*> Cache;
+	static std::unordered_map<uint32_t, Behavior*> Cache;
 	static CDBehaviorParameterTable* BehaviorParameterTable;
 
 	static Behavior* GetBehavior(uint32_t behaviorId);

--- a/dGame/dUtilities/Preconditions.cpp
+++ b/dGame/dUtilities/Preconditions.cpp
@@ -317,7 +317,7 @@ bool PreconditionExpression::Check(Entity* player, bool evaluateCosts) const
 		GameMessages::SendNotifyClientFailedPrecondition(player->GetObjectID(), player->GetSystemAddress(), u"", condition);
 	}
 
-	const auto b = next == nullptr ? true : next->Check(player);
+	const auto b = next == nullptr ? true : next->Check(player, evaluateCosts);
 
 	return m_or ? a || b : a && b;
 }


### PR DESCRIPTION
This PR addresses the immense number of queries that were run against the CDServer when loading a behavior to now, instead, load the data from an internal data structure so we dont need to run useless queries against the CDServer.  This speeds up the load time of behaviors to near instantaneous where as before they would cause lots of lag on Ninjago, Frakjaw Battle Instance and Crux Prime.

Tested some various skills and behaviors and all of them loaded and used their skills as expected.  Will be testing more thoroughly to ensure that most behaviors still work.  Since this is basically a query caching PR, no functionality is expected to be impacted.