### PR TITLE
Add support to name and describe models

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -870,6 +870,14 @@ void Entity::WriteBaseReplicaData(RakNet::BitStream* outBitStream, eReplicaPacke
 			for (size_t i = 0; i < name.size(); ++i) {
 				outBitStream->Write<uint16_t>(name[i]);
 			}
+		} else if (GetComponent<ModelComponent>()){
+			auto* spawner = m_Spawner;
+			if (m_Spawner) {
+				const auto& name = spawner->m_Info.name;
+
+				outBitStream->Write<uint8_t>(uint8_t(name.size()));
+				for (auto character : name) outBitStream->Write<uint16_t>(character);
+			}
 		} else {
 			const auto& name = GetVar<std::string>(u"npcName");
 			outBitStream->Write<uint8_t>(uint8_t(name.size()));

--- a/dGame/EntityManager.cpp
+++ b/dGame/EntityManager.cpp
@@ -86,7 +86,7 @@ Entity* EntityManager::CreateEntity(EntityInfo info, User* user, Entity* parentE
 		}
 
 		// Exclude the zone control object from any flags
-		if (!controller && info.lot != 14) {
+		if (!controller) {
 
 			// The client flags means the client should render the entity
 			id = GeneralUtils::SetBit(id, OBJECT_BIT_CLIENT);

--- a/dGame/dComponents/ModelComponent.cpp
+++ b/dGame/dComponents/ModelComponent.cpp
@@ -4,6 +4,10 @@
 ModelComponent::ModelComponent(Entity* parent) : Component(parent) {
 	m_OriginalPosition = m_Parent->GetDefaultPosition();
 	m_OriginalRotation = m_Parent->GetDefaultRotation();
+	m_Description = u"";
+	m_Name = u"";
+	m_DescriptionStatus = ModerationStatus::NoStatus;
+	m_NameStatus = ModerationStatus::NoStatus;
 
 	m_userModelID = m_Parent->GetVarAs<LWOOBJID>(u"userModelID");
 }
@@ -13,8 +17,12 @@ void ModelComponent::Serialize(RakNet::BitStream* outBitStream, bool bIsInitialU
 	if (!m_Parent->HasComponent(COMPONENT_TYPE_PET)) {
 		outBitStream->Write1();
 		outBitStream->Write<LWOOBJID>(m_userModelID != LWOOBJID_EMPTY ? m_userModelID : m_Parent->GetObjectID());
-		outBitStream->Write<int>(0);
-		outBitStream->Write0();
+		outBitStream->Write<ModerationStatus>(m_DescriptionStatus);
+		outBitStream->Write(m_Description.size() > 0);
+		if (m_Description.size() > 0) {
+			outBitStream->Write(static_cast<uint32_t>(m_Description.size()));
+			for (auto character : m_Description) outBitStream->Write(character);
+		}
 	}
 
 	//actual model component:

--- a/dGame/dComponents/ModelComponent.h
+++ b/dGame/dComponents/ModelComponent.h
@@ -4,6 +4,7 @@
 #include "NiPoint3.h"
 #include "NiQuaternion.h"
 #include "Component.h"
+#include "eModerationStatus.h"
 
 class Entity;
 
@@ -42,6 +43,36 @@ public:
 	 */
 	void SetRotation(const NiQuaternion& rot) { m_OriginalRotation = rot; }
 
+	/**
+	 * Set the moderation status of the description of this model
+	 */
+	void SetDescriptionModerationStatus(ModerationStatus status) { this->m_DescriptionStatus = status; };
+
+	/**
+	 * Sets the description of the model
+	 */
+	void SetDescription(const std::u16string& description) { this->m_Description = description; m_DescriptionStatus = ModerationStatus::NoStatus; };
+
+	/**
+	 * @return The models current description
+	 */
+	std::u16string GetDescription() { return this->m_Description; };
+
+	/**
+	 * Set the moderation status of the name of this model
+	 */
+	void SetNameModerationStatus(ModerationStatus status) { this->m_NameStatus = status; };
+
+	/**
+	 * Sets the Name of the model
+	 */
+	void SetName(const std::u16string& name) { this->m_Name = name; m_NameStatus = ModerationStatus::NoStatus; };
+
+	/**
+	 * @return The models current Name
+	 */
+	std::u16string GetName() { return this->m_Name; };
+
 private:
 
 	/**
@@ -58,4 +89,24 @@ private:
 	 * The ID of the user that made the model
 	 */
 	LWOOBJID m_userModelID;
+
+	/**
+	 * Whether or not the description of this model is approved.
+	 */
+	ModerationStatus m_DescriptionStatus;
+
+	/**
+	 * The description of this model
+	 */
+	std::u16string m_Description;
+
+	/**
+	 * Whether or not the name of this model is approved.
+	 */
+	ModerationStatus m_NameStatus;
+
+	/**
+	 * The name of this model
+	 */
+	std::u16string m_Name;
 };

--- a/dGame/dComponents/eModerationStatus.h
+++ b/dGame/dComponents/eModerationStatus.h
@@ -1,0 +1,14 @@
+#ifndef __EMODERATIONSTATUS__H__
+#define __EMODERATIONSTATUS__H__
+
+#pragma once
+
+#include <cstdint>
+
+enum class ModerationStatus : uint32_t {
+	NoStatus = 0,
+	Approved,
+	Rejected
+};
+
+#endif  //!__EMODERATIONSTATUS__H__


### PR DESCRIPTION
Adds support to name and describe models.
Tested that User Generated Content models can be named and described and that the property does not get its name overwritten anymore. Regular models maintain their name and description across instances. This does not allow the name to persist when the model is picked up as this is a larger implementation. Tested that taming pets and spawning pets does not cause crashes or issues.

EntityManager changes are because the client expects the objectID of the User Generated Content model to have those flags set.

BaseReplicaData changes are because the client expects the name to be set in the construction of the entity.
Tested that if the requested name is not in the whitelist, the name reverts to its previous value, same with the description.