### PR TITLE
Add migration to make play_key_id nullable

### DIFF
--- a/migrations/dlu/7_make_play_key_id_nullable.sql
+++ b/migrations/dlu/7_make_play_key_id_nullable.sql
@@ -1,0 +1,1 @@
+ALTER TABLE account MODIFY play_key_id INT DEFAULT 0;


### PR DESCRIPTION
Since there is an option not to use play_keys

Tested that things still work, logging in with and without keys and that the authconfig option is repsected