### PR TITLE
Move CDServer migration history table

### DIFF
--- a/dDatabase/MigrationRunner.cpp
+++ b/dDatabase/MigrationRunner.cpp
@@ -109,7 +109,7 @@ void MigrationRunner::RunSQLiteMigrations() {
 
 		// Check if there is an entry in the migration history table on the cdclient database.
 		cdstmt = CDClientDatabase::CreatePreppedStmt("SELECT name FROM migration_history WHERE name = ?;");
-		cdstmt.bind((int) 1, migration.name.c_str());
+		cdstmt.bind((int32_t) 1, migration.name.c_str());
 		auto cdres = cdstmt.execQuery();
 		bool doExit = !cdres.eof();
 		cdres.finalize();
@@ -127,7 +127,7 @@ void MigrationRunner::RunSQLiteMigrations() {
 		if (doExit) {
 			// Insert into cdclient database if there is an entry in the main database but not the cdclient database.
 			cdstmt = CDClientDatabase::CreatePreppedStmt("INSERT INTO migration_history (name) VALUES (?);");
-			cdstmt.bind((int) 1, migration.name.c_str());
+			cdstmt.bind((int32_t) 1, migration.name.c_str());
 			cdstmt.execQuery().finalize();
 			cdstmt.finalize();
 			continue;
@@ -147,7 +147,7 @@ void MigrationRunner::RunSQLiteMigrations() {
 
 		// Insert into cdclient database.
 		cdstmt = CDClientDatabase::CreatePreppedStmt("INSERT INTO migration_history (name) VALUES (?);");
-		cdstmt.bind((int) 1, migration.name.c_str());
+		cdstmt.bind((int32_t) 1, migration.name.c_str());
 		cdstmt.execQuery().finalize();
 		cdstmt.finalize();
 	}

--- a/dDatabase/MigrationRunner.cpp
+++ b/dDatabase/MigrationRunner.cpp
@@ -94,6 +94,10 @@ void MigrationRunner::RunMigrations() {
 }
 
 void MigrationRunner::RunSQLiteMigrations() {
+	auto cdstmt = CDClientDatabase::CreatePreppedStmt("CREATE TABLE IF NOT EXISTS migration_history (name TEXT NOT NULL, date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP);");
+	cdstmt.execQuery().finalize();
+	cdstmt.finalize();
+
 	auto* stmt = Database::CreatePreppedStmt("CREATE TABLE IF NOT EXISTS migration_history (name TEXT NOT NULL, date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP());");
 	stmt->execute();
 	delete stmt;
@@ -103,13 +107,31 @@ void MigrationRunner::RunSQLiteMigrations() {
 
 		if (migration.data.empty()) continue;
 
+		// Check if there is an entry in the migration history table on the cdclient database.
+		cdstmt = CDClientDatabase::CreatePreppedStmt("SELECT name FROM migration_history WHERE name = ?;");
+		cdstmt.bind((int) 1, migration.name.c_str());
+		auto cdres = cdstmt.execQuery();
+		bool doExit = !cdres.eof();
+		cdres.finalize();
+		cdstmt.finalize();
+
+		if (doExit) continue;
+
+		// Check first if there is entry in the migration history table on the main database.
 		stmt = Database::CreatePreppedStmt("SELECT name FROM migration_history WHERE name = ?;");
 		stmt->setString(1, migration.name.c_str());
 		auto* res = stmt->executeQuery();
-		bool doExit = res->next();
+		doExit = res->next();
 		delete res;
 		delete stmt;
-		if (doExit) continue;
+		if (doExit) {
+			// Insert into cdclient database if there is an entry in the main database but not the cdclient database.
+			cdstmt = CDClientDatabase::CreatePreppedStmt("INSERT INTO migration_history (name) VALUES (?);");
+			cdstmt.bind((int) 1, migration.name.c_str());
+			cdstmt.execQuery().finalize();
+			cdstmt.finalize();
+			continue;
+		}
 
 		// Doing these 1 migration at a time since one takes a long time and some may think it is crashing.
 		// This will at the least guarentee that the full migration needs to be run in order to be counted as "migrated".
@@ -122,10 +144,13 @@ void MigrationRunner::RunSQLiteMigrations() {
 				Game::logger->Log("MigrationRunner", "Encountered error running DML command: (%i) : %s", e.errorCode(), e.errorMessage());
 			}
 		}
-		stmt = Database::CreatePreppedStmt("INSERT INTO migration_history (name) VALUES (?);");
-		stmt->setString(1, migration.name);
-		stmt->execute();
-		delete stmt;
+
+		// Insert into cdclient database.
+		cdstmt = CDClientDatabase::CreatePreppedStmt("INSERT INTO migration_history (name) VALUES (?);");
+		cdstmt.bind((int) 1, migration.name.c_str());
+		cdstmt.execQuery().finalize();
+		cdstmt.finalize();
 	}
+
 	Game::logger->Log("MigrationRunner", "CDServer database is up to date.");
 }


### PR DESCRIPTION
This pull request seeks to add functionality to move the cdserver migration history from the main database to the cdserver database.

Has been tested and is backwards compatible with the current system. The server will copy over cdserver migrations history table entries from the main database to the cdserver database, and any new migrations will go into the cdserver database.

This will make it easier to switch out the cdserver database for the purpose of modding and alike.

Fixes:  #866