### PR TITLE
Address friends list IDs and removal of friends

### DIFF
--- a/migrations/dlu/4_friends_list_objectids.sql
+++ b/migrations/dlu/4_friends_list_objectids.sql
@@ -1,0 +1,1 @@
+UPDATE friends SET player_id = player_id % 0x100000000, friend_id = friend_id % 0x100000000;


### PR DESCRIPTION
Fixes #267 
Fixes #249 
Fixes #469 

Address an issue where the incorrect player IDs were being sent into the friends database, as well as address the issue where you couldnt remove friends.  The former allows our database to follow the foreign key restraint setup by the initial mysql and also allow us to cross reference this table with others in the database without needing to convert to the character id.  A new migration is added this patch to convert the player LWOOBJIDs back into char IDs.  In the server however, they are still stored and used as LWOOBJID.  

Tested changes with 3 clients, all sending multiple requests and only 1 entry was added to the database per player<->friend pair.  Removing a friend also does not cause issues and removes the correct entry from the database.