### PR TITLE
Enforce migrations to run in a specific order

### DIFF
--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -12,6 +12,7 @@
 #include <BitStream.h>
 
 #include "Game.h"
+#include "dLogger.h"
 
 /*!
   \file GeneralUtils.hpp
@@ -138,7 +139,7 @@ namespace GeneralUtils {
 
 	std::vector<std::string> SplitString(const std::string& str, char delimiter);
 
-	std::vector<std::string> GetFileNamesFromFolder(const std::string& folder);
+	std::vector<std::string> GetSqlFileNamesFromFolder(const std::string& folder);
 
 	template <typename T>
 	T Parse(const char* value);

--- a/dDatabase/MigrationRunner.cpp
+++ b/dDatabase/MigrationRunner.cpp
@@ -38,7 +38,7 @@ void MigrationRunner::RunMigrations() {
 
 	sql::SQLString finalSQL = "";
 	bool runSd0Migrations = false;
-	for (const auto& entry : GeneralUtils::GetFileNamesFromFolder((BinaryPathFinder::GetBinaryDir() / "./migrations/dlu/").string())) {
+	for (const auto& entry : GeneralUtils::GetSqlFileNamesFromFolder((BinaryPathFinder::GetBinaryDir() / "./migrations/dlu/").string())) {
 		auto migration = LoadMigration("dlu/" + entry);
 
 		if (migration.data.empty()) {
@@ -102,7 +102,7 @@ void MigrationRunner::RunSQLiteMigrations() {
 	stmt->execute();
 	delete stmt;
 
-	for (const auto& entry : GeneralUtils::GetFileNamesFromFolder((BinaryPathFinder::GetBinaryDir() / "migrations/cdserver/").string())) {
+	for (const auto& entry : GeneralUtils::GetSqlFileNamesFromFolder((BinaryPathFinder::GetBinaryDir() / "migrations/cdserver/").string())) {
 		auto migration = LoadMigration("cdserver/" + entry);
 
 		if (migration.data.empty()) continue;


### PR DESCRIPTION
Enforce that migrations are run in the order specified by the file name.
Tested that the list, even with triple digit migration numbers, correctly ordered migrations and executed them in order.
Master successfully runs and executes the migrations to CDServer and the MySQL database.