### PR TITLE
Make build script fail if any command fails

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,6 @@
+# Error if any command fails
+set -e
+
 # Create the build directory, preserving it if it already exists
 mkdir -p build
 cd build


### PR DESCRIPTION
Verified that running `build.sh` with a build error causes the script to exit with a non-zero, while normally the script succeeds