### PR TITLE
Add back precondition check for packages and remove GM 9 bypass for preconditions

### DIFF
--- a/dGame/dInventory/Item.cpp
+++ b/dGame/dInventory/Item.cpp
@@ -253,7 +253,7 @@ bool Item::Consume() {
 		}
 	}
 
-	Game::logger->Log("Item", "Consumed (%i) / (%llu) with (%d)", lot, id, success);
+	Game::logger->LogDebug("Item", "Consumed LOT (%i) itemID (%llu).  Success=(%d)", lot, id, success);
 
 	GameMessages::SendUseItemResult(inventory->GetComponent()->GetParent(), lot, success);
 
@@ -265,14 +265,34 @@ bool Item::Consume() {
 }
 
 void Item::UseNonEquip() {
+	LOT thisLot = this->GetLot();
+	if (!GetInventory()) {
+		Game::logger->LogDebug("Item", "item %i has no inventory??", this->GetLot());
+		return;
+	}
+
+	auto* playerInventoryComponent = GetInventory()->GetComponent();
+	if (!playerInventoryComponent) {
+		Game::logger->LogDebug("Item", "no inventory component attached to item id %llu lot %i", this->GetId(), this->GetLot());
+		return;
+	}
+
+	auto* playerEntity = playerInventoryComponent->GetParent();
+	if (!playerEntity) {
+		Game::logger->LogDebug("Item", "no player entity attached to inventory? item id is %llu", this->GetId());
+		return;
+	}
+
 	const auto type = static_cast<eItemType>(info->itemType);
 	if (type == eItemType::ITEM_TYPE_MOUNT) {
-		GetInventory()->GetComponent()->HandlePossession(this);
+		playerInventoryComponent->HandlePossession(this);
+		// TODO Check if mounts are allowed to be spawned
 	} else if (type == eItemType::ITEM_TYPE_PET_INVENTORY_ITEM && subKey != LWOOBJID_EMPTY) {
-		const auto& databasePet = GetInventory()->GetComponent()->GetDatabasePet(subKey);
+		const auto& databasePet = playerInventoryComponent->GetDatabasePet(subKey);
 		if (databasePet.lot != LOT_NULL) {
-			GetInventory()->GetComponent()->SpawnPet(this);
+			playerInventoryComponent->SpawnPet(this);
 		}
+		// This precondition response is taken care of in SpawnPet().
 	} else {
 		auto* compRegistryTable = CDClientManager::Instance()->GetTable<CDComponentsRegistryTable>("ComponentsRegistry");
 		const auto packageComponentId = compRegistryTable->GetByIDAndType(lot, COMPONENT_TYPE_PACKAGE);
@@ -282,18 +302,41 @@ void Item::UseNonEquip() {
 		auto* packCompTable = CDClientManager::Instance()->GetTable<CDPackageComponentTable>("PackageComponent");
 		auto packages = packCompTable->Query([=](const CDPackageComponent entry) {return entry.id == static_cast<uint32_t>(packageComponentId); });
 
-		const auto success = !packages.empty();
+		auto success = !packages.empty();
 		if (success) {
-			auto* entityParent = inventory->GetComponent()->GetParent();
-			for (auto& pack : packages) {
-				std::unordered_map<LOT, int32_t> result{};
-				result = LootGenerator::Instance().RollLootMatrix(entityParent, pack.LootMatrixIndex);
-				if (!inventory->GetComponent()->HasSpaceForLoot(result)) {
+			if (this->GetPreconditionExpression()->Check(playerInventoryComponent->GetParent())) {
+				auto* entityParent = playerInventoryComponent->GetParent();
+				// Roll the loot for all the packages then see if it all fits.  If it fits, give it to the player, otherwise don't.
+				std::unordered_map<LOT, int32_t> rolledLoot{};
+				for (auto& pack : packages) {
+					auto thisPackage = LootGenerator::Instance().RollLootMatrix(entityParent, pack.LootMatrixIndex);
+					for (auto& loot : thisPackage) {
+						// If we already rolled this lot, add it to the existing one, otherwise create a new entry.
+						auto existingLoot = rolledLoot.find(loot.first);
+						if (existingLoot == rolledLoot.end()) {
+							rolledLoot.insert(loot);
+						} else {
+							existingLoot->second += loot.second;
+						}
+					}
 				}
-				LootGenerator::Instance().GiveLoot(inventory->GetComponent()->GetParent(), result, eLootSourceType::LOOT_SOURCE_CONSUMPTION);
+				if (playerInventoryComponent->HasSpaceForLoot(rolledLoot)) {
+					LootGenerator::Instance().GiveLoot(playerInventoryComponent->GetParent(), rolledLoot, eLootSourceType::LOOT_SOURCE_CONSUMPTION);
+					playerInventoryComponent->RemoveItem(lot, 1);
+				} else {
+					success = false;
+				}
+			} else {
+				GameMessages::SendUseItemRequirementsResponse(
+					playerInventoryComponent->GetParent()->GetObjectID(),
+					playerInventoryComponent->GetParent()->GetSystemAddress(),
+					UseItemResponse::FailedPrecondition
+				);
+				success = false;
 			}
-			inventory->GetComponent()->RemoveItem(lot, 1);
 		}
+		Game::logger->LogDebug("Item", "Player %llu %s used item %i", playerEntity->GetObjectID(), success ? "successfully" : "unsuccessfully", thisLot);
+		GameMessages::SendUseItemResult(playerInventoryComponent->GetParent(), thisLot, success);
 	}
 }
 

--- a/dGame/dUtilities/Preconditions.cpp
+++ b/dGame/dUtilities/Preconditions.cpp
@@ -154,7 +154,7 @@ bool Precondition::CheckValue(Entity* player, const uint32_t value, bool evaluat
 	case PreconditionType::MissionComplete:
 		mission = missionComponent->GetMission(value);
 
-		return mission == nullptr || mission->GetMissionState() >= MissionState::MISSION_STATE_COMPLETE;
+		return mission == nullptr ? false : mission->GetMissionState() >= MissionState::MISSION_STATE_COMPLETE;
 	case PreconditionType::PetDeployed:
 		return false; // TODO
 	case PreconditionType::HasFlag:
@@ -274,11 +274,6 @@ PreconditionExpression::PreconditionExpression(const std::string& conditions) {
 
 bool PreconditionExpression::Check(Entity* player, bool evaluateCosts) const {
 	if (empty) {
-		return true;
-	}
-
-	if (player->GetGMLevel() >= 9) // Developers can skip this for testing
-	{
 		return true;
 	}
 


### PR DESCRIPTION
- First change removes the precondition bypass for gm9 players.  
- Second change improves the package opener to not allow partial opening of packages.
    - Implemented a GM send when the client fails a precondition when trying to use an item
    - Implemented a GM send when the client used an item which sends whether that usage was successful or not
    - I did not confirm this, but the previous code would also allow you to open packages even if you did not have the space for them.  This has been addressed and you are unable to use a package if the items would not fit in your inventory.
- Tested using an Ultra Mega Faction Token Bag and was unable to get faction tokens when the precondition (level 6 and mission 474) were not met and was able to use the bag when the conditions were met.
- Tested that I could open a picnic basket and receive its items since it has no preconditions.
- Tested that having a full inventory or less than the required slots available did not allow me to open packages
- Tested that having exactly enough slots allowed me to open a package

Fixes #374 