### PR TITLE
Implement missing null checks on destruction of the navigation mesh

### DIFF
--- a/dNavigation/dNavMesh.cpp
+++ b/dNavigation/dNavMesh.cpp
@@ -28,13 +28,13 @@ dNavMesh::dNavMesh(uint32_t zoneId) {
 dNavMesh::~dNavMesh() {
 	// Clean up Recast information
 
-	rcFreeHeightField(m_Solid);
-	rcFreeCompactHeightfield(m_CHF);
-	rcFreeContourSet(m_CSet);
-	rcFreePolyMesh(m_PMesh);
-	rcFreePolyMeshDetail(m_PMDMesh);
-	dtFreeNavMesh(m_NavMesh);
-	dtFreeNavMeshQuery(m_NavQuery);
+	if(m_Solid) rcFreeHeightField(m_Solid);
+	if (m_CHF) rcFreeCompactHeightfield(m_CHF);
+	if (m_CSet) rcFreeContourSet(m_CSet);
+	if (m_PMesh) rcFreePolyMesh(m_PMesh);
+	if (m_PMDMesh) rcFreePolyMeshDetail(m_PMDMesh);
+	if (m_NavMesh) dtFreeNavMesh(m_NavMesh);
+	if (m_NavQuery) dtFreeNavMeshQuery(m_NavQuery);
 
 	if (m_Ctx) delete m_Ctx;
 	if (m_Triareas) delete[] m_Triareas;

--- a/dPhysics/dpWorld.cpp
+++ b/dPhysics/dpWorld.cpp
@@ -32,9 +32,10 @@ dpWorld::~dpWorld() {
 		m_Grid = nullptr;
 	}
 
-	m_NavMesh->~dNavMesh();
-	delete m_NavMesh;
-	m_NavMesh = nullptr;
+	if (m_NavMesh) {
+		delete m_NavMesh;
+		m_NavMesh = nullptr;
+	}
 }
 
 void dpWorld::StepWorld(float deltaTime) {

--- a/dPhysics/dpWorld.h
+++ b/dPhysics/dpWorld.h
@@ -42,5 +42,5 @@ private:
 	std::vector<dpEntity*> m_StaticEntities;
 	std::vector<dpEntity*> m_DynamicEntites;
 
-	dNavMesh* m_NavMesh;
+	dNavMesh* m_NavMesh = nullptr;
 };


### PR DESCRIPTION
Add a few checks before calling free on some Detour objects