### PR TITLE
Add an update bash script for updating the Darkflame Server [no-ci]

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,17 @@
+# Git Pull the recent changes from the repository
+git pull
+
+# check if there is a submodule update
+git submodule update --init --recursive
+
+# cd into the directory build
+cd build
+
+# run the cmake command
+cmake ..
+
+# run the make command
+make
+
+# run the migrations
+./MasterServer -m


### PR DESCRIPTION
This script is intended for updating the Darkflame Server in Linux, it does all of what build.sh does but this has more commands on it as its starting from the first command you run when updating your Darkflame Server which is `git pull` then 
`git submodule update --init --recursive`

I feel like I should try to justify my reasoning for this, build.sh can be seen as a first use when building the server as if you are building the server for the first time you aren't going to be git pulling rather git cloning, update.sh can be seen as updating the server (assuming you have already your server set up and all it needs is to update to the latest changes) there after.