### PR TITLE
Fixed typo in migration 7 that prevented its execution 

### DIFF
--- a/migrations/dlu/7_make_play_key_id_nullable.sql
+++ b/migrations/dlu/7_make_play_key_id_nullable.sql
@@ -1,1 +1,1 @@
-ALTER TABLE account MODIFY play_key_id INT DEFAULT 0;
+ALTER TABLE accounts MODIFY play_key_id INT DEFAULT 0;


### PR DESCRIPTION
Fixed a typo in the mysql migration 7 causing it to error when ran.

Was set to table `account` instead of `accounts`

Resulted in the following error when ran

`[MigrationRunner] Encountered error running migration: (conn=6) Table 'darkflame.account' doesn't exist`

--

Tested by running the migration without errors.