### PR TITLE
Fix checks for if the physics world is loaded

### DIFF
--- a/dNavigation/dNavMesh.h
+++ b/dNavigation/dNavMesh.h
@@ -17,6 +17,9 @@ public:
 
 	float GetHeightAtPoint(const NiPoint3& location);
 	std::vector<NiPoint3> GetPath(const NiPoint3& startPos, const NiPoint3& endPos, float speed = 10.0f);
+
+	class dtNavMesh* GetdtNavMesh() { return m_NavMesh; }
+
 private:
 	void LoadNavmesh();
 

--- a/dPhysics/dpWorld.h
+++ b/dPhysics/dpWorld.h
@@ -24,7 +24,7 @@ public:
 	~dpWorld();
 
 	bool ShouldUseSP(unsigned int zoneID);
-	bool IsLoaded() const { return m_NavMesh != nullptr; }
+	bool IsLoaded() const { return m_NavMesh->GetdtNavMesh() != nullptr; }
 
 	void StepWorld(float deltaTime);
 


### PR DESCRIPTION
This PR fixes the check for if the physics world is loaded and therefore repairs the navigation of ships in the Gnarled Forest shooting gallery.