### PR TITLE
Add checks to AssetBuffers before they are used

### DIFF
--- a/dGame/dInventory/Item.cpp
+++ b/dGame/dInventory/Item.cpp
@@ -345,7 +345,7 @@ void Item::DisassembleModel() {
 	auto buffer = Game::assetManager->GetFileAsBuffer(lxfmlPath.c_str());
 
 	if (!buffer.m_Success) {
-		Game::logger->Log("Item", "Failed to load %s", lxfmlPath.c_str());
+		Game::logger->Log("Item", "Failed to load %s to disassemble model into bricks, check that this file exists", lxfmlPath.c_str());
 		return;
 	}
 

--- a/dGame/dInventory/Item.cpp
+++ b/dGame/dInventory/Item.cpp
@@ -344,6 +344,11 @@ void Item::DisassembleModel() {
 	std::string lxfmlPath = "BrickModels/" + GeneralUtils::SplitString(renderAssetSplit.back(), '.').at(0) + ".lxfml";
 	auto buffer = Game::assetManager->GetFileAsBuffer(lxfmlPath.c_str());
 
+	if (!buffer.m_Success) {
+		Game::logger->Log("Item", "Failed to load %s", lxfmlPath.c_str());
+		return;
+	}
+
 	std::istream file(&buffer);
 
 	result.finalize();

--- a/dGame/dUtilities/BrickDatabase.cpp
+++ b/dGame/dUtilities/BrickDatabase.cpp
@@ -19,6 +19,11 @@ std::vector<Brick>& BrickDatabase::GetBricks(const std::string& lxfmlPath) {
 	}
 
 	AssetMemoryBuffer buffer = Game::assetManager->GetFileAsBuffer((lxfmlPath).c_str());
+
+	if (!buffer.m_Success) {
+		return emptyCache;
+	}
+
 	std::istream file(&buffer);
 	if (!file.good()) {
 		return emptyCache;

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -584,6 +584,12 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		if (args[0].find("\\") != std::string::npos) return;
 
 		auto buf = Game::assetManager->GetFileAsBuffer(("macros/" + args[0] + ".scm").c_str());
+
+		 if (!buf.m_Success){
+			ChatPackets::SendSystemMessage(sysAddr, u"Unknown macro! Is the filename right?");
+			return;
+		 }
+
 		std::istream infile(&buf);
 
 		if (infile.good()) {

--- a/dZoneManager/Zone.cpp
+++ b/dZoneManager/Zone.cpp
@@ -42,6 +42,12 @@ void Zone::LoadZoneIntoMemory() {
 	if (m_ZoneFilePath == "ERR") return;
 
 	AssetMemoryBuffer buffer = Game::assetManager->GetFileAsBuffer(m_ZoneFilePath.c_str());
+
+	if (!buffer.m_Success) {
+		Game::logger->Log("Zone", "Failed to load %s", m_ZoneFilePath.c_str());
+		return;
+	}
+
 	std::istream file(&buffer);
 	if (file) {
 		BinaryIO::BinaryRead(file, m_ZoneFileFormatVersion);
@@ -265,7 +271,10 @@ std::vector<LUTriggers::Trigger*> Zone::LoadLUTriggers(std::string triggerFile, 
 
 	auto buffer = Game::assetManager->GetFileAsBuffer((m_ZonePath + triggerFile).c_str());
 
-	if (!buffer.m_Success) return lvlTriggers;
+	if (!buffer.m_Success) {
+		Game::logger->Log("Zone", "Failed to load %s", (m_ZonePath + triggerFile).c_str());
+		return lvlTriggers;
+	}
 
 	std::istream file(&buffer);
 	std::stringstream data;

--- a/dZoneManager/Zone.cpp
+++ b/dZoneManager/Zone.cpp
@@ -45,7 +45,7 @@ void Zone::LoadZoneIntoMemory() {
 
 	if (!buffer.m_Success) {
 		Game::logger->Log("Zone", "Failed to load %s", m_ZoneFilePath.c_str());
-		return;
+		throw std::runtime_error("Aborting Zone loading due to no Zone File.");
 	}
 
 	std::istream file(&buffer);
@@ -272,7 +272,7 @@ std::vector<LUTriggers::Trigger*> Zone::LoadLUTriggers(std::string triggerFile, 
 	auto buffer = Game::assetManager->GetFileAsBuffer((m_ZonePath + triggerFile).c_str());
 
 	if (!buffer.m_Success) {
-		Game::logger->Log("Zone", "Failed to load %s", (m_ZonePath + triggerFile).c_str());
+		Game::logger->Log("Zone", "Failed to load %s from disk. Skipping loading triggers", (m_ZonePath + triggerFile).c_str());
 		return lvlTriggers;
 	}
 


### PR DESCRIPTION
to avoid crashing
Tested that this fixes crashing on non-existent macros.
When ahead and added checks where this is used to avoid accidental crashes.
Tested that those places are handled gracefully as well