### PR TITLE
Update Docker.md submodule note

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -25,8 +25,7 @@
 
 **NOTE #4**: Make sure to run the following in the repo root directory after cloning so submodules are also downloaded.
 ```
-git submodule init
-git submodule update
+git submodule update --init --recursive
 ```
 **NOTE #5**: If DarkflameSetup fails due to not having cdclient.fdb, rename CDClient.fdb (in the same folder) to cdclient.fdb
 


### PR DESCRIPTION
* Update Docker.md 

Changed note to recursively update git submodules, otherwise would lead users into #728

Following the old command set would initialize all submodules except for required submodules of mariadb-connector-cpp. This was fixed by using a recursive tag.

#### Image of using new command after `git submodule init` and `git submodule update` in a fresh repository 

This shows that there's additional content not included by the initial command suggestions

![image](https://user-images.githubusercontent.com/22532991/184542696-262a56a3-1c78-4be6-bebd-5fd7226ce037.png)

Close #728