### PR TITLE
Selective saving for map and location

### DIFF
--- a/dGame/Character.cpp
+++ b/dGame/Character.cpp
@@ -301,20 +301,22 @@ void Character::SaveXMLToDatabase() {
 		character->SetAttribute("gm", m_GMLevel);
 		character->SetAttribute("cc", m_Coins);
 
+		auto zoneInfo = dZoneManager::Instance()->GetZone()->GetZoneID();
 		// lzid garbage, binary concat of zoneID, zoneInstance and zoneClone
-		if (Game::server->GetZoneID() != 0) {
-			auto zoneInfo = dZoneManager::Instance()->GetZone()->GetZoneID();
-			uint64_t lzidConcat = zoneInfo.GetCloneID();
-			lzidConcat = (lzidConcat << 16) | uint16_t(zoneInfo.GetInstanceID());
-			lzidConcat = (lzidConcat << 16) | uint16_t(zoneInfo.GetMapID());
-			character->SetAttribute("lzid", lzidConcat);
-			character->SetAttribute("lnzid", GetLastNonInstanceZoneID());
+		if ((zoneInfo.GetMapID() != 0) && !(1700 > zoneInfo.GetMapID() && zoneInfo.GetMapID() > 1600)) {
+			if (zoneInfo.GetCloneID() == 0) {
+				uint64_t lzidConcat = zoneInfo.GetCloneID();
+				lzidConcat = (lzidConcat << 16) | uint16_t(zoneInfo.GetInstanceID());
+				lzidConcat = (lzidConcat << 16) | uint16_t(zoneInfo.GetMapID());
+				character->SetAttribute("lzid", lzidConcat);
+				character->SetAttribute("lnzid", GetLastNonInstanceZoneID());
 
-			//Darwin's backup:
-			character->SetAttribute("lwid", Game::server->GetZoneID());
+				//Darwin's backup:
+				character->SetAttribute("lwid", Game::server->GetZoneID());
 
-			// Set the target scene, custom attribute
-			character->SetAttribute("tscene", m_TargetScene.c_str());
+				// Set the target scene, custom attribute
+				character->SetAttribute("tscene", m_TargetScene.c_str());
+			}
 		}
 
 		auto emotes = character->FirstChildElement("ue");

--- a/dGame/Character.cpp
+++ b/dGame/Character.cpp
@@ -303,7 +303,7 @@ void Character::SaveXMLToDatabase() {
 
 		auto zoneInfo = dZoneManager::Instance()->GetZone()->GetZoneID();
 		// lzid garbage, binary concat of zoneID, zoneInstance and zoneClone
-		if ((zoneInfo.GetMapID() != 0) && !(1700 > zoneInfo.GetMapID() && zoneInfo.GetMapID() > 1600)) {
+		if ((zoneInfo.GetMapID() != 0)) {
 			if (zoneInfo.GetCloneID() == 0) {
 				uint64_t lzidConcat = zoneInfo.GetCloneID();
 				lzidConcat = (lzidConcat << 16) | uint16_t(zoneInfo.GetInstanceID());

--- a/dGame/Character.cpp
+++ b/dGame/Character.cpp
@@ -303,20 +303,18 @@ void Character::SaveXMLToDatabase() {
 
 		auto zoneInfo = dZoneManager::Instance()->GetZone()->GetZoneID();
 		// lzid garbage, binary concat of zoneID, zoneInstance and zoneClone
-		if ((zoneInfo.GetMapID() != 0)) {
-			if (zoneInfo.GetCloneID() == 0) {
-				uint64_t lzidConcat = zoneInfo.GetCloneID();
-				lzidConcat = (lzidConcat << 16) | uint16_t(zoneInfo.GetInstanceID());
-				lzidConcat = (lzidConcat << 16) | uint16_t(zoneInfo.GetMapID());
-				character->SetAttribute("lzid", lzidConcat);
-				character->SetAttribute("lnzid", GetLastNonInstanceZoneID());
+		if (zoneInfo.GetMapID() != 0 && zoneInfo.GetCloneID() == 0) {
+			uint64_t lzidConcat = zoneInfo.GetCloneID();
+			lzidConcat = (lzidConcat << 16) | uint16_t(zoneInfo.GetInstanceID());
+			lzidConcat = (lzidConcat << 16) | uint16_t(zoneInfo.GetMapID());
+			character->SetAttribute("lzid", lzidConcat);
+			character->SetAttribute("lnzid", GetLastNonInstanceZoneID());
 
-				//Darwin's backup:
-				character->SetAttribute("lwid", Game::server->GetZoneID());
+			//Darwin's backup:
+			character->SetAttribute("lwid", Game::server->GetZoneID());
 
-				// Set the target scene, custom attribute
-				character->SetAttribute("tscene", m_TargetScene.c_str());
-			}
+			// Set the target scene, custom attribute
+			character->SetAttribute("tscene", m_TargetScene.c_str());
 		}
 
 		auto emotes = character->FirstChildElement("ue");

--- a/dGame/dComponents/ControllablePhysicsComponent.cpp
+++ b/dGame/dComponents/ControllablePhysicsComponent.cpp
@@ -166,16 +166,14 @@ void ControllablePhysicsComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
 
 	auto zoneInfo = dZoneManager::Instance()->GetZone()->GetZoneID();
 
-	if ((zoneInfo.GetMapID() != 0)) {
-		if (zoneInfo.GetCloneID() == 0) {
-			character->SetAttribute("lzx", m_Position.x);
-			character->SetAttribute("lzy", m_Position.y);
-			character->SetAttribute("lzz", m_Position.z);
-			character->SetAttribute("lzrx", m_Rotation.x);
-			character->SetAttribute("lzry", m_Rotation.y);
-			character->SetAttribute("lzrz", m_Rotation.z);
-			character->SetAttribute("lzrw", m_Rotation.w);
-		}
+	if (zoneInfo.GetMapID() != 0 && zoneInfo.GetCloneID() == 0) {
+		character->SetAttribute("lzx", m_Position.x);
+		character->SetAttribute("lzy", m_Position.y);
+		character->SetAttribute("lzz", m_Position.z);
+		character->SetAttribute("lzrx", m_Rotation.x);
+		character->SetAttribute("lzry", m_Rotation.y);
+		character->SetAttribute("lzrz", m_Rotation.z);
+		character->SetAttribute("lzrw", m_Rotation.w);
 	}
 }
 

--- a/dGame/dComponents/ControllablePhysicsComponent.cpp
+++ b/dGame/dComponents/ControllablePhysicsComponent.cpp
@@ -11,6 +11,7 @@
 #include "CDClientManager.h"
 #include "EntityManager.h"
 #include "Character.h"
+#include "dZoneManager.h"
 
 ControllablePhysicsComponent::ControllablePhysicsComponent(Entity* entity) : Component(entity) {
 	m_Position = {};
@@ -163,13 +164,19 @@ void ControllablePhysicsComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
 		return;
 	}
 
-	character->SetAttribute("lzx", m_Position.x);
-	character->SetAttribute("lzy", m_Position.y);
-	character->SetAttribute("lzz", m_Position.z);
-	character->SetAttribute("lzrx", m_Rotation.x);
-	character->SetAttribute("lzry", m_Rotation.y);
-	character->SetAttribute("lzrz", m_Rotation.z);
-	character->SetAttribute("lzrw", m_Rotation.w);
+	auto zoneInfo = dZoneManager::Instance()->GetZone()->GetZoneID();
+
+	if ((zoneInfo.GetMapID() != 0) && !(1700 > zoneInfo.GetMapID() && zoneInfo.GetMapID() > 1600)) {
+		if (zoneInfo.GetCloneID() == 0) {
+			character->SetAttribute("lzx", m_Position.x);
+			character->SetAttribute("lzy", m_Position.y);
+			character->SetAttribute("lzz", m_Position.z);
+			character->SetAttribute("lzrx", m_Rotation.x);
+			character->SetAttribute("lzry", m_Rotation.y);
+			character->SetAttribute("lzrz", m_Rotation.z);
+			character->SetAttribute("lzrw", m_Rotation.w);
+		}
+	}
 }
 
 void ControllablePhysicsComponent::SetPosition(const NiPoint3& pos) {

--- a/dGame/dComponents/ControllablePhysicsComponent.cpp
+++ b/dGame/dComponents/ControllablePhysicsComponent.cpp
@@ -166,7 +166,7 @@ void ControllablePhysicsComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
 
 	auto zoneInfo = dZoneManager::Instance()->GetZone()->GetZoneID();
 
-	if ((zoneInfo.GetMapID() != 0) && !(1700 > zoneInfo.GetMapID() && zoneInfo.GetMapID() > 1600)) {
+	if ((zoneInfo.GetMapID() != 0)) {
 		if (zoneInfo.GetCloneID() == 0) {
 			character->SetAttribute("lzx", m_Position.x);
 			character->SetAttribute("lzy", m_Position.y);


### PR DESCRIPTION
Don't save the map and char location info if we are in an instanced Zone

tested going to a prop and making sure everything else saved but I got put back in the origin world.