### PR TITLE
Address being able to friend yourself

### DIFF
--- a/dChatServer/ChatPacketHandler.cpp
+++ b/dChatServer/ChatPacketHandler.cpp
@@ -114,7 +114,10 @@ void ChatPacketHandler::HandleFriendRequest(Packet* packet) {
 	inStream.Read(isBestFriendRequest);
 
 	auto requestor = playerContainer.GetPlayerData(requestorPlayerID);
-	if (requestor->playerName == playerName) return;
+	if (requestor->playerName == playerName) {
+		SendFriendResponse(requestor, requestor, AddFriendResponseType::MYTHRAN);
+		return;
+	};
 	std::unique_ptr<PlayerData> requestee(playerContainer.GetPlayerData(playerName));
 
 	// Check if player is online first

--- a/dChatServer/ChatPacketHandler.cpp
+++ b/dChatServer/ChatPacketHandler.cpp
@@ -33,9 +33,10 @@ void ChatPacketHandler::HandleFriendlistRequest(Packet* packet) {
 		"WHEN friend_id = ? THEN player_id "
 		"END AS requested_player, best_friend FROM friends) AS fr "
 		"JOIN charinfo AS ci ON ci.id = fr.requested_player "
-		"WHERE fr.requested_player IS NOT NULL;"));
+		"WHERE fr.requested_player IS NOT NULL AND fr.requested_player != ?;"));
 	stmt->setUInt(1, static_cast<uint32_t>(playerID));
 	stmt->setUInt(2, static_cast<uint32_t>(playerID));
+	stmt->setUInt(3, static_cast<uint32_t>(playerID));
 
 	std::vector<FriendData> friends;
 
@@ -113,6 +114,7 @@ void ChatPacketHandler::HandleFriendRequest(Packet* packet) {
 	inStream.Read(isBestFriendRequest);
 
 	auto requestor = playerContainer.GetPlayerData(requestorPlayerID);
+	if (requestor->playerName == playerName) return;
 	std::unique_ptr<PlayerData> requestee(playerContainer.GetPlayerData(playerName));
 
 	// Check if player is online first


### PR DESCRIPTION
Fix an issue where players could friend themselves.  Also stops yourself as appearing as a friend on your own friends list.

Tested adding myself as a friend using the [GM] workaround.  Was not able to.  Tested logging in and our and I did not show up as a friend on my own friend list.

Fixes #771 