### PR TITLE
Improve cpplinq checks

### DIFF
--- a/thirdparty/cpplinq/cpplinq.hpp
+++ b/thirdparty/cpplinq/cpplinq.hpp
@@ -14,6 +14,8 @@
 #ifndef CPPLINQ__HEADER_GUARD
 #   define CPPLINQ__HEADER_GUARD
 
+#undef min
+#undef max
 #define NOMINMAX
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
On certain Windows header versions defining NOMINMAX doesn't work for some odd reason.