### PR TITLE
Fix server type advertisement in handshake with custom auth port

### DIFF
--- a/dNet/AuthPackets.cpp
+++ b/dNet/AuthPackets.cpp
@@ -29,16 +29,16 @@ void AuthPackets::HandleHandshake(dServer* server, Packet* packet) {
 	inStream.Read(clientVersion);
 
 	server->GetLogger()->Log("AuthPackets", "Received client version: %i", clientVersion);
-	SendHandshake(server, packet->systemAddress, server->GetIP(), server->GetPort());
+	SendHandshake(server, packet->systemAddress, server->GetIP(), server->GetPort(), server->GetServerType());
 }
 
-void AuthPackets::SendHandshake(dServer* server, const SystemAddress& sysAddr, const std::string& nextServerIP, uint16_t nextServerPort) {
+void AuthPackets::SendHandshake(dServer* server, const SystemAddress& sysAddr, const std::string& nextServerIP, uint16_t nextServerPort, const ServerType serverType) {
 	RakNet::BitStream bitStream;
 	PacketUtils::WriteHeader(bitStream, SERVER, MSG_SERVER_VERSION_CONFIRM);
 	bitStream.Write<unsigned int>(NET_VERSION);
 	bitStream.Write(uint32_t(0x93));
 
-	if (nextServerPort == 1001) bitStream.Write(uint32_t(1)); //Conn: auth
+	if (serverType == ServerType::Auth) bitStream.Write(uint32_t(1)); //Conn: auth
 	else bitStream.Write(uint32_t(4)); //Conn: world
 
 	bitStream.Write(uint32_t(0)); //Server process ID

--- a/dNet/AuthPackets.h
+++ b/dNet/AuthPackets.h
@@ -4,12 +4,13 @@
 #define _VARIADIC_MAX 10
 #include "dCommonVars.h"
 #include "dNetCommon.h"
+#include "dServer.h"
 
 class dServer;
 
 namespace AuthPackets {
 	void HandleHandshake(dServer* server, Packet* packet);
-	void SendHandshake(dServer* server, const SystemAddress& sysAddr, const std::string& nextServerIP, uint16_t nextServerPort);
+	void SendHandshake(dServer* server, const SystemAddress& sysAddr, const std::string& nextServerIP, uint16_t nextServerPort, const ServerType serverType);
 
 	void HandleLoginRequest(dServer* server, Packet* packet);
 	void SendLoginResponse(dServer* server, const SystemAddress& sysAddr, eLoginResponse responseCode, const std::string& errorMsg, const std::string& wServerIP, uint16_t wServerPort, std::string username);

--- a/dNet/AuthPackets.h
+++ b/dNet/AuthPackets.h
@@ -4,8 +4,8 @@
 #define _VARIADIC_MAX 10
 #include "dCommonVars.h"
 #include "dNetCommon.h"
-#include "dServer.h"
 
+enum class ServerType : uint32_t;
 class dServer;
 
 namespace AuthPackets {


### PR DESCRIPTION
Tested by setting auth port to 2001 and using nginx to redirect port 2001 to 1001. Successfully authenticated and loaded char.