### PR TITLE
Better Unicode support in GeneralUtils

### DIFF
--- a/dCommon/GeneralUtils.cpp
+++ b/dCommon/GeneralUtils.cpp
@@ -42,6 +42,8 @@ inline void PushUTF8CodePoint(std::string& ret, char32_t cp) {
     }
 }
 
+constexpr const char16_t REPLACEMENT_CHARACTER = 0xFFFD;
+
 //! Converts an std::string (ASCII) to UCS-2 / UTF-16
 std::u16string GeneralUtils::ASCIIToUTF16(const std::string& string, size_t size) {
     size_t newSize = MinSize(size, string);
@@ -50,8 +52,7 @@ std::u16string GeneralUtils::ASCIIToUTF16(const std::string& string, size_t size
 
     for (size_t i = 0; i < newSize; i++) {
         char c = string[i];
-        assert(c > 0 && c <= 127);
-        ret.push_back(static_cast<char16_t>(c));
+        ret.push_back((c > 0 && c <= 127) ? static_cast<char16_t>(c) : REPLACEMENT_CHARACTER);
     }
 
     return ret;

--- a/dCommon/GeneralUtils.cpp
+++ b/dCommon/GeneralUtils.cpp
@@ -50,7 +50,7 @@ bool _IsSuffixChar(uint8_t c) {
 
 bool GeneralUtils::_NextUTF8Char(std::string_view& slice, uint32_t& out) {
     size_t rem = slice.length();
-    const uint8_t* bytes = (const uint8_t*) slice.begin();
+    const uint8_t* bytes = (const uint8_t*) &slice.front();
     if (rem > 0) {
         uint8_t first = bytes[0];
         if (first < 0x80) { // 1 byte character

--- a/dCommon/GeneralUtils.cpp
+++ b/dCommon/GeneralUtils.cpp
@@ -6,7 +6,7 @@
 #include <algorithm>
 
 template <typename T>
-inline size_t MinSize(size_t size, const std::basic_string<T>& string) {
+inline size_t MinSize(size_t size, const std::basic_string_view<T>& string) {
     if (size == size_t(-1) || size > string.size()) {
         return string.size();
     } else {
@@ -103,7 +103,7 @@ bool GeneralUtils::_NextUTF8Char(std::string_view& slice, uint32_t& out) {
     return false;
 }
 
-std::u16string GeneralUtils::UTF8ToUTF16(const std::string& string, size_t size) {
+std::u16string GeneralUtils::UTF8ToUTF16(const std::string_view& string, size_t size) {
     size_t newSize = MinSize(size, string);
     std::u16string output;
     output.reserve(newSize);
@@ -125,7 +125,7 @@ std::u16string GeneralUtils::UTF8ToUTF16(const std::string& string, size_t size)
 }
 
 //! Converts an std::string (ASCII) to UCS-2 / UTF-16
-std::u16string GeneralUtils::ASCIIToUTF16(const std::string& string, size_t size) {
+std::u16string GeneralUtils::ASCIIToUTF16(const std::string_view& string, size_t size) {
     size_t newSize = MinSize(size, string);
     std::u16string ret;
     ret.reserve(newSize);
@@ -141,7 +141,7 @@ std::u16string GeneralUtils::ASCIIToUTF16(const std::string& string, size_t size
 
 //! Converts a (potentially-ill-formed) UTF-16 string to UTF-8
 //! See: <http://simonsapin.github.io/wtf-8/#decoding-ill-formed-utf-16>
-std::string GeneralUtils::UTF16ToWTF8(const std::u16string& string, size_t size) {
+std::string GeneralUtils::UTF16ToWTF8(const std::u16string_view& string, size_t size) {
     size_t newSize = MinSize(size, string);
     std::string ret;
     ret.reserve(newSize);

--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -26,7 +26,7 @@ namespace GeneralUtils {
       \param size A size to trim the string to. Default is -1 (No trimming)
       \return An UTF-16 representation of the string
      */
-    std::u16string ASCIIToUTF16(const std::string& string, size_t size = -1);
+    std::u16string ASCIIToUTF16(const std::string_view& string, size_t size = -1);
 
     //! Converts a UTF-8 String to a UTF-16 string
     /*!
@@ -34,7 +34,7 @@ namespace GeneralUtils {
       \param size A size to trim the string to. Default is -1 (No trimming)
       \return An UTF-16 representation of the string
      */
-    std::u16string UTF8ToUTF16(const std::string& string, size_t size = -1);
+    std::u16string UTF8ToUTF16(const std::string_view& string, size_t size = -1);
 
     //! Internal, do not use
     bool _NextUTF8Char(std::string_view& slice, uint32_t& out);
@@ -45,7 +45,7 @@ namespace GeneralUtils {
       \param size A size to trim the string to. Default is -1 (No trimming)
       \return An UTF-8 representation of the string
      */
-    std::string UTF16ToWTF8(const std::u16string& string, size_t size = -1);
+    std::string UTF16ToWTF8(const std::u16string_view& string, size_t size = -1);
 
     /**
      * Compares two basic strings but does so ignoring case sensitivity

--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -34,8 +34,9 @@ namespace GeneralUtils {
       \param size A size to trim the string to. Default is -1 (No trimming)
       \return An UTF-16 representation of the string
      */
-    std::u16string UTF8ToUTF16(const std::string& string, size_t size);
+    std::u16string UTF8ToUTF16(const std::string& string, size_t size = -1);
 
+    //! Internal, do not use
     bool _NextUTF8Char(std::string_view& slice, uint32_t& out);
 
     //! Converts a UTF-16 string to a UTF-8 string

--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -28,6 +28,16 @@ namespace GeneralUtils {
      */
     std::u16string ASCIIToUTF16(const std::string& string, size_t size = -1);
 
+    //! Converts a UTF-8 String to a UTF-16 string
+    /*!
+      \param string The string to convert
+      \param size A size to trim the string to. Default is -1 (No trimming)
+      \return An UTF-16 representation of the string
+     */
+    std::u16string UTF8ToUTF16(const std::string& string, size_t size);
+
+    bool _NextUTF8Char(std::string_view& slice, uint32_t& out);
+
     //! Converts a UTF-16 string to a UTF-8 string
     /*!
       \param string The string to convert

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ create_test_sourcelist (Tests
 	AMFDeserializeTests.cpp
 	TestNiPoint3.cpp
 	TestLDFFormat.cpp
+	TestEncoding.cpp
 )
 
 # add the executable

--- a/tests/TestEncoding.cpp
+++ b/tests/TestEncoding.cpp
@@ -4,10 +4,6 @@
 #include "GeneralUtils.h"
 #include "CommonCxxTests.h"
 
-void Test(std::string_view& text_under_test, char32_t[] list) {
-
-}
-
 int TestEncoding(int argc, char* *const argv) {
     std::string x = "Hello World!";
     std::string_view v(x);
@@ -46,6 +42,11 @@ int TestEncoding(int argc, char* *const argv) {
     GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, 0x2696);
     GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, 0xFE0F);
     ASSERT_EQ(GeneralUtils::_NextUTF8Char(v, out), false);
+
+    ASSERT_EQ(GeneralUtils::UTF8ToUTF16("Hello World!"), u"Hello World!");
+    ASSERT_EQ(GeneralUtils::UTF8ToUTF16("Frühling"), u"Frühling");
+    ASSERT_EQ(GeneralUtils::UTF8ToUTF16("中文字"), u"中文字");
+    ASSERT_EQ(GeneralUtils::UTF8ToUTF16("👨‍⚖️"), u"👨‍⚖️");
 
     return 0;
 }

--- a/tests/TestEncoding.cpp
+++ b/tests/TestEncoding.cpp
@@ -1,0 +1,51 @@
+#include <stdexcept>
+#include <string>
+
+#include "GeneralUtils.h"
+#include "CommonCxxTests.h"
+
+void Test(std::string_view& text_under_test, char32_t[] list) {
+
+}
+
+int TestEncoding(int argc, char* *const argv) {
+    std::string x = "Hello World!";
+    std::string_view v(x);
+
+    uint32_t out;
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, 'H');
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, 'e');
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, 'l');
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, 'l');
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, 'o');
+    ASSERT_EQ(GeneralUtils::_NextUTF8Char(v, out), true);
+
+    x = u8"Frühling";
+    v = x;
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, U'F');
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, U'r');
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, U'ü');
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, U'h');
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, U'l');
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, U'i');
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, U'n');
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, U'g');
+    ASSERT_EQ(GeneralUtils::_NextUTF8Char(v, out), false);
+
+    x = "中文字";
+    v = x;
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, U'中');
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, U'文');
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, U'字');
+    ASSERT_EQ(GeneralUtils::_NextUTF8Char(v, out), false);
+
+    x = "👨‍⚖️";
+    v = x;
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, 0x1F468);
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, 0x200D);
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, 0x2696);
+    GeneralUtils::_NextUTF8Char(v, out); ASSERT_EQ(out, 0xFE0F);
+    ASSERT_EQ(GeneralUtils::_NextUTF8Char(v, out), false);
+
+    return 0;
+}


### PR DESCRIPTION
This PR

- Implements `UTF8ToUTF16`
- Produces `�` for bad `ASCIIToUTF16` input instead of crashing on assert
    - partial fix for #350

Note: For ease of reviews, this PR doesn't actually use `UTF8ToUTF16` in places where it really should, yet. That'll be done in an upcoming PR.