### PR TITLE
CDClient rework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,6 +331,15 @@ target_link_libraries(dNet dDatabase)
 target_link_libraries(dGame dDatabase)
 target_link_libraries(dChatFilter dDatabase)
 
+# Include Boost
+find_package(Boost COMPONENTS interprocess)
+
+if(Boost_FOUND)
+    include_directories(${Boost_INCLUDE_DIRS}) 
+    
+    target_link_libraries(dGame ${Boost_LIBRARIES})
+endif()
+
 if(WIN32)
 target_link_libraries(raknet ws2_32)
 endif(WIN32)

--- a/dDatabase/Tables/CDBehaviorParameterTable.h
+++ b/dDatabase/Tables/CDBehaviorParameterTable.h
@@ -12,17 +12,17 @@
 
 //! BehaviorParameter Entry Struct
 struct CDBehaviorParameter {
-    unsigned int behaviorID;            //!< The Behavior ID
-    std::string parameterID;       //!< The Parameter ID
+    int32_t behaviorID;            //!< The Behavior ID
+    int32_t parameterID;       //!< The Parameter ID
     float value;                 //!< The value of the behavior template
 };
 
 //! BehaviorParameter table
 class CDBehaviorParameterTable : public CDTable {
 private:
-	std::unordered_map<size_t, CDBehaviorParameter> m_Entries;
-	std::unordered_set<std::string> m_ParametersList;
+	std::unordered_map<size_t, float> m_Entries;
 public:
+    static void CreateSharedMap();
     
     //! Constructor
     CDBehaviorParameterTable(void);
@@ -36,7 +36,5 @@ public:
      */
     std::string GetName(void) const override;
     
-	CDBehaviorParameter GetEntry(const uint32_t behaviorID, const std::string& name, const float defaultValue = 0);
-
-	std::map<std::string, float> GetParametersByBehaviorID(uint32_t behaviorID);
+	float GetEntry(const uint32_t behaviorID, const std::string& name, const float defaultValue = 0);
 };

--- a/dGame/dBehaviors/AndBehavior.cpp
+++ b/dGame/dBehaviors/AndBehavior.cpp
@@ -3,6 +3,8 @@
 #include "Game.h"
 #include "dLogger.h"
 
+#include <sstream>
+
 void AndBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, const BehaviorBranchContext branch)
 {
 	for (auto* behavior : this->m_behaviors)
@@ -27,15 +29,19 @@ void AndBehavior::UnCast(BehaviorContext* context, const BehaviorBranchContext b
 
 void AndBehavior::Load()
 {
-	const auto parameters = GetParameterNames();
+	std::string ss = "behavior ";
 
-	for (const auto& parameter : parameters)
-	{
-		if (parameter.first.rfind("behavior", 0) == 0)
-		{
-			auto* action = GetAction(parameter.second);
+	int i = 1;
 
-			this->m_behaviors.push_back(action);
+	while (true) {
+		std::string s = ss + std::to_string(i);
+
+		if (GetInt(s, 0) == 0) {
+			break;
 		}
+
+		m_behaviors.push_back(GetAction(s));
+
+		++i;
 	}
 }

--- a/dGame/dBehaviors/Behavior.cpp
+++ b/dGame/dBehaviors/Behavior.cpp
@@ -453,7 +453,7 @@ float Behavior::GetFloat(const std::string& name, const float defaultValue) cons
 {
 	// Get the behavior parameter entry and return its value.
 	if (!BehaviorParameterTable) BehaviorParameterTable = CDClientManager::Instance()->GetTable<CDBehaviorParameterTable>("BehaviorParameter");
-	return BehaviorParameterTable->GetEntry(this->m_behaviorId, name, defaultValue).value;
+	return BehaviorParameterTable->GetEntry(this->m_behaviorId, name, defaultValue);
 }
 
 
@@ -485,10 +485,10 @@ std::map<std::string, float> Behavior::GetParameterNames() const
 {
 	std::map<std::string, float> templatesInDatabase;
 	// Find behavior template by its behavior id.
-	if (!BehaviorParameterTable) BehaviorParameterTable = CDClientManager::Instance()->GetTable<CDBehaviorParameterTable>("BehaviorParameter");
+	/*if (!BehaviorParameterTable) BehaviorParameterTable = CDClientManager::Instance()->GetTable<CDBehaviorParameterTable>("BehaviorParameter");
 	if (BehaviorParameterTable) {
 		templatesInDatabase = BehaviorParameterTable->GetParametersByBehaviorID(this->m_behaviorId);
-	}
+	}*/
 
 	return templatesInDatabase;
 }

--- a/dGame/dBehaviors/ChainBehavior.cpp
+++ b/dGame/dBehaviors/ChainBehavior.cpp
@@ -26,15 +26,19 @@ void ChainBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitSt
 
 void ChainBehavior::Load()
 {
-	const auto parameters = GetParameterNames();
+	std::string ss = "behavior ";
 
-	for (const auto& parameter : parameters)
-	{
-		if (parameter.first.rfind("behavior", 0) == 0)
-		{
-			auto* action = GetAction(parameter.second);
+	int i = 1;
 
-			this->m_behaviors.push_back(action);
+	while (true) {
+		std::string s = ss + std::to_string(i);
+
+		if (GetInt(s, 0) == 0) {
+			break;
 		}
+
+		m_behaviors.push_back(GetAction(s));
+
+		++i;
 	}
 }

--- a/dGame/dBehaviors/NpcCombatSkillBehavior.cpp
+++ b/dGame/dBehaviors/NpcCombatSkillBehavior.cpp
@@ -17,15 +17,19 @@ void NpcCombatSkillBehavior::Load()
 {
 	this->m_npcSkillTime = GetFloat("npc skill time");
 	
-	const auto parameters = GetParameterNames();
+	std::string ss = "behavior ";
 
-	for (const auto& parameter : parameters)
-	{
-		if (parameter.first.rfind("behavior", 0) == 0)
-		{
-			auto* action = GetAction(parameter.second);
+	int i = 1;
 
-			this->m_behaviors.push_back(action);
+	while (true) {
+		std::string s = ss + std::to_string(i);
+
+		if (GetInt(s, 0) == 0) {
+			break;
 		}
+
+		m_behaviors.push_back(GetAction(s));
+
+		++i;
 	}
 }

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -218,6 +218,8 @@ int main(int argc, char** argv) {
 	ObjectIDManager::Instance()->Initialize(Game::logger);
 	Game::im = new InstanceManager(Game::logger, Game::server->GetIP());
 
+	CDBehaviorParameterTable::CreateSharedMap();
+
 	//Depending on the config, start up servers:
 	if (config.GetValue("prestart_servers") != "" && config.GetValue("prestart_servers") == "1") {
 		StartChatServer();


### PR DESCRIPTION
Utilizes `boost::interprocess` to share maps between worlds.
The master server loads the tables into memory, and the worlds hook into it when they want to get an entry.

This solves the issue of skill delay and saves memory, but introduces the third-party library Boost.
There should be a conversation about the introduction of Boost — it is a large library and adds extra steps to the installation. Other options should be considered.