### PR TITLE
Fix crash in BasicAttackBehavior

### DIFF
--- a/dGame/dBehaviors/BasicAttackBehavior.cpp
+++ b/dGame/dBehaviors/BasicAttackBehavior.cpp
@@ -93,9 +93,6 @@ void BasicAttackBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bi
 	case 1:
 		this->m_OnSuccess->Handle(context, bitStream, branch);
 		break;
-	case 2:
-		this->m_OnFailArmor->Handle(context, bitStream, branch);
-		break;
 	default:
 		Game::logger->LogDebug("BasicAttackBehavior", "Unknown success state (%i)!", successState);
 		break;

--- a/dGame/dBehaviors/BasicAttackBehavior.h
+++ b/dGame/dBehaviors/BasicAttackBehavior.h
@@ -4,12 +4,6 @@
 class BasicAttackBehavior final : public Behavior
 {
 public:
-	uint32_t m_minDamage;
-
-	uint32_t m_maxDamage;
-
-	Behavior* m_onSuccess;
-
 	explicit BasicAttackBehavior(const uint32_t behaviorId) : Behavior(behaviorId) {
 	}
 
@@ -18,4 +12,12 @@ public:
 	void Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) override;
 
 	void Load() override;
+private:
+	uint32_t m_MinDamage;
+
+	uint32_t m_MaxDamage;
+
+	Behavior* m_OnSuccess;
+
+	Behavior* m_OnFailArmor;
 };

--- a/dGame/dComponents/SkillComponent.cpp
+++ b/dGame/dComponents/SkillComponent.cpp
@@ -319,34 +319,6 @@ void SkillComponent::CalculateUpdate(const float deltaTime) {
 			const auto distance = Vector3::DistanceSquared(targetPosition, closestPoint);
 
 			if (distance > 3 * 3) {
-				/*
-				if (entry.TrackTarget && distance <= entry.TrackRadius)
-				{
-					const auto rotation = NiQuaternion::LookAtUnlocked(position, targetPosition);
-
-					const auto speed = entry.Velocity.Length();
-
-					const auto homingTarget = rotation.GetForwardVector() * speed;
-
-					Vector3 homing;
-
-					// Move towards
-
-					const auto difference = homingTarget - entry.Velocity;
-					const auto mag = difference.Length();
-					if (mag <= speed || mag == 0)
-					{
-						homing = homingTarget;
-					}
-					else
-					{
-						entry.Velocity + homingTarget / mag * speed;
-					}
-
-					entry.Velocity = homing;
-				}
-				*/
-
 				continue;
 			}
 

--- a/dGame/dComponents/SkillComponent.cpp
+++ b/dGame/dComponents/SkillComponent.cpp
@@ -319,6 +319,7 @@ void SkillComponent::CalculateUpdate(const float deltaTime) {
 			const auto distance = Vector3::DistanceSquared(targetPosition, closestPoint);
 
 			if (distance > 3 * 3) {
+				// TODO There is supposed to be an implementation for homing projectiles here
 				continue;
 			}
 


### PR DESCRIPTION
Address the BasicAttackBehavior reading out of bounds memory and reading bits that didnt exist, which occasionally caused crashes and also caused the behavior to do undefined behavior due to the bad reads.

Tested that attacking a wall anywhere with a projectile now does not crash the game.  Tested with logs that the behavior correctly returned when there were no allocated bits or returned when other unserialized states were not met.

No observed issues from about 10 minutes of attacking things, both grouped and not grouped.

Fixes #430 