### PR TITLE
Add physics volume for property orb to increase its radius

### DIFF
--- a/dGame/dComponents/PhantomPhysicsComponent.cpp
+++ b/dGame/dComponents/PhantomPhysicsComponent.cpp
@@ -205,6 +205,12 @@ PhantomPhysicsComponent::PhantomPhysicsComponent(Entity* parent) : Component(par
 			m_dpEntity->SetRotation(m_Rotation);
 			m_dpEntity->SetPosition(m_Position);
 			dpWorld::Instance().AddEntity(m_dpEntity);
+		} else if (info->physicsAsset == "env\\vfx_propertyImaginationBall.hkx") {
+			m_dpEntity = new dpEntity(m_Parent->GetObjectID(), 4.5f);
+			m_dpEntity->SetScale(m_Scale);
+			m_dpEntity->SetRotation(m_Rotation);
+			m_dpEntity->SetPosition(m_Position);
+			dpWorld::Instance().AddEntity(m_dpEntity);
 		} else {
 			//Game::logger->Log("PhantomPhysicsComponent", "This one is supposed to have %s", info->physicsAsset.c_str());
 


### PR DESCRIPTION
Fixes #707 

Adds a much more accurate and larger Phantom Physics sphere as opposed to the default rectangle.  Previous collider was 2x2x2 whereas the new collider is a sphere of radius 4.5.  

Tested that the physics sphere properly registers the player having entered it if they touch the edges of the sphere.
Tested that the player still has to jump into the orb and cannot trigger it from on the elevator floor.
