### PR TITLE
Adding migration command to build script (updated)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,3 +7,6 @@ cmake ..
 
 # Run make to build the project. To build utilizing multiple cores, append `-j` and the amount of cores to utilize, for example `make -j8`
 make
+
+# Run migrations
+./MasterServer -m


### PR DESCRIPTION
Same intentions as in https://github.com/DarkflameUniverse/DarkflameServer/pull/645 , but implemented requested changes.

Checks are now done in MasterServer as requested. 

Tested in the following environments:

- Fully setup system (has all client files, mysql installed and database setup)
- Half setup system (no client files. mysql installed, but database NOT setup)
- Not setup system (no client files, and mysql NOT installed)

For the first environment, it compiled and ran the migration runner. MasterServer also ran with no crashes (with and without a migration history)

The last two environments compiled and skipped running the migration runner as expected. 