### PR TITLE
Fix Boogie Down

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -454,7 +454,7 @@ void Entity::Initialize() {
 	 */
 
 	CDScriptComponentTable* scriptCompTable = CDClientManager::Instance()->GetTable<CDScriptComponentTable>("ScriptComponent");
-	int scriptComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, COMPONENT_TYPE_SCRIPT);
+	int32_t scriptComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, COMPONENT_TYPE_SCRIPT, -1);
 
 	std::string scriptName = "";
 	bool client = false;
@@ -496,7 +496,7 @@ void Entity::Initialize() {
 		scriptName = customScriptServer;
 	}
 
-	if (!scriptName.empty() || client || m_Character) {
+	if (!scriptName.empty() || client || m_Character || scriptComponentID >= 0) {
 		m_Components.insert(std::make_pair(COMPONENT_TYPE_SCRIPT, new ScriptComponent(this, scriptName, true, client && scriptName.empty())));
 	}
 

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -4894,27 +4894,27 @@ void GameMessages::HandlePlayEmote(RakNet::BitStream* inStream, Entity* entity) 
 	inStream->Read(emoteID);
 	inStream->Read(targetID);
 
-	Game::logger->Log("GameMessages", "Emote (%i) (%llu)", emoteID, targetID);
+	Game::logger->LogDebug("GameMessages", "Emote (%i) (%llu)", emoteID, targetID);
 
 	//TODO: If targetID != 0, and we have one of the "perform emote" missions, complete them.
 
 	if (emoteID == 0) return;
 	std::string sAnimationName = "deaded"; //Default name in case we fail to get the emote
 
-	MissionComponent* mission = static_cast<MissionComponent*>(entity->GetComponent(COMPONENT_TYPE_MISSION));
-	if (mission) {
-		mission->Progress(MissionTaskType::MISSION_TASK_TYPE_EMOTE, emoteID, targetID);
-	}
+	MissionComponent* missionComponent = entity->GetComponent<MissionComponent>();
+	if (!missionComponent) return;
 
 	if (targetID != LWOOBJID_EMPTY) {
 		auto* targetEntity = EntityManager::Instance()->GetEntity(targetID);
 
-		Game::logger->Log("GameMessages", "Emote target found (%d)", targetEntity != nullptr);
+		Game::logger->LogDebug("GameMessages", "Emote target found (%d)", targetEntity != nullptr);
 
 		if (targetEntity != nullptr) {
 			targetEntity->OnEmoteReceived(emoteID, entity);
+			missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_EMOTE, emoteID, targetID);
 		}
 	} else {
+		Game::logger->LogDebug("GameMessages", "Target ID is empty, using backup");
 		const auto scriptedEntities = EntityManager::Instance()->GetEntitiesByComponent(COMPONENT_TYPE_SCRIPT);
 
 		const auto& referencePoint = entity->GetPosition();
@@ -4923,6 +4923,7 @@ void GameMessages::HandlePlayEmote(RakNet::BitStream* inStream, Entity* entity) 
 			if (Vector3::DistanceSquared(scripted->GetPosition(), referencePoint) > 5.0f * 5.0f) continue;
 
 			scripted->OnEmoteReceived(emoteID, entity);
+			missionComponent->Progress(MissionTaskType::MISSION_TASK_TYPE_EMOTE, emoteID, scripted->GetObjectID());
 		}
 	}
 

--- a/dScripts/ai/FV/FvNinjaGuard.cpp
+++ b/dScripts/ai/FV/FvNinjaGuard.cpp
@@ -19,12 +19,6 @@ void FvNinjaGuard::OnEmoteReceived(Entity* self, const int32_t emote, Entity* ta
 
 	GameMessages::SendPlayAnimation(self, u"scared");
 
-	auto* missionComponent = target->GetComponent<MissionComponent>();
-
-	if (missionComponent != nullptr && missionComponent->HasMission(737)) {
-		missionComponent->ForceProgressTaskType(737, 5, 1, false);
-	}
-
 	if (self->GetLOT() == 7412) {
 		auto* rightGuard = EntityManager::Instance()->GetEntity(m_RightGuard);
 
@@ -39,4 +33,3 @@ void FvNinjaGuard::OnEmoteReceived(Entity* self, const int32_t emote, Entity* ta
 		}
 	}
 }
-


### PR DESCRIPTION
- Give entities that have a script component ID of zero a script component still
- Progress scripted entity missions within the for loop as we do for script calls

Tested that Boogie Down is (finally) completable.
Tested that Mission 737 is still completable
Checked that missions progressed inside OnEmoteReceived scripts to not double trigger progression

Fixes #278 