### PR TITLE
Enable _dynamic by default

### DIFF
--- a/CMakeVariables.txt
+++ b/CMakeVariables.txt
@@ -8,7 +8,7 @@ LICENSE=AGPL-3.0
 # 171022 - Unmodded client
 NET_VERSION=171022
 # Debugging
-# __dynamic=1
+__dynamic=1
 # Set __dynamic to 1 to enable the -rdynamic flag for the linker, yielding some symbols in crashlogs.
 # __ggdb=1
 # Set __ggdb to 1 to enable the -ggdb flag for the linker, including more debug info.


### PR DESCRIPTION
This allows for better crash logs at a ~2MB binary size increase on WSL and a fraction of a percent on Windows.  Crash logs will now show a better description of the stack trace and methods that were active at the time.  

Server still compiles and runs on Windows and WSL

Example snippet screenshotted below of running /crash which correctly shows the trace from Handle Packet to HandleChatCommand
![image](https://user-images.githubusercontent.com/39972741/179700078-4ec6b5b2-92a8-446e-8cd9-dc58c3ee488b.png)
