### PR TITLE
Fix NPC Proxy items

### DIFF
--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -66,6 +66,25 @@ InventoryComponent::InventoryComponent(Entity* parent, tinyxml2::XMLDocument* do
 		const auto& info = Inventory::FindItemComponent(item.itemid);
 
 		UpdateSlot(info.equipLocation, { id, static_cast<LOT>(item.itemid), item.count, slot++ });
+		
+		// Equip this items proxies.
+		auto subItems = info.subItems;
+		
+		subItems.erase(std::remove_if(subItems.begin(), subItems.end(), ::isspace), subItems.end());
+		
+		if (!subItems.empty()) {
+			const auto subItemsSplit = GeneralUtils::SplitString(subItems, ',');
+			
+			for (auto proxyLotAsString : subItemsSplit) {
+				const auto proxyLOT = static_cast<LOT>(std::stoi(proxyLotAsString));
+				
+				const auto& proxyInfo = Inventory::FindItemComponent(proxyLOT);
+				const LWOOBJID proxyId = ObjectIDManager::Instance()->GenerateObjectID();
+				
+				// Use item.count since we equip item.count number of the item this is a requested proxy of
+				UpdateSlot(proxyInfo.equipLocation, { proxyId, proxyLOT, item.count, slot++ } );
+			}
+		}
 	}
 }
 

--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -818,7 +818,7 @@ void RacingControlComponent::Update(float deltaTime) {
 
             // Reached the start point, lapped
             if (respawnIndex == 0) {
-                time_t lapTime = std::time(nullptr) - (player.lap == 1 ? m_StartTime : player.lapTime);
+                time_t lapTime = std::time(nullptr) - (player.lap == 0 ? m_StartTime : player.lapTime);
 
                 // Cheating check
                 if (lapTime < 40) {


### PR DESCRIPTION
NPCs are supposed to equip the sub items of items they equip and were not doing so.  This PR adds this functionality and fixes and issue where Neido on Crux Prime was not wearing their sword.

Tested that Neido has their sword and that other NPCs that wear proxies also get their proxies equipped.  Had no issues with any other world crashing.