### PR TITLE
Address poor communication between Master and World servers

### DIFF
--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -303,7 +303,6 @@ int main(int argc, char** argv) {
 
 			if (affirmTimeout == 1000) {
 				instance->Shutdown();
-				instance->SetShutdownComplete(true);
 
 				Game::im->RedirectPendingRequests(instance);
 			}


### PR DESCRIPTION
We need to wait for the message that the world has shutdown before saying its been shutdown and allowing a new one to be created.  Assuming it has shutdown does not verify that the process was actually stopped an its better to play it safe than sorry and possibly lose player save data