### PR TITLE
Add Frostbrugh Race Track to the disable landing animation switch case

### DIFF
--- a/dGame/dComponents/CharacterComponent.cpp
+++ b/dGame/dComponents/CharacterComponent.cpp
@@ -47,6 +47,7 @@ bool CharacterComponent::LandingAnimDisabled(int zoneID) {
 	case 1202:
 	case 1203:
 	case 1204:
+	case 1261:
 	case 1301:
 	case 1302:
 	case 1303:


### PR DESCRIPTION
Fixes #781 
tested and it works
Fixes the issue of spawning in incorrectly on the Space blizzard racetrack