### PR TITLE
Remove Game Master level 9 helping hands

### DIFF
--- a/dGame/dUtilities/Preconditions.cpp
+++ b/dGame/dUtilities/Preconditions.cpp
@@ -277,11 +277,6 @@ bool PreconditionExpression::Check(Entity* player, bool evaluateCosts) const {
 		return true;
 	}
 
-	if (player->GetGMLevel() >= 9) // Developers can skip this for testing
-	{
-		return true;
-	}
-
 	const auto a = Preconditions::Check(player, condition, evaluateCosts);
 
 	if (!a) {


### PR DESCRIPTION
This has been more annoying than helpful for testing because you expect 1 behavior but get another.