### PR TITLE
Remove parentheses from ADD reporter_id

### DIFF
--- a/migrations/dlu/2_reporter_id.sql
+++ b/migrations/dlu/2_reporter_id.sql
@@ -1,1 +1,1 @@
-ALTER TABLE bug_reports ADD (reporter_id) INT NOT NULL DEFAULT 0;
+ALTER TABLE bug_reports ADD reporter_id INT NOT NULL DEFAULT 0;


### PR DESCRIPTION
Removes parentheses from the `ADD reporter_id` statement in [migrations/dlu/2_reporter_id.sql](https://github.com/DarkflameUniverse/DarkflameServer/compare/reporter_id_fix?expand=1#diff-cf744faf89bba96f349dfaded7e41503511067b9fb4d1bcd7ef5d5337ad8abc7). This statement will error with parentheses on stock MariaDB.