### PR TITLE
Use UTF8ToUTF16 in more places

### DIFF
--- a/dChatServer/ChatPacketHandler.cpp
+++ b/dChatServer/ChatPacketHandler.cpp
@@ -599,7 +599,7 @@ void ChatPacketHandler::HandleTeamKick(Packet* packet) {
 	if (kicked != nullptr) {
 		kickedId = kicked->playerID;
 	} else {
-		kickedId = playerContainer.GetId(GeneralUtils::ASCIIToUTF16(kickedPlayer));
+		kickedId = playerContainer.GetId(GeneralUtils::UTF8ToUTF16(kickedPlayer));
 	}
 
 	if (kickedId == LWOOBJID_EMPTY) return;
@@ -690,7 +690,7 @@ void ChatPacketHandler::HandleTeamStatusRequest(Packet* packet) {
 
 		playerContainer.TeamStatusUpdate(team);
 
-		const auto leaderName = GeneralUtils::ASCIIToUTF16(std::string(data->playerName.c_str()));
+		const auto leaderName = GeneralUtils::UTF8ToUTF16(data->playerName);
 
 		for (const auto memberId : team->memberIDs) {
 			auto* otherMember = playerContainer.GetPlayerData(memberId);

--- a/dChatServer/PlayerContainer.cpp
+++ b/dChatServer/PlayerContainer.cpp
@@ -35,7 +35,7 @@ void PlayerContainer::InsertPlayer(Packet* packet) {
 	inStream.Read(data->muteExpire);
 	data->sysAddr = packet->systemAddress;
 
-	mNames[data->playerID] = GeneralUtils::ASCIIToUTF16(std::string(data->playerName.c_str()));
+	mNames[data->playerID] = GeneralUtils::UTF8ToUTF16(data->playerName);
 
 	mPlayers.insert(std::make_pair(data->playerID, data));
 	Game::logger->Log("PlayerContainer", "Added user: %s (%llu), zone: %i", data->playerName.c_str(), data->playerID, data->zoneID.GetMapID());
@@ -71,7 +71,7 @@ void PlayerContainer::RemovePlayer(Packet* packet) {
 	auto* team = GetTeam(playerID);
 
 	if (team != nullptr) {
-		const auto memberName = GeneralUtils::ASCIIToUTF16(std::string(player->playerName.c_str()));
+		const auto memberName = GeneralUtils::UTF8ToUTF16(std::string(player->playerName.c_str()));
 
 		for (const auto memberId : team->memberIDs) {
 			auto* otherMember = GetPlayerData(memberId);
@@ -221,8 +221,8 @@ void PlayerContainer::AddMember(TeamData* team, LWOOBJID playerID) {
 
 	if (leader == nullptr || member == nullptr) return;
 
-	const auto leaderName = GeneralUtils::ASCIIToUTF16(std::string(leader->playerName.c_str()));
-	const auto memberName = GeneralUtils::ASCIIToUTF16(std::string(member->playerName.c_str()));
+	const auto leaderName = GeneralUtils::UTF8ToUTF16(leader->playerName);
+	const auto memberName = GeneralUtils::UTF8ToUTF16(member->playerName);
 
 	ChatPacketHandler::SendTeamInviteConfirm(member, false, leader->playerID, leader->zoneID, team->lootFlag, 0, 0, leaderName);
 
@@ -309,7 +309,7 @@ void PlayerContainer::DisbandTeam(TeamData* team) {
 
 		if (otherMember == nullptr) continue;
 
-		const auto memberName = GeneralUtils::ASCIIToUTF16(std::string(otherMember->playerName.c_str()));
+		const auto memberName = GeneralUtils::UTF8ToUTF16(otherMember->playerName);
 
 		ChatPacketHandler::SendTeamSetLeader(otherMember, LWOOBJID_EMPTY);
 		ChatPacketHandler::SendTeamRemovePlayer(otherMember, true, false, false, team->local, team->leaderID, otherMember->playerID, memberName);
@@ -331,7 +331,7 @@ void PlayerContainer::TeamStatusUpdate(TeamData* team) {
 
 	if (leader == nullptr) return;
 
-	const auto leaderName = GeneralUtils::ASCIIToUTF16(std::string(leader->playerName.c_str()));
+	const auto leaderName = GeneralUtils::UTF8ToUTF16(leader->playerName);
 
 	for (const auto memberId : team->memberIDs) {
 		auto* otherMember = GetPlayerData(memberId);

--- a/dCommon/LDFFormat.cpp
+++ b/dCommon/LDFFormat.cpp
@@ -49,7 +49,7 @@ LDFBaseData* LDFBaseData::DataFromString(const std::string& format) {
 
 			switch (type) {
 			case LDF_TYPE_UTF_16: {
-				std::u16string data = GeneralUtils::ASCIIToUTF16(dataArray[1]);
+				std::u16string data = GeneralUtils::UTF8ToUTF16(dataArray[1]);
 				return new LDFData<std::u16string>(key, data);
 			}
 

--- a/dDatabase/Tables/CDRailActivatorComponent.cpp
+++ b/dDatabase/Tables/CDRailActivatorComponent.cpp
@@ -8,23 +8,12 @@ CDRailActivatorComponentTable::CDRailActivatorComponentTable() {
 
 		entry.id = tableData.getIntField(0);
 
-		std::string startAnimation(tableData.getStringField(1, ""));
-		entry.startAnimation = GeneralUtils::ASCIIToUTF16(startAnimation);
-
-		std::string loopAnimation(tableData.getStringField(2, ""));
-		entry.loopAnimation = GeneralUtils::ASCIIToUTF16(loopAnimation);
-
-		std::string stopAnimation(tableData.getStringField(3, ""));
-		entry.stopAnimation = GeneralUtils::ASCIIToUTF16(stopAnimation);
-
-		std::string startSound(tableData.getStringField(4, ""));
-		entry.startSound = GeneralUtils::ASCIIToUTF16(startSound);
-
-		std::string loopSound(tableData.getStringField(5, ""));
-		entry.loopSound = GeneralUtils::ASCIIToUTF16(loopSound);
-
-		std::string stopSound(tableData.getStringField(6, ""));
-		entry.stopSound = GeneralUtils::ASCIIToUTF16(stopSound);
+		entry.startAnimation = GeneralUtils::ASCIIToUTF16(tableData.getStringField(1, ""));
+		entry.loopAnimation = GeneralUtils::ASCIIToUTF16(tableData.getStringField(2, ""));
+		entry.stopAnimation = GeneralUtils::ASCIIToUTF16(tableData.getStringField(3, ""));
+		entry.startSound = GeneralUtils::ASCIIToUTF16(tableData.getStringField(4, ""));
+		entry.loopSound = GeneralUtils::ASCIIToUTF16(tableData.getStringField(5, ""));
+		entry.stopSound = GeneralUtils::ASCIIToUTF16(tableData.getStringField(6, ""));
 
 		std::string loopEffectString(tableData.getStringField(7, ""));
 		entry.loopEffectID = EffectPairFromString(loopEffectString);

--- a/dGame/LeaderboardManager.cpp
+++ b/dGame/LeaderboardManager.cpp
@@ -45,7 +45,7 @@ std::u16string Leaderboard::ToString() const {
 		index++;
 	}
 
-	return GeneralUtils::ASCIIToUTF16(leaderboard);
+	return GeneralUtils::UTF8ToUTF16(leaderboard);
 }
 
 std::vector<LeaderboardEntry> Leaderboard::GetEntries() {

--- a/dGame/dComponents/CharacterComponent.cpp
+++ b/dGame/dComponents/CharacterComponent.cpp
@@ -228,7 +228,7 @@ void CharacterComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
 	const tinyxml2::XMLAttribute* rocketConfig = character->FindAttribute("lcbp");
 
 	if (rocketConfig) {
-		m_LastRocketConfig = GeneralUtils::ASCIIToUTF16(std::string(rocketConfig->Value()));
+		m_LastRocketConfig = GeneralUtils::ASCIIToUTF16(rocketConfig->Value());
 	} else {
 		m_LastRocketConfig = u"";
 	}
@@ -262,7 +262,7 @@ void CharacterComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
 		character->QueryInt64Attribute("gid", &gid);
 		if (gid != 0) {
 			std::string guildname(gn);
-			m_GuildName = GeneralUtils::ASCIIToUTF16(guildname);
+			m_GuildName = GeneralUtils::UTF8ToUTF16(guildname);
 			m_GuildID = gid;
 			m_DirtySocialInfo = true;
 		}

--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -121,8 +121,8 @@ void PetComponent::Serialize(RakNet::BitStream* outBitStream, bool bIsInitialUpd
 	if (tamed) {
 		outBitStream->Write(m_ModerationStatus);
 
-		const auto nameData = GeneralUtils::ASCIIToUTF16(m_Name);
-		const auto ownerNameData = GeneralUtils::ASCIIToUTF16(m_OwnerName);
+		const auto nameData = GeneralUtils::UTF8ToUTF16(m_Name);
+		const auto ownerNameData = GeneralUtils::UTF8ToUTF16(m_OwnerName);
 
 		outBitStream->Write(static_cast<uint8_t>(nameData.size()));
 		for (const auto c : nameData) {
@@ -567,7 +567,7 @@ void PetComponent::NotifyTamingBuildSuccess(NiPoint3 position) {
 	std::string petName = tamer->GetCharacter()->GetName();
 	petName += "'s Pet";
 
-	GameMessages::SendAddPetToPlayer(m_Tamer, 0, GeneralUtils::ASCIIToUTF16(petName), petSubKey, m_Parent->GetLOT(), tamer->GetSystemAddress());
+	GameMessages::SendAddPetToPlayer(m_Tamer, 0, GeneralUtils::UTF8ToUTF16(petName), petSubKey, m_Parent->GetLOT(), tamer->GetSystemAddress());
 
 	GameMessages::SendRegisterPetID(m_Tamer, m_Parent->GetObjectID(), tamer->GetSystemAddress());
 
@@ -634,7 +634,7 @@ void PetComponent::RequestSetPetName(std::u16string name) {
 			//Save our pet's new name to the db:
 			SetPetNameForModeration(GeneralUtils::UTF16ToWTF8(name));
 
-			GameMessages::SendSetPetName(m_Owner, GeneralUtils::ASCIIToUTF16(m_Name), m_DatabaseId, owner->GetSystemAddress());
+			GameMessages::SendSetPetName(m_Owner, GeneralUtils::UTF8ToUTF16(m_Name), m_DatabaseId, owner->GetSystemAddress());
 			GameMessages::SendSetPetNameModerated(m_Owner, m_DatabaseId, m_ModerationStatus, owner->GetSystemAddress());
 		}
 
@@ -665,9 +665,11 @@ void PetComponent::RequestSetPetName(std::u16string name) {
 
 	EntityManager::Instance()->SerializeEntity(m_Parent);
 
-	GameMessages::SendSetPetName(m_Tamer, GeneralUtils::ASCIIToUTF16(m_Name), m_DatabaseId, tamer->GetSystemAddress());
-	GameMessages::SendSetPetName(m_Tamer, GeneralUtils::ASCIIToUTF16(m_Name), LWOOBJID_EMPTY, tamer->GetSystemAddress());
-	GameMessages::SendPetNameChanged(m_Parent->GetObjectID(), m_ModerationStatus, GeneralUtils::ASCIIToUTF16(m_Name), GeneralUtils::ASCIIToUTF16(m_OwnerName), UNASSIGNED_SYSTEM_ADDRESS);
+	std::u16string u16name = GeneralUtils::UTF8ToUTF16(m_Name);
+	std::u16string u16ownerName = GeneralUtils::UTF8ToUTF16(m_OwnerName);
+	GameMessages::SendSetPetName(m_Tamer, u16name, m_DatabaseId, tamer->GetSystemAddress());
+	GameMessages::SendSetPetName(m_Tamer, u16name, LWOOBJID_EMPTY, tamer->GetSystemAddress());
+	GameMessages::SendPetNameChanged(m_Parent->GetObjectID(), m_ModerationStatus, u16name, u16ownerName, UNASSIGNED_SYSTEM_ADDRESS);
 	GameMessages::SendSetPetNameModerated(m_Tamer, m_DatabaseId, m_ModerationStatus, tamer->GetSystemAddress());
 
 	GameMessages::SendNotifyPetTamingMinigame(
@@ -877,7 +879,7 @@ void PetComponent::Activate(Item* item, bool registerPet, bool fromTaming) {
 	m_OwnerName = owner->GetCharacter()->GetName();
 
 	if (updatedModerationStatus) {
-		GameMessages::SendSetPetName(m_Owner, GeneralUtils::ASCIIToUTF16(m_Name), m_DatabaseId, owner->GetSystemAddress());
+		GameMessages::SendSetPetName(m_Owner, GeneralUtils::UTF8ToUTF16(m_Name), m_DatabaseId, owner->GetSystemAddress());
 		GameMessages::SendSetPetNameModerated(m_Owner, m_DatabaseId, m_ModerationStatus, owner->GetSystemAddress());
 	}
 
@@ -892,7 +894,7 @@ void PetComponent::Activate(Item* item, bool registerPet, bool fromTaming) {
 	owner->GetCharacter()->SetPlayerFlag(69, true);
 
 	if (registerPet) {
-		GameMessages::SendAddPetToPlayer(m_Owner, 0, GeneralUtils::ASCIIToUTF16(m_Name), m_DatabaseId, m_Parent->GetLOT(), owner->GetSystemAddress());
+		GameMessages::SendAddPetToPlayer(m_Owner, 0, GeneralUtils::UTF8ToUTF16(m_Name), m_DatabaseId, m_Parent->GetLOT(), owner->GetSystemAddress());
 
 		GameMessages::SendRegisterPetID(m_Owner, m_Parent->GetObjectID(), owner->GetSystemAddress());
 

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -978,6 +978,8 @@ void GameMessages::SendSetNetworkScriptVar(Entity* entity, const SystemAddress& 
 		bitStream.Write(entity->GetObjectID());
 	bitStream.Write((uint16_t)GAME_MSG_SET_NETWORK_SCRIPT_VAR);
 
+	// FIXME: this is a bad place to need to do a conversion because we have no clue whether data is utf8 or plain ascii
+	// an this has performance implications
 	const auto u16Data = GeneralUtils::ASCIIToUTF16(data);
 	uint32_t dataSize = static_cast<uint32_t>(u16Data.size());
 
@@ -3188,7 +3190,7 @@ void GameMessages::HandleClientTradeRequest(RakNet::BitStream* inStream, Entity*
 			i64Invitee,
 			bNeedInvitePopUp,
 			entity->GetObjectID(),
-			GeneralUtils::ASCIIToUTF16(entity->GetCharacter()->GetName()),
+			GeneralUtils::UTF8ToUTF16(entity->GetCharacter()->GetName()),
 			invitee->GetSystemAddress()
 		);
 	}
@@ -5086,7 +5088,8 @@ void GameMessages::HandleNotifyServerLevelProcessingComplete(RakNet::BitStream* 
 	wss << "name=0:";
 	wss << character->GetName();
 
-	std::u16string attrs = GeneralUtils::ASCIIToUTF16(wss.str());
+	// FIXME: only really need utf8 conversion for the name, so move that up?
+	std::u16string attrs = GeneralUtils::UTF8ToUTF16(wss.str());
 	std::u16string wsText = u"UI_LEVEL_PROGRESSION_LEVELUP_MESSAGE";
 
 	GameMessages::SendBroadcastTextToChatbox(entity, UNASSIGNED_SYSTEM_ADDRESS, attrs, wsText);

--- a/dGame/dGameMessages/PropertyDataMessage.cpp
+++ b/dGame/dGameMessages/PropertyDataMessage.cpp
@@ -14,19 +14,19 @@ void GameMessages::PropertyDataMessage::Serialize(RakNet::BitStream& stream) con
 	stream.Write<uint16_t>(VendorMapId); // - vendor map id
 	stream.Write<uint32_t>(cloneId); // clone id
 
-	const auto& name = GeneralUtils::ASCIIToUTF16(Name);
+	const auto& name = GeneralUtils::UTF8ToUTF16(Name);
 	stream.Write(uint32_t(name.size()));
 	for (uint32_t i = 0; i < name.size(); ++i) {
 		stream.Write(uint16_t(name[i]));
 	}
 
-	const auto& description = GeneralUtils::ASCIIToUTF16(Description);
+	const auto& description = GeneralUtils::UTF8ToUTF16(Description);
 	stream.Write(uint32_t(description.size()));
 	for (uint32_t i = 0; i < description.size(); ++i) {
 		stream.Write(uint16_t(description[i]));
 	}
 
-	const auto& owner = GeneralUtils::ASCIIToUTF16(OwnerName);
+	const auto& owner = GeneralUtils::UTF8ToUTF16(OwnerName);
 	stream.Write(uint32_t(owner.size()));
 	for (uint32_t i = 0; i < owner.size(); ++i) {
 		stream.Write(uint16_t(owner[i]));
@@ -68,7 +68,7 @@ void GameMessages::PropertyDataMessage::Serialize(RakNet::BitStream& stream) con
 	else stream.Write<uint32_t>(REJECTION_STATUS_PENDING);
 
 	// Does this go here???
-	// const auto& rejectionReasonConverted = GeneralUtils::ASCIIToUTF16(rejectionReason);
+	// const auto& rejectionReasonConverted = GeneralUtils::UTF8ToUTF16(rejectionReason);
 	// stream.Write(uint32_t(rejectionReasonConverted.size()));
 	// for (uint32_t i = 0; i < rejectionReasonConverted.size(); ++i) {
 	// 	stream.Write(uint16_t(rejectionReasonConverted[i]));

--- a/dGame/dGameMessages/PropertySelectQueryProperty.cpp
+++ b/dGame/dGameMessages/PropertySelectQueryProperty.cpp
@@ -3,19 +3,19 @@
 void PropertySelectQueryProperty::Serialize(RakNet::BitStream& stream) const {
 	stream.Write(CloneId);
 
-	const auto& owner = GeneralUtils::ASCIIToUTF16(OwnerName);
+	const auto& owner = GeneralUtils::UTF8ToUTF16(OwnerName);
 	stream.Write(uint32_t(owner.size()));
 	for (uint32_t i = 0; i < owner.size(); ++i) {
 		stream.Write(static_cast<uint16_t>(owner[i]));
 	}
 
-	const auto& name = GeneralUtils::ASCIIToUTF16(Name);
+	const auto& name = GeneralUtils::UTF8ToUTF16(Name);
 	stream.Write(uint32_t(name.size()));
 	for (uint32_t i = 0; i < name.size(); ++i) {
 		stream.Write(static_cast<uint16_t>(name[i]));
 	}
 
-	const auto& description = GeneralUtils::ASCIIToUTF16(Description);
+	const auto& description = GeneralUtils::UTF8ToUTF16(Description);
 	stream.Write(uint32_t(description.size()));
 	for (uint32_t i = 0; i < description.size(); ++i) {
 		stream.Write(static_cast<uint16_t>(description[i]));

--- a/dGame/dUtilities/Mail.cpp
+++ b/dGame/dUtilities/Mail.cpp
@@ -290,9 +290,9 @@ void Mail::HandleDataRequest(RakNet::BitStream* packet, const SystemAddress& sys
 		while (res->next()) {
 			bitStream.Write(res->getUInt64(1)); //MailID
 
-			/*std::u16string subject = GeneralUtils::ASCIIToUTF16(res->getString(7));
-			std::u16string body = GeneralUtils::ASCIIToUTF16(res->getString(8));
-			std::u16string sender = GeneralUtils::ASCIIToUTF16(res->getString(3));
+			/*std::u16string subject = GeneralUtils::UTF8ToUTF16(res->getString(7));
+			std::u16string body = GeneralUtils::UTF8ToUTF16(res->getString(8));
+			std::u16string sender = GeneralUtils::UTF8ToUTF16(res->getString(3));
 
 			WriteToPacket(&bitStream, subject, 50);
 			WriteToPacket(&bitStream, body, 400);

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -173,7 +173,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		std::stringstream message;
 		message << character->GetName() << " changed their PVP flag to " << std::to_string(character->GetPvpEnabled()) << "!";
 
-		ChatPackets::SendSystemMessage(UNASSIGNED_SYSTEM_ADDRESS, GeneralUtils::ASCIIToUTF16(message.str()), true);
+		ChatPackets::SendSystemMessage(UNASSIGNED_SYSTEM_ADDRESS, GeneralUtils::UTF8ToUTF16(message.str()), true);
 
 		return;
 	}
@@ -189,7 +189,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 			ChatPackets::SendSystemMessage(
 				sysAddr,
-				GeneralUtils::ASCIIToUTF16(player == entity ? name + " (you)" : name)
+				GeneralUtils::UTF8ToUTF16(player == entity ? name + " (you)" : name)
 			);
 		}
 	}
@@ -678,6 +678,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			return;
 		}
 
+		// FIXME: use fallible ASCIIToUTF16 conversion, because non-ascii isn't valid anyway
 		GameMessages::SendPlayFXEffect(entity->GetObjectID(), effectID, GeneralUtils::ASCIIToUTF16(args[1]), args[2]);
 	}
 
@@ -829,7 +830,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			name += arg + " ";
 		}
 
-		GameMessages::SendSetName(entity->GetObjectID(), GeneralUtils::ASCIIToUTF16(name), UNASSIGNED_SYSTEM_ADDRESS);
+		GameMessages::SendSetName(entity->GetObjectID(), GeneralUtils::UTF8ToUTF16(name), UNASSIGNED_SYSTEM_ADDRESS);
 	}
 
 	if (chatCommand == "title" && entity->GetGMLevel() >= GAME_MASTER_LEVEL_DEVELOPER) {
@@ -839,7 +840,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			name += arg + " ";
 		}
 
-		GameMessages::SendSetName(entity->GetObjectID(), GeneralUtils::ASCIIToUTF16(name), UNASSIGNED_SYSTEM_ADDRESS);
+		GameMessages::SendSetName(entity->GetObjectID(), GeneralUtils::UTF8ToUTF16(name), UNASSIGNED_SYSTEM_ADDRESS);
 	}
 
 	if ((chatCommand == "teleport" || chatCommand == "tele") && entity->GetGMLevel() >= GAME_MASTER_LEVEL_JUNIOR_MODERATOR) {
@@ -971,7 +972,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 				delete result;
 
 				if (accountId == 0) {
-					ChatPackets::SendSystemMessage(sysAddr, u"Count not find player of name: " + GeneralUtils::ASCIIToUTF16(args[0]));
+					ChatPackets::SendSystemMessage(sysAddr, u"Count not find player of name: " + GeneralUtils::UTF8ToUTF16(args[0]));
 
 					return;
 				}
@@ -1023,7 +1024,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 			const auto timeStr = GeneralUtils::ASCIIToUTF16(std::string(buffer));
 
-			ChatPackets::SendSystemMessage(sysAddr, u"Muted: " + GeneralUtils::ASCIIToUTF16(args[0]) + u" until " + timeStr);
+			ChatPackets::SendSystemMessage(sysAddr, u"Muted: " + GeneralUtils::UTF8ToUTF16(args[0]) + u" until " + timeStr);
 
 			//Notify chat about it
 			CBITSTREAM;
@@ -1042,15 +1043,15 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		if (args.size() == 1) {
 			auto* player = Player::GetPlayer(args[0]);
 
+			std::u16string username = GeneralUtils::UTF8ToUTF16(args[0]);
 			if (player == nullptr) {
-				ChatPackets::SendSystemMessage(sysAddr, u"Count not find player of name: " + GeneralUtils::ASCIIToUTF16(args[0]));
-
+				ChatPackets::SendSystemMessage(sysAddr, u"Count not find player of name: " + username);
 				return;
 			}
 
 			Game::server->Disconnect(player->GetSystemAddress(), SERVER_DISCON_KICK);
 
-			ChatPackets::SendSystemMessage(sysAddr, u"Kicked: " + GeneralUtils::ASCIIToUTF16(args[0]));
+			ChatPackets::SendSystemMessage(sysAddr, u"Kicked: " + username);
 		} else {
 			ChatPackets::SendSystemMessage(sysAddr, u"Correct usage: /kick <username>");
 		}
@@ -1077,7 +1078,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 				delete result;
 
 				if (accountId == 0) {
-					ChatPackets::SendSystemMessage(sysAddr, u"Count not find player of name: " + GeneralUtils::ASCIIToUTF16(args[0]));
+					ChatPackets::SendSystemMessage(sysAddr, u"Count not find player of name: " + GeneralUtils::UTF8ToUTF16(args[0]));
 
 					return;
 				}
@@ -1165,7 +1166,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 		while (!tables.eof()) {
 			std::string message = std::to_string(tables.getIntField(0)) + " - " + tables.getStringField(1);
-			ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16(message, message.size()));
+			ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::UTF8ToUTF16(message, message.size()));
 			tables.nextRow();
 		}
 	}
@@ -1222,12 +1223,12 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			auto requestedPlayer = Player::GetPlayer(requestedPlayerToSetLevelOf);
 
 			if (!requestedPlayer) {
-				ChatPackets::SendSystemMessage(sysAddr, u"No player found with username: (" + GeneralUtils::ASCIIToUTF16(requestedPlayerToSetLevelOf) + u").");
+				ChatPackets::SendSystemMessage(sysAddr, u"No player found with username: (" + GeneralUtils::UTF8ToUTF16(requestedPlayerToSetLevelOf) + u").");
 				return;
 			}
 
 			if (!requestedPlayer->GetOwner()) {
-				ChatPackets::SendSystemMessage(sysAddr, u"No entity found with username: (" + GeneralUtils::ASCIIToUTF16(requestedPlayerToSetLevelOf) + u").");
+				ChatPackets::SendSystemMessage(sysAddr, u"No entity found with username: (" + GeneralUtils::UTF8ToUTF16(requestedPlayerToSetLevelOf) + u").");
 				return;
 			}
 
@@ -1269,7 +1270,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 		if (requestedPlayerToSetLevelOf != "") {
 			ChatPackets::SendSystemMessage(
-				sysAddr, u"Set " + GeneralUtils::ASCIIToUTF16(requestedPlayerToSetLevelOf) + u"'s level to " + GeneralUtils::to_u16string(requestedLevel) +
+				sysAddr, u"Set " + GeneralUtils::UTF8ToUTF16(requestedPlayerToSetLevelOf) + u"'s level to " + GeneralUtils::to_u16string(requestedLevel) +
 				u" and UScore to " + GeneralUtils::to_u16string(characterComponent->GetUScore()) +
 				u". Relog to see changes.");
 		} else {
@@ -1437,8 +1438,8 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 				});
 		} else {
 			std::string msg = "ZoneID not found or allowed: ";
-			msg.append(args[0]);
-			ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16(msg, msg.size()));
+			msg.append(args[0]); // FIXME: unnecessary utf16 re-encoding just for error
+			ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::UTF8ToUTF16(msg, msg.size()));
 		}
 	}
 
@@ -1572,17 +1573,18 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		GameConfig::SetValue(args[0], args[1]);
 
 		ChatPackets::SendSystemMessage(
-			sysAddr, u"Set config value: " + GeneralUtils::ASCIIToUTF16(args[0]) + u" to " + GeneralUtils::ASCIIToUTF16(args[1])
+			sysAddr, u"Set config value: " + GeneralUtils::UTF8ToUTF16(args[0]) + u" to " + GeneralUtils::UTF8ToUTF16(args[1])
 		);
 	}
 
 	if (chatCommand == "config-get" && entity->GetGMLevel() >= GAME_MASTER_LEVEL_DEVELOPER && args.size() >= 1) {
 		const auto& value = GameConfig::GetValue(args[0]);
 
+		std::u16string u16key = GeneralUtils::UTF8ToUTF16(args[0]);
 		if (value.empty()) {
-			ChatPackets::SendSystemMessage(sysAddr, u"No value found for " + GeneralUtils::ASCIIToUTF16(args[0]));
+			ChatPackets::SendSystemMessage(sysAddr, u"No value found for " + u16key);
 		} else {
-			ChatPackets::SendSystemMessage(sysAddr, u"Value for " + GeneralUtils::ASCIIToUTF16(args[0]) + u": " + GeneralUtils::ASCIIToUTF16(value));
+			ChatPackets::SendSystemMessage(sysAddr, u"Value for " + u16key + u": " + GeneralUtils::UTF8ToUTF16(value));
 		}
 	}
 
@@ -1672,7 +1674,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		if (!GeneralUtils::TryParse(args[0], component)) {
 			component = -1;
 
-			ldf = GeneralUtils::ASCIIToUTF16(args[0]);
+			ldf = GeneralUtils::UTF8ToUTF16(args[0]);
 
 			isLDF = true;
 		}
@@ -1755,10 +1757,10 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 				EntityManager::Instance()->SerializeEntity(closest);
 			} else if (args[1] == "-a" && args.size() >= 3) {
-				GameMessages::SendPlayAnimation(closest, GeneralUtils::ASCIIToUTF16(args[2]));
+				GameMessages::SendPlayAnimation(closest, GeneralUtils::UTF8ToUTF16(args[2]));
 			} else if (args[1] == "-s") {
 				for (auto* entry : closest->GetSettings()) {
-					ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16(entry->GetString()));
+					ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::UTF8ToUTF16(entry->GetString()));
 				}
 
 				ChatPackets::SendSystemMessage(sysAddr, u"------");


### PR DESCRIPTION
As suggested in #658, this replaces `ASCIIToUTF16` with the new `UTF8ToUTF16` in a few places where it seems appropriate. I haven't tested this ingame yet, so would appreciate if someone does, incase we missed a spot where the input encoding is actually Latin-1 / windows-1521