### PR TITLE
Replace the vsprintf used in the logger with vsnprintf.

### DIFF
--- a/dCommon/dLogger.cpp
+++ b/dCommon/dLogger.cpp
@@ -26,13 +26,6 @@ dLogger::~dLogger() {
 }
 
 void dLogger::vLog(const char* format, va_list args) {
-	const char* tempPtr = format; // strlen_s implementation for Linux and Windows
-	for (; *tempPtr != '\0'; ++tempPtr) {
-		size_t size = tempPtr - format;
-		if (size > 600) {
-			return;
-		}
-	}
 #ifdef _WIN32
 	time_t t = time(NULL);
 	struct tm time;
@@ -40,7 +33,7 @@ void dLogger::vLog(const char* format, va_list args) {
 	char timeStr[70];
 	strftime(timeStr, sizeof(timeStr), "%d-%m-%y %H:%M:%S", &time);
 	char message[2048];
-	vsprintf_s(message, format, args);
+	vsnprintf(message, 2048, format, args);
 
 	if (m_logToConsole) std::cout << "[" << timeStr << "] " << message;
 	mFile << "[" << timeStr << "] " << message;
@@ -50,7 +43,7 @@ void dLogger::vLog(const char* format, va_list args) {
 	char timeStr[70];
 	strftime(timeStr, sizeof(timeStr), "%d-%m-%y %H:%M:%S", time);
 	char message[2048];
-	vsprintf(message, format, args);
+	vsnprintf(message, 2048, format, args);
 
 	if (m_logToConsole) {
 		fputs("[", stdout);


### PR DESCRIPTION
This removes the requirement for a strlen implementation at the top of the function.