### PR TITLE
WSL Readme Section Changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ cmake --build . --config Release
 ### Windows builds (WSL)
 This section will go through how to install [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) and building in a Linux environment under Windows. WSL requires Windows 10 version 2004 and higher (Build 19041 and higher) or Windows 11 (Build 22000 and higher). 
 
-Please note that Microsoft sometimes ends up breaking WSL (there tends to be network issues when using WSL) and DLU won't be able to fix them so verify that its not WSL that is broken before reporting an issue.
+Please note that Microsoft sometimes ends up breaking WSL2 (there tends to be network issues when using WSL2) and DLU won't be able to fix them so verify that its not WSL that is broken before reporting an issue. Its also recommended that users use WSL1 instead as it's more stable. 
 
 **Open the Command Prompt application with Administrator permissions and run the following:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -114,12 +114,20 @@ cmake --build . --config Release
 ```
 
 ### Windows builds (WSL)
-This section will go through how to install [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) and building in a Linux environment under Windows. WSL requires Windows 10 version 2004 and higher (Build 19041 and higher) or Windows 11 (Build 22000 and higher).
+This section will go through how to install [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) and building in a Linux environment under Windows. WSL requires Windows 10 version 2004 and higher (Build 19041 and higher) or Windows 11 (Build 22000 and higher). 
+
+Please note that Microsoft sometimes ends up breaking WSL (there tends to be network issues when using WSL) and DLU won't be able to fix them so verify that its not WSL that is broken before reporting an issue.
 
 **Open the Command Prompt application with Administrator permissions and run the following:**
 ```bash
 # Installing Windows Subsystem for Linux
 wsl --install
+```
+
+**Change WSL version (OPTIONAL):**
+```bash
+# Changing WSL version for the distro you are using (by default its WSL2)
+wsl --set-version <distro name> <1 or 2>
 ```
 
 **Open the Ubuntu application and run the following:**

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ cmake --build . --config Release
 ```
 
 ### Windows builds (WSL)
-This section will go through how to install [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) and building in a Linux environment under Windows. WSL requires Windows 10 version 2004 and higher (Build 19041 and higher) or Windows 11.
+This section will go through how to install [WSL](https://docs.microsoft.com/en-us/windows/wsl/install) and building in a Linux environment under Windows. WSL requires Windows 10 version 2004 and higher (Build 19041 and higher) or Windows 11 (Build 22000 and higher).
 
 **Open the Command Prompt application with Administrator permissions and run the following:**
 ```bash


### PR DESCRIPTION
As the title says, this will be changing some stuff in the readme section for WSL

Changes include 

- Added the Windows 11 RTM build 22000 to the WSL requirement for Windows 11 `WSL requires...`
- Added "Change WSL version" which is optional if the user wants to use WSL1 instead
- Added a note that lets users reading the readme know about the network issues that may occur when using WSL and that its not an issue to do with DLU

I think this PR is a good idea especially knowing some people use WSL and report network issues sometimes that DLU can't solve as its to do with Microsoft