### PR TITLE
Fix racing lap times

### DIFF
--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -818,7 +818,7 @@ void RacingControlComponent::Update(float deltaTime) {
 
             // Reached the start point, lapped
             if (respawnIndex == 0) {
-                time_t lapTime = std::time(nullptr) - (player.lap == 1 ? m_StartTime : player.lapTime);
+                time_t lapTime = std::time(nullptr) - (player.lap == 0 ? m_StartTime : player.lapTime);
 
                 // Cheating check
                 if (lapTime < 40) {


### PR DESCRIPTION
Fixes #463 

Just a small change to properly track lap times on the first and second lap for races

Tested with logs and the correct time was reported for the first, second and third lap.