### PR TITLE
Fixed server failing to start without a cdclient.fdb being present

### DIFF
--- a/dCommon/dClient/AssetManager.cpp
+++ b/dCommon/dClient/AssetManager.cpp
@@ -34,6 +34,10 @@ AssetManager::AssetManager(const std::string& path) {
 		m_AssetBundleType = eAssetBundleType::Unpacked;
 
 		m_ResPath = m_Path;
+	} else if (std::filesystem::exists(m_Path / "CDServer.sqlite")) {
+		m_AssetBundleType = eAssetBundleType::Unpacked;
+
+		m_ResPath = m_Path;
 	}
 
 	if (m_AssetBundleType == eAssetBundleType::None) {

--- a/dCommon/dClient/AssetManager.cpp
+++ b/dCommon/dClient/AssetManager.cpp
@@ -26,15 +26,11 @@ AssetManager::AssetManager(const std::string& path) {
 
 		m_RootPath = (m_Path / ".." / "..");
 		m_ResPath = m_Path;
-	} else if (std::filesystem::exists(m_Path / "res" / "cdclient.fdb") && !std::filesystem::exists(m_Path / "res" / "pack")) {
+	} else if ((std::filesystem::exists(m_Path / "res" / "cdclient.fdb") || std::filesystem::exists(m_Path / "res" / "CDServer.sqlite")) && !std::filesystem::exists(m_Path / "res" / "pack")) {
 		m_AssetBundleType = eAssetBundleType::Unpacked;
 
 		m_ResPath = (m_Path / "res");
-	} else if (std::filesystem::exists(m_Path / "cdclient.fdb") && !std::filesystem::exists(m_Path / "pack")) {
-		m_AssetBundleType = eAssetBundleType::Unpacked;
-
-		m_ResPath = m_Path;
-	} else if (std::filesystem::exists(m_Path / "CDServer.sqlite")) {
+	} else if ((std::filesystem::exists(m_Path / "cdclient.fdb") || std::filesystem::exists(m_Path / "CDServer.sqlite")) && !std::filesystem::exists(m_Path / "pack")) {
 		m_AssetBundleType = eAssetBundleType::Unpacked;
 
 		m_ResPath = m_Path;


### PR DESCRIPTION
Fixes https://github.com/DarkflameUniverse/DarkflameServer/issues/839 

Tested a res dir:

- with `CDServer.sqlite` only
- with  `CDServer.sqlite` and `cdclient.fdb`
- with `cdclient.fdb` only