### PR TITLE
Update workflow actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -16,7 +16,7 @@ jobs:
         os: [ windows-2022, ubuntu-20.04, macos-11 ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Add msbuild to PATH (Windows only)
@@ -35,7 +35,7 @@ jobs:
         buildPreset: "ci-${{matrix.os}}"
         testPreset: "ci-${{matrix.os}}"
     - name: artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: ${{ github.ref == 'ref/head/main' }}
       with:
         name: build-${{matrix.os}}


### PR DESCRIPTION
This fixes deprecation warnings as seen in the annotations for instance here: https://github.com/DarkflameUniverse/DarkflameServer/actions/runs/3518570052

Node.js 12 has been marked as deprecated for GitHub workflow actions and everyone should switch to Node.js 16 as soon as possible. This PR bumps all deprecated actions to their newest respective version.