### PR TITLE
cleanup and define all unknowns in zone reading

### DIFF
--- a/dZoneManager/Zone.cpp
+++ b/dZoneManager/Zone.cpp
@@ -358,11 +358,8 @@ SceneTransitionInfo Zone::LoadSceneTransitionInfo(std::istream& file) {
 void Zone::LoadPath(std::istream& file) {
 	Path path = Path();
 
-	uint32_t flags;
-	uint32_t pathType;
-	uint32_t pathBehavior;
-
 	BinaryIO::BinaryRead(file, path.pathVersion);
+
 	uint8_t stringLength;
 	BinaryIO::BinaryRead(file, stringLength);
 	for (uint8_t i = 0; i < stringLength; ++i) {
@@ -370,11 +367,10 @@ void Zone::LoadPath(std::istream& file) {
 		BinaryIO::BinaryRead(file, character);
 		path.pathName.push_back(character);
 	}
-	BinaryIO::BinaryRead(file, pathType);
-	path.pathType = PathType(pathType);
-	BinaryIO::BinaryRead(file, flags);
-	BinaryIO::BinaryRead(file, pathBehavior);
-	path.pathBehavior = PathBehavior(pathBehavior);
+
+	BinaryIO::BinaryRead(file, path.pathType);
+	BinaryIO::BinaryRead(file, path.flags);
+	BinaryIO::BinaryRead(file, path.pathBehavior);
 
 	if (path.pathType == PathType::MovingPlatform) {
 		if (path.pathVersion >= 18) {
@@ -389,17 +385,9 @@ void Zone::LoadPath(std::istream& file) {
 			}
 		}
 	} else if (path.pathType == PathType::Property) {
-
-		int32_t propertyPathType;
-		BinaryIO::BinaryRead(file, propertyPathType);
-		path.property.pathType = PropertyPathType(propertyPathType);
-
+		BinaryIO::BinaryRead(file, path.property.pathType);
 		BinaryIO::BinaryRead(file, path.property.price);
-
-		int32_t rentalTime;
-		BinaryIO::BinaryRead(file, rentalTime);
-		path.property.rentalTime = PropertyRentalTimeUnit(rentalTime);
-
+		BinaryIO::BinaryRead(file, path.property.rentalTime);
 		BinaryIO::BinaryRead(file, path.property.associatedZone);
 
 		if (path.pathVersion >= 5) {
@@ -419,12 +407,7 @@ void Zone::LoadPath(std::istream& file) {
 			}
 		}
 
-		if (path.pathVersion >= 6) {
-			int32_t propertyType;
-			BinaryIO::BinaryRead(file, propertyType);
-			path.property.type = PropertyType(propertyType);
-
-		}
+		if (path.pathVersion >= 6) BinaryIO::BinaryRead(file, path.property.type);
 
 		if (path.pathVersion >= 7) {
 			BinaryIO::BinaryRead(file, path.property.cloneLimit);
@@ -452,7 +435,6 @@ void Zone::LoadPath(std::istream& file) {
 
 		}
 	} else if (path.pathType == PathType::Spawner) {
-		//SpawnerPath* path = static_cast<SpawnerPath*>(path); // Convert to a spawner path
 		BinaryIO::BinaryRead(file, path.spawner.spawnedLOT);
 		BinaryIO::BinaryRead(file, path.spawner.respawnTime);
 		BinaryIO::BinaryRead(file, path.spawner.maxToSpawn);

--- a/dZoneManager/Zone.cpp
+++ b/dZoneManager/Zone.cpp
@@ -489,11 +489,11 @@ void Zone::LoadPath(std::istream& file) {
 			BinaryIO::BinaryRead(file, waypoint.camera.continuity);
 			BinaryIO::BinaryRead(file, waypoint.camera.bias);
 		} else if (path.pathType == PathType::Race) {
-			BinaryIO::BinaryRead(file, waypoint.raceing.isResetNode);
-			BinaryIO::BinaryRead(file, waypoint.raceing.isNonHorizontalCamera);
-			BinaryIO::BinaryRead(file, waypoint.raceing.planeWidth);
-			BinaryIO::BinaryRead(file, waypoint.raceing.planeHeight);
-			BinaryIO::BinaryRead(file, waypoint.raceing.shortestDistanceToEnd);
+			BinaryIO::BinaryRead(file, waypoint.racing.isResetNode);
+			BinaryIO::BinaryRead(file, waypoint.racing.isNonHorizontalCamera);
+			BinaryIO::BinaryRead(file, waypoint.racing.planeWidth);
+			BinaryIO::BinaryRead(file, waypoint.racing.planeHeight);
+			BinaryIO::BinaryRead(file, waypoint.racing.shortestDistanceToEnd);
 		}
 
 		// object LDF configs

--- a/dZoneManager/Zone.cpp
+++ b/dZoneManager/Zone.cpp
@@ -387,7 +387,7 @@ void Zone::LoadPath(std::istream& file) {
 	} else if (path.pathType == PathType::Property) {
 		BinaryIO::BinaryRead(file, path.property.pathType);
 		BinaryIO::BinaryRead(file, path.property.price);
-		BinaryIO::BinaryRead(file, path.property.rentalTime);
+		BinaryIO::BinaryRead(file, path.property.rentalTimeUnit);
 		BinaryIO::BinaryRead(file, path.property.associatedZone);
 
 		if (path.pathVersion >= 5) {

--- a/dZoneManager/Zone.h
+++ b/dZoneManager/Zone.h
@@ -59,9 +59,23 @@ struct MovingPlatformPathWaypoint {
 
 struct CameraPathWaypoint {
 	float time;
+	float fov;
 	float tension;
 	float continuity;
 	float bias;
+};
+
+struct RacingPathWaypoint {
+	uint8_t isResetNode;
+	uint8_t isNonHorizontalCamera;
+	float planeWidth;
+	float planeHeight;
+	float shortestDistanceToEnd;
+};
+
+struct RailPathWaypoint {
+	float speed;
+	std::vector<LDFBaseData*> config;
 };
 
 struct PathWaypoint {
@@ -69,6 +83,8 @@ struct PathWaypoint {
 	NiQuaternion rotation; // not included in all, but it's more convenient here
 	MovingPlatformPathWaypoint movingPlatform;
 	CameraPathWaypoint camera;
+	RacingPathWaypoint raceing;
+	RailPathWaypoint rail;
 	std::vector<LDFBaseData*> config;
 };
 
@@ -87,6 +103,19 @@ enum class PathBehavior : uint32_t {
 	Loop = 0,
 	Bounce = 1,
 	Once = 2
+};
+
+enum class PropertyPathType : int32_t {
+	Path = 0,
+	EntireZone = 1,
+	GenetatedRectangle = 2
+};
+
+enum class PropertyType : int32_t{
+	Premiere = 0,
+    Prize = 1,
+    LUP = 2,
+    Headspace = 3
 };
 
 enum class PropertyRentalTimeUnit : int32_t {
@@ -116,14 +145,17 @@ enum class PropertyAchievmentRequired : int32_t {
 
 struct MovingPlatformPath {
 	std::string platformTravelSound;
+	uint8_t timeBasedMovement;
 };
 
 struct PropertyPath {
+	PropertyPathType pathType;
 	int32_t price;
-	int32_t rentalTime;
+	PropertyRentalTimeUnit rentalTime;
 	uint64_t associatedZone;
 	std::string displayName;
 	std::string displayDesc;
+	PropertyType type;
 	int32_t cloneLimit;
 	float repMultiplier;
 	PropertyRentalTimeUnit rentalTimeUnit;
@@ -134,6 +166,7 @@ struct PropertyPath {
 
 struct CameraPath {
 	std::string nextPath;
+	uint8_t rotatePlayer;
 };
 
 struct SpawnerPath {
@@ -150,6 +183,7 @@ struct Path {
 	uint32_t pathVersion;
 	PathType pathType;
 	std::string pathName;
+	uint32_t flags;
 	PathBehavior pathBehavior;
 	uint32_t waypointCount;
 	std::vector<PathWaypoint> pathWaypoints;
@@ -219,9 +253,11 @@ private:
 
 	std::map<LWOSCENEID, SceneRef, mapCompareLwoSceneIDs> m_Scenes;
 	std::vector<SceneTransition> m_SceneTransitions;
+
 	uint32_t m_PathDataLength;
-	//std::vector<char> m_PathData; //Binary path data
-	std::vector<Path> m_Paths;
+	uint32_t m_PathChunkVersion;
+ 	std::vector<Path> m_Paths;
+
 	std::map<LWOSCENEID, uint32_t, mapCompareLwoSceneIDs> m_MapRevisions; //rhs is the revision!
 
 	//private ("helper") functions:

--- a/dZoneManager/Zone.h
+++ b/dZoneManager/Zone.h
@@ -83,7 +83,7 @@ struct PathWaypoint {
 	NiQuaternion rotation; // not included in all, but it's more convenient here
 	MovingPlatformPathWaypoint movingPlatform;
 	CameraPathWaypoint camera;
-	RacingPathWaypoint raceing;
+	RacingPathWaypoint racing;
 	RailPathWaypoint rail;
 	std::vector<LDFBaseData*> config;
 };

--- a/dZoneManager/Zone.h
+++ b/dZoneManager/Zone.h
@@ -151,14 +151,13 @@ struct MovingPlatformPath {
 struct PropertyPath {
 	PropertyPathType pathType;
 	int32_t price;
-	PropertyRentalTimeUnit rentalTime;
+	PropertyRentalTimeUnit rentalTimeUnit;
 	uint64_t associatedZone;
 	std::string displayName;
 	std::string displayDesc;
 	PropertyType type;
 	int32_t cloneLimit;
 	float repMultiplier;
-	PropertyRentalTimeUnit rentalTimeUnit;
 	PropertyAchievmentRequired achievementRequired;
 	NiPoint3 playerZoneCoords;
 	float maxBuildHeight;


### PR DESCRIPTION
fix for movement path config reading
Tested that this has no functional changes. There may can be changes made since this data is more clearly defined.
This is also in prep for npc movement pathing
reference: https://github.com/lcdr/lu_formats/blob/master/files/luz.ksy 