### PR TITLE
Add automatic cdclient migration runner support and setup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,8 +14,8 @@
 	path = thirdparty/mariadb-connector-cpp
 	url = https://github.com/mariadb-corporation/mariadb-connector-cpp.git
 	ignore = dirty
-[submodule "thirdparty/docker-utils"]
-	path = thirdparty/docker-utils
+[submodule "thirdparty/utils"]
+	path = thirdparty/utils
 	url = https://github.com/lcdr/utils.git
 [submodule "thirdparty/LUnpack"]
 	path = thirdparty/LUnpack

--- a/.gitmodules
+++ b/.gitmodules
@@ -14,8 +14,8 @@
 	path = thirdparty/mariadb-connector-cpp
 	url = https://github.com/mariadb-corporation/mariadb-connector-cpp.git
 	ignore = dirty
-[submodule "thirdparty/utils"]
-	path = thirdparty/utils
+[submodule "thirdparty/docker-utils"]
+	path = thirdparty/docker-utils
 	url = https://github.com/lcdr/utils.git
 [submodule "thirdparty/LUnpack"]
 	path = thirdparty/LUnpack

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,13 +108,25 @@ foreach(file ${VANITY_FILES})
 endforeach()
 
 # Move our migrations for MasterServer to run
-file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/migrations/)
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/migrations/dlu/)
 file(GLOB SQL_FILES ${CMAKE_SOURCE_DIR}/migrations/dlu/*.sql)
 foreach(file ${SQL_FILES})
 	get_filename_component(file ${file} NAME)
-	if (NOT EXISTS ${PROJECT_BINARY_DIR}/migrations/${file})
+	if (NOT EXISTS ${PROJECT_BINARY_DIR}/migrations/dlu/${file})
 		configure_file(
-			${CMAKE_SOURCE_DIR}/migrations/dlu/${file} ${PROJECT_BINARY_DIR}/migrations/${file}
+			${CMAKE_SOURCE_DIR}/migrations/dlu/${file} ${PROJECT_BINARY_DIR}/migrations/dlu/${file}
+			COPYONLY
+		)
+	endif()
+endforeach()
+
+file(MAKE_DIRECTORY ${PROJECT_BINARY_DIR}/migrations/cdserver/)
+file(GLOB SQL_FILES ${CMAKE_SOURCE_DIR}/migrations/cdserver/*.sql)
+foreach(file ${SQL_FILES})
+	get_filename_component(file ${file} NAME)
+	if (NOT EXISTS ${PROJECT_BINARY_DIR}/migrations/cdserver/${file})
+		configure_file(
+			${CMAKE_SOURCE_DIR}/migrations/cdserver/${file} ${PROJECT_BINARY_DIR}/migrations/cdserver/${file}
 			COPYONLY
 		)
 	endif()

--- a/README.md
+++ b/README.md
@@ -196,9 +196,10 @@ certutil -hashfile <file> SHA256
 * Copy over or create symlinks from `locale.xml` in your client `locale` directory to the `build/locale` directory
 
 #### Client database
-* Use `fdb_to_sqlite.py` in lcdr's utilities on `res/cdclient.fdb` in the unpacked client to convert the client database to `cdclient.sqlite`
-* Move and rename `cdclient.sqlite` into `build/res/CDServer.sqlite`
-* Run each SQL file in the order at which they appear [here](migrations/cdserver/) on the SQLite database
+* Move the file `res/cdclient.fdb` from the unpacked client to the `build/res` folder on the server.
+* The server will automatically copy and convert the file from fdb to sqlite should `CDServer.sqlite` not already exist.
+* You can also convert the database manually using `fdb_to_sqlite.py` using lcdr's utilities.  Just make sure to rename the file to `CDServer.sqlite` instead of `cdclient.sqlite`.
+* Migrations to the database are automatically run on server start.  When migrations are needed to be ran, the server may take a bit longer to start.
 
 ### Database
 Darkflame Universe utilizes a MySQL/MariaDB database for account and character information.
@@ -229,7 +230,7 @@ Your build directory should now look like this:
 * **locale/**
   * locale.xml
 * **res/**
-  * CDServer.sqlite
+  * cdclient.fdb
   * chatplus_en_us.txt
   * **macros/**
     * ...

--- a/dDatabase/CDClientDatabase.cpp
+++ b/dDatabase/CDClientDatabase.cpp
@@ -14,6 +14,11 @@ CppSQLite3Query CDClientDatabase::ExecuteQuery(const std::string& query) {
 	return conn->execQuery(query.c_str());
 }
 
+//! Updates the CDClient file with Data Manipulation Language (DML) commands.
+int CDClientDatabase::ExecuteDML(const std::string& query) {
+	return conn->execDML(query.c_str());
+}
+
 //! Makes prepared statements
 CppSQLite3Statement CDClientDatabase::CreatePreppedStmt(const std::string& query) {
 	return conn->compileStatement(query.c_str());

--- a/dDatabase/CDClientDatabase.h
+++ b/dDatabase/CDClientDatabase.h
@@ -40,6 +40,14 @@ namespace CDClientDatabase {
 	 */
 	CppSQLite3Query ExecuteQuery(const std::string& query);
 
+	//! Updates the CDClient file with Data Manipulation Language (DML) commands.
+	/*!
+	  \param query The DML command to run.  DML command can be multiple queries in one string but only
+		the last one will return its number of updated rows.
+	  \return The number of updated rows.
+	*/
+	int ExecuteDML(const std::string& query);
+
 	//! Queries the CDClient and parses arguments
 	/*!
 	  \param query The query with formatted arguments

--- a/dDatabase/MigrationRunner.cpp
+++ b/dDatabase/MigrationRunner.cpp
@@ -121,9 +121,9 @@ void MigrationRunner::RunSQLiteMigrations() {
 	}
 
 	if (!finalSQL.empty()) {
+		Game::logger->Log("MigrationRunner", "final length %i", finalSQL.length());
 		try {
-			CppSQLite3Statement simpleStatement = CDClientDatabase::CreatePreppedStmt(finalSQL.c_str());
-			simpleStatement.execQuery();
+			CDClientDatabase::ExecuteDML(finalSQL.c_str());
 		} catch (CppSQLite3Exception& e) {
 			Game::logger->Log("MigrationRunner", "Encountered error running migration: (%i) : %s", e.errorCode(), e.errorMessage());
 		}

--- a/dDatabase/MigrationRunner.cpp
+++ b/dDatabase/MigrationRunner.cpp
@@ -1,11 +1,34 @@
 #include "MigrationRunner.h"
 
 #include "BrickByBrickFix.h"
+#include "CDClientDatabase.h"
+#include "Database.h"
+#include "Game.h"
 #include "GeneralUtils.h"
+#include "dLogger.h"
 
-#include <fstream>
-#include <algorithm>
-#include <thread>
+#include <istream>
+
+Migration LoadMigration(std::string path) {
+	Migration migration{};
+	std::ifstream file("./migrations/" + path);
+
+	if (file.is_open()) {
+		std::string line;
+		std::string total = "";
+
+		while (std::getline(file, line)) {
+			total += line;
+		}
+
+		file.close();
+
+		migration.name = path;
+		migration.data = total;
+	}
+
+	return migration;
+}
 
 void MigrationRunner::RunMigrations() {
 	auto* stmt = Database::CreatePreppedStmt("CREATE TABLE IF NOT EXISTS migration_history (name TEXT NOT NULL, date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP());");
@@ -13,16 +36,13 @@ void MigrationRunner::RunMigrations() {
 	delete stmt;
 
 	sql::SQLString finalSQL = "";
-	Migration checkMigration{};
 	bool runSd0Migrations = false;
-	for (const auto& entry : GeneralUtils::GetFileNamesFromFolder("./migrations/")) {
-		auto migration = LoadMigration(entry);
+	for (const auto& entry : GeneralUtils::GetFileNamesFromFolder("./migrations/dlu/")) {
+		auto migration = LoadMigration("dlu/" + entry);
 
 		if (migration.data.empty()) {
 			continue;
 		}
-
-		checkMigration = migration;
 
 		stmt = Database::CreatePreppedStmt("SELECT name FROM migration_history WHERE name = ?;");
 		stmt->setString(1, migration.name);
@@ -40,7 +60,7 @@ void MigrationRunner::RunMigrations() {
 		}
 
 		stmt = Database::CreatePreppedStmt("INSERT INTO migration_history (name) VALUES (?);");
-		stmt->setString(1, entry);
+		stmt->setString(1, migration.name);
 		stmt->execute();
 		delete stmt;
 	}
@@ -72,23 +92,42 @@ void MigrationRunner::RunMigrations() {
 	}
 }
 
-Migration MigrationRunner::LoadMigration(std::string path) {
-	Migration migration{};
-	std::ifstream file("./migrations/" + path);
+void MigrationRunner::RunSQLiteMigrations() {
+	auto* stmt = Database::CreatePreppedStmt("CREATE TABLE IF NOT EXISTS migration_history (name TEXT NOT NULL, date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP());");
+	stmt->execute();
+	delete stmt;
 
-	if (file.is_open()) {
-		std::string line;
-		std::string total = "";
+	sql::SQLString finalSQL = "";
+	for (const auto& entry : GeneralUtils::GetFileNamesFromFolder("./migrations/cdserver/")) {
+		auto migration = LoadMigration("cdserver/" + entry);
 
-		while (std::getline(file, line)) {
-			total += line;
-		}
+		if (migration.data.empty()) continue;
 
-		file.close();
+		stmt = Database::CreatePreppedStmt("SELECT name FROM migration_history WHERE name = ?;");
+		stmt->setString(1, migration.name);
+		auto* res = stmt->executeQuery();
+		bool doExit = res->next();
+		delete res;
+		delete stmt;
+		if (doExit) continue;
 
-		migration.name = path;
-		migration.data = total;
+		Game::logger->Log("MigrationRunner", "Running migration: %s", migration.name.c_str());
+		finalSQL.append(migration.data);
+
+		stmt = Database::CreatePreppedStmt("INSERT INTO migration_history (name) VALUES (?);");
+		stmt->setString(1, migration.name);
+		stmt->execute();
+		delete stmt;
 	}
 
-	return migration;
+	if (!finalSQL.empty()) {
+		try {
+			CppSQLite3Statement simpleStatement = CDClientDatabase::CreatePreppedStmt(finalSQL.c_str());
+			simpleStatement.execQuery();
+		} catch (CppSQLite3Exception& e) {
+			Game::logger->Log("MigrationRunner", "Encountered error running migration: (%i) : %s", e.errorCode(), e.errorMessage());
+		}
+		return;
+	}
+	Game::logger->Log("MigrationRunner", "CDServer database is up to date.");
 }

--- a/dDatabase/MigrationRunner.h
+++ b/dDatabase/MigrationRunner.h
@@ -1,19 +1,13 @@
 #pragma once
 
-#include "Database.h"
-
-#include "dCommonVars.h"
-#include "Game.h"
-#include "dCommonVars.h"
-#include "dLogger.h"
+#include <string>
 
 struct Migration {
 	std::string data;
 	std::string name;
 };
 
-class MigrationRunner {
-public:
-	static void RunMigrations();
-	static Migration LoadMigration(std::string path);
+namespace MigrationRunner {
+	void RunMigrations();
+	void RunSQLiteMigrations();
 };

--- a/migrations/cdserver/0_nt_footrace.sql
+++ b/migrations/cdserver/0_nt_footrace.sql
@@ -1,6 +1,2 @@
-BEGIN TRANSACTION;
-
 UPDATE ComponentsRegistry SET component_id = 1901 WHERE id = 12916 AND component_type = 39;
 INSERT INTO ActivityRewards (objectTemplate, ActivityRewardIndex, activityRating, LootMatrixIndex, CurrencyIndex, ChallengeRating, description) VALUES (1901, 166, -1, 598, 1, 4, 'NT Foot Race');
-
-COMMIT;


### PR DESCRIPTION
Add support to automatically migrate and update CDServers with new migrations.  Also adds support to simplify the setup process by simply putting the fdb in the res folder and letting the server convert it to sqlite.

This reduces the amount of back and forth when setting up a server and also allows us to fix bugs by using cdclient migrations as opposed to special case code.

It is likely up for debate whether we should handle converting the database to sqlite or require the user to do this.  Since we already require python and are cloning a repository which has tools to convert to sqlite from fdb.

Tested that starting a server with just the fdb in ./build/res properly copies and converts the database to sqlite and applies all migrations.  Went into Block yard and was able to open the mailbox (a required script in the migrations).
Tested that starting a server with the sqlite file has no changes aside from automatically applying the migrations that have not been run yet.
Tested that the migrations do not cause issues if run twice.  Since no columns are being added there was no issue planned here anyways but tested just in case.