### PR TITLE
Added windows build commands  to build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -9,11 +9,6 @@ cmake ..
 if [[ "$OSTYPE" =~ ^msys ]]; then
 
 	cmake --build . --config Release
-	
-	# Move over binaries
-	if test -f "Release/MasterServer.exe"; then
-		mv Release/*.exe .
-	fi
 else
 
 	# Run make to build the project. To build utilizing multiple cores, append `-j` and the amount of cores to utilize, for example `make -j8`

--- a/build.sh
+++ b/build.sh
@@ -5,15 +5,8 @@ cd build
 # Run cmake to generate make files
 cmake ..
 
-# Windows build
-if [[ "$OSTYPE" =~ ^msys ]]; then
-
-	cmake --build . --config Release
-else
-
-	# Run make to build the project. To build utilizing multiple cores, append `-j` and the amount of cores to utilize, for example `make -j8`
-	make
-fi
+# To build utilizing multiple cores, append `-j` and the amount of cores to utilize, for example `cmake --build . --config Release -j8'
+cmake --build . --config Release
 
 # Run migrations
 ./MasterServer -m

--- a/build.sh
+++ b/build.sh
@@ -5,8 +5,20 @@ cd build
 # Run cmake to generate make files
 cmake ..
 
-# Run make to build the project. To build utilizing multiple cores, append `-j` and the amount of cores to utilize, for example `make -j8`
-make
+# Windows build
+if [[ "$OSTYPE" =~ ^msys ]]; then
+
+	cmake --build . --config Release
+	
+	# Move over binaries
+	if test -f "Release/MasterServer.exe"; then
+		mv Release/*.exe .
+	fi
+else
+
+	# Run make to build the project. To build utilizing multiple cores, append `-j` and the amount of cores to utilize, for example `make -j8`
+	make
+fi
 
 # Run migrations
 ./MasterServer -m


### PR DESCRIPTION
Added "intelligence" to the build script to run different build commands if on Windows.

Also, given this uses the OSTYPE variable, the ability to run different commands for different OS's could be added in the future.