### PR TITLE
Fix chat message reads

### DIFF
--- a/dChatServer/ChatPacketHandler.cpp
+++ b/dChatServer/ChatPacketHandler.cpp
@@ -394,7 +394,7 @@ void ChatPacketHandler::HandleChatMessage(Packet* packet) {
 	uint8_t channel = 0;
 	inStream.Read(channel);
 
-	std::string message = PacketUtils::ReadString(0x66, packet, true);
+	std::string message = PacketUtils::ReadString(0x66, packet, true, 512);
 
 	Game::logger->Log("ChatPacketHandler", "Got a message from (%s) [%d]: %s", senderName.c_str(), channel, message.c_str());
 

--- a/dChatServer/ChatPacketHandler.cpp
+++ b/dChatServer/ChatPacketHandler.cpp
@@ -436,7 +436,7 @@ void ChatPacketHandler::HandleChatMessage(Packet* packet) {
 void ChatPacketHandler::HandlePrivateChatMessage(Packet* packet) {
 	LWOOBJID senderID = PacketUtils::ReadPacketS64(0x08, packet);
 	std::string receiverName = PacketUtils::ReadString(0x66, packet, true);
-	std::string message = PacketUtils::ReadString(0xAA, packet, true);
+	std::string message = PacketUtils::ReadString(0xAA, packet, true, 512);
 
 	//Get the bois:
 	auto goonA = playerContainer.GetPlayerData(senderID);


### PR DESCRIPTION
Fixes #756 

Tested that two clients that are private messaging each other read the full message
Tested that two clients on teams can message each other
