### PR TITLE
Use Aggro and Tether radii settings from Entity Settings

### DIFF
--- a/dGame/dComponents/BaseCombatAIComponent.cpp
+++ b/dGame/dComponents/BaseCombatAIComponent.cpp
@@ -61,6 +61,15 @@ BaseCombatAIComponent::BaseCombatAIComponent(Entity* parent, const uint32_t id) 
 
 	componentResult.finalize();
 
+	// Get aggro and tether radius from settings and use this if it is present.  Only overwrite the
+	// radii if it is greater than the one in the database.
+	if (m_Parent) {
+		auto aggroRadius = m_Parent->GetVar<float>(u"aggroRadius");
+		m_AggroRadius = std::max(aggroRadius, m_AggroRadius);
+		auto tetherRadius = m_Parent->GetVar<float>(u"tetherRadius");
+		m_HardTetherRadius = std::max(tetherRadius, m_HardTetherRadius);
+	}
+
 	/*
 	 * Find skills
 	 */


### PR DESCRIPTION
Override the DB aggro and tether radii from the settings if they are present and greater than the database entry.  Fixes Battle of Nimbus Station enemies not aggroing as they did in live across the whole map.

Tested that enemies around Battle of Nimbus Station and Avant Gardens still aggro'd correctly and all were aggroing and tethering at the expected radii