### PR TITLE
Prevent adding movingplatform components to all entites with an attached_path

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -699,10 +699,10 @@ void Entity::Initialize() {
 		// else if we are a movement path
 		} else if (path->pathType == PathType::Movement) {
 			auto movementAIcomp = GetComponent<MovementAIComponent>();
-			if (!movementAIcomp){
-				// TODO: create movementAIcomp and set path
-			} else {
+			if (movementAIcomp){
 				// TODO: set path in existing movementAIComp
+			} else {
+				// TODO: create movementAIcomp and set path
 			}
 		}
 	}

--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -690,21 +690,21 @@ void Entity::Initialize() {
 	std::string pathName = GetVarAsString(u"attached_path");
 	const Path* path = dZoneManager::Instance()->GetZone()->GetPath(pathName);
 
-	//Check to see if we have an attached path and assing the appropiate component to handle it:
+	//Check to see if we have an attached path and add the appropiate component to handle it:
 	if (path){
 		// if we have a moving platform path, then we need a moving platform component
 		if (path->pathType == PathType::MovingPlatform) {
 			MovingPlatformComponent* plat = new MovingPlatformComponent(this, pathName);
 			m_Components.insert(std::make_pair(COMPONENT_TYPE_MOVING_PLATFORM, plat));
 		// else if we are a movement path
-		} else if (path->pathType == PathType::Movement) {
+		} /*else if (path->pathType == PathType::Movement) {
 			auto movementAIcomp = GetComponent<MovementAIComponent>();
 			if (movementAIcomp){
 				// TODO: set path in existing movementAIComp
 			} else {
 				// TODO: create movementAIcomp and set path
 			}
-		}
+		}*/
 	}
 
 	int proximityMonitorID = compRegistryTable->GetByIDAndType(m_TemplateID, COMPONENT_TYPE_PROXIMITY_MONITOR);

--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -648,11 +648,6 @@ void Entity::Initialize() {
 		m_Components.insert(std::make_pair(COMPONENT_TYPE_RAIL_ACTIVATOR, new RailActivatorComponent(this, railComponentID)));
 	}
 
-	// need this up here to include in other movement AI setup
-	std::string pathName = GetVarAsString(u"attached_path");
-
-	const Path* path = dZoneManager::Instance()->GetZone()->GetPath(pathName);
-
 	int movementAIID = compRegistryTable->GetByIDAndType(m_TemplateID, COMPONENT_TYPE_MOVEMENT_AI);
 	if (movementAIID > 0) {
 		CDMovementAIComponentTable* moveAITable = CDClientManager::Instance()->GetTable<CDMovementAIComponentTable>("MovementAIComponent");
@@ -691,6 +686,9 @@ void Entity::Initialize() {
 
 		m_Components.insert(std::make_pair(COMPONENT_TYPE_MOVEMENT_AI, new MovementAIComponent(this, moveInfo)));
 	}
+
+	std::string pathName = GetVarAsString(u"attached_path");
+	const Path* path = dZoneManager::Instance()->GetZone()->GetPath(pathName);
 
 	//Check to see if we have an attached path and assing the appropiate component to handle it:
 	if (path){


### PR DESCRIPTION
This is preparation for npc pathing. 
All entities that have an attached_path should not have moving platform components as they do now, so only add a moving platform comp if the path type is for a moving platform