### PR TITLE
Resolve warnings, change config init order and remove unused Game variables for all servers

### DIFF
--- a/dAuthServer/AuthServer.cpp
+++ b/dAuthServer/AuthServer.cpp
@@ -40,8 +40,8 @@ int main(int argc, char** argv) {
 	if (!Game::logger) return EXIT_FAILURE;
 
 	//Read our config:
-	Game::config = new dConfig("authconfig.ini");
-	Game::logger->SetLogToConsole(bool(std::stoi(Game::config->GetValue("log_to_console"))));
+	Game::config = new dConfig((BinaryPathFinder::GetBinaryDir() / "authconfig.ini").string());
+	Game::logger->SetLogToConsole(Game::config->GetValue("log_to_console") != "0");
 	Game::logger->SetLogDebugStatements(Game::config->GetValue("log_debug_statements") == "1");
 
 	Game::logger->Log("AuthServer", "Starting Auth server...");

--- a/dAuthServer/AuthServer.cpp
+++ b/dAuthServer/AuthServer.cpp
@@ -22,9 +22,9 @@
 
 #include "Game.h"
 namespace Game {
-	dLogger* logger;
-	dServer* server;
-	dConfig* config;
+	dLogger* logger = nullptr;
+	dServer* server = nullptr;
+	dConfig* config = nullptr;
 }
 
 dLogger* SetupLogger();
@@ -37,22 +37,22 @@ int main(int argc, char** argv) {
 
 	//Create all the objects we need to run our service:
 	Game::logger = SetupLogger();
-	if (!Game::logger) return 0;
+	if (!Game::logger) return EXIT_FAILURE;
+
+	//Read our config:
+	Game::config = new dConfig("authconfig.ini");
+	Game::logger->SetLogToConsole(bool(std::stoi(Game::config->GetValue("log_to_console"))));
+	Game::logger->SetLogDebugStatements(Game::config->GetValue("log_debug_statements") == "1");
+
 	Game::logger->Log("AuthServer", "Starting Auth server...");
 	Game::logger->Log("AuthServer", "Version: %i.%i", PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR);
 	Game::logger->Log("AuthServer", "Compiled on: %s", __TIMESTAMP__);
 
-	//Read our config:
-	dConfig config("authconfig.ini");
-	Game::config = &config;
-	Game::logger->SetLogToConsole(bool(std::stoi(config.GetValue("log_to_console"))));
-	Game::logger->SetLogDebugStatements(config.GetValue("log_debug_statements") == "1");
-
 	//Connect to the MySQL Database
-	std::string mysql_host = config.GetValue("mysql_host");
-	std::string mysql_database = config.GetValue("mysql_database");
-	std::string mysql_username = config.GetValue("mysql_username");
-	std::string mysql_password = config.GetValue("mysql_password");
+	std::string mysql_host = Game::config->GetValue("mysql_host");
+	std::string mysql_database = Game::config->GetValue("mysql_database");
+	std::string mysql_username = Game::config->GetValue("mysql_username");
+	std::string mysql_password = Game::config->GetValue("mysql_password");
 
 	try {
 		Database::Connect(mysql_host, mysql_database, mysql_username, mysql_password);
@@ -61,7 +61,7 @@ int main(int argc, char** argv) {
 		Database::Destroy("AuthServer");
 		delete Game::server;
 		delete Game::logger;
-		return 0;
+		return EXIT_FAILURE;
 	}
 
 	//Find out the master's IP:
@@ -80,10 +80,10 @@ int main(int argc, char** argv) {
 	//It's safe to pass 'localhost' here, as the IP is only used as the external IP.
 	int maxClients = 50;
 	int ourPort = 1001; //LU client is hardcoded to use this for auth port, so I'm making it the default.
-	if (config.GetValue("max_clients") != "") maxClients = std::stoi(config.GetValue("max_clients"));
-	if (config.GetValue("port") != "") ourPort = std::atoi(config.GetValue("port").c_str());
+	if (Game::config->GetValue("max_clients") != "") maxClients = std::stoi(Game::config->GetValue("max_clients"));
+	if (Game::config->GetValue("port") != "") ourPort = std::atoi(Game::config->GetValue("port").c_str());
 
-	Game::server = new dServer(config.GetValue("external_ip"), ourPort, 0, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::Auth, Game::config);
+	Game::server = new dServer(Game::config->GetValue("external_ip"), ourPort, 0, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::Auth, Game::config);
 
 	//Run it until server gets a kill message from Master:
 	auto t = std::chrono::high_resolution_clock::now();
@@ -145,8 +145,8 @@ int main(int argc, char** argv) {
 	Database::Destroy("AuthServer");
 	delete Game::server;
 	delete Game::logger;
+	delete Game::config;
 
-	exit(EXIT_SUCCESS);
 	return EXIT_SUCCESS;
 }
 

--- a/dChatServer/ChatServer.cpp
+++ b/dChatServer/ChatServer.cpp
@@ -45,8 +45,8 @@ int main(int argc, char** argv) {
 	if (!Game::logger) return EXIT_FAILURE;
 
 	//Read our config:
-	Game::config = new dConfig("chatconfig.ini");
-	Game::logger->SetLogToConsole(bool(std::stoi(Game::config->GetValue("log_to_console"))));
+	Game::config = new dConfig((BinaryPathFinder::GetBinaryDir() / "chatconfig.ini").string());
+	Game::logger->SetLogToConsole(Game::config->GetValue("log_to_console") != "0");
 	Game::logger->SetLogDebugStatements(Game::config->GetValue("log_debug_statements") == "1");
 
 	Game::logger->Log("ChatServer", "Starting Chat server...");

--- a/dChatServer/ChatServer.cpp
+++ b/dChatServer/ChatServer.cpp
@@ -20,11 +20,11 @@
 
 #include "Game.h"
 namespace Game {
-	dLogger* logger;
-	dServer* server;
-	dConfig* config;
-	dChatFilter* chatFilter;
-	AssetManager* assetManager;
+	dLogger* logger = nullptr;
+	dServer* server = nullptr;
+	dConfig* config = nullptr;
+	dChatFilter* chatFilter = nullptr;
+	AssetManager* assetManager = nullptr;
 }
 
 //RakNet includes:
@@ -42,19 +42,19 @@ int main(int argc, char** argv) {
 
 	//Create all the objects we need to run our service:
 	Game::logger = SetupLogger();
-	if (!Game::logger) return 0;
+	if (!Game::logger) return EXIT_FAILURE;
+
+	//Read our config:
+	Game::config = new dConfig("chatconfig.ini");
+	Game::logger->SetLogToConsole(bool(std::stoi(Game::config->GetValue("log_to_console"))));
+	Game::logger->SetLogDebugStatements(Game::config->GetValue("log_debug_statements") == "1");
+
 	Game::logger->Log("ChatServer", "Starting Chat server...");
 	Game::logger->Log("ChatServer", "Version: %i.%i", PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR);
 	Game::logger->Log("ChatServer", "Compiled on: %s", __TIMESTAMP__);
 
-	//Read our config:
-	dConfig config("chatconfig.ini");
-	Game::config = &config;
-	Game::logger->SetLogToConsole(bool(std::stoi(config.GetValue("log_to_console"))));
-	Game::logger->SetLogDebugStatements(config.GetValue("log_debug_statements") == "1");
-
 	try {
-		std::string clientPathStr = config.GetValue("client_location");
+		std::string clientPathStr = Game::config->GetValue("client_location");
 		if (clientPathStr.empty()) clientPathStr = "./res";
 		std::filesystem::path clientPath = std::filesystem::path(clientPathStr);
 		if (clientPath.is_relative()) {
@@ -69,10 +69,10 @@ int main(int argc, char** argv) {
 	}
 
 	//Connect to the MySQL Database
-	std::string mysql_host = config.GetValue("mysql_host");
-	std::string mysql_database = config.GetValue("mysql_database");
-	std::string mysql_username = config.GetValue("mysql_username");
-	std::string mysql_password = config.GetValue("mysql_password");
+	std::string mysql_host = Game::config->GetValue("mysql_host");
+	std::string mysql_database = Game::config->GetValue("mysql_database");
+	std::string mysql_username = Game::config->GetValue("mysql_username");
+	std::string mysql_password = Game::config->GetValue("mysql_password");
 
 	try {
 		Database::Connect(mysql_host, mysql_database, mysql_username, mysql_password);
@@ -81,7 +81,7 @@ int main(int argc, char** argv) {
 		Database::Destroy("ChatServer");
 		delete Game::server;
 		delete Game::logger;
-		return 0;
+		return EXIT_FAILURE;
 	}
 
 	//Find out the master's IP:
@@ -100,12 +100,12 @@ int main(int argc, char** argv) {
 	//It's safe to pass 'localhost' here, as the IP is only used as the external IP.
 	int maxClients = 50;
 	int ourPort = 1501;
-	if (config.GetValue("max_clients") != "") maxClients = std::stoi(config.GetValue("max_clients"));
-	if (config.GetValue("port") != "") ourPort = std::atoi(config.GetValue("port").c_str());
+	if (Game::config->GetValue("max_clients") != "") maxClients = std::stoi(Game::config->GetValue("max_clients"));
+	if (Game::config->GetValue("port") != "") ourPort = std::atoi(Game::config->GetValue("port").c_str());
 
-	Game::server = new dServer(config.GetValue("external_ip"), ourPort, 0, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::Chat, Game::config);
+	Game::server = new dServer(Game::config->GetValue("external_ip"), ourPort, 0, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::Chat, Game::config);
 
-	Game::chatFilter = new dChatFilter(Game::assetManager->GetResPath().string() + "/chatplus_en_us", bool(std::stoi(config.GetValue("dont_generate_dcf"))));
+	Game::chatFilter = new dChatFilter(Game::assetManager->GetResPath().string() + "/chatplus_en_us", bool(std::stoi(Game::config->GetValue("dont_generate_dcf"))));
 
 	//Run it until server gets a kill message from Master:
 	auto t = std::chrono::high_resolution_clock::now();
@@ -167,8 +167,8 @@ int main(int argc, char** argv) {
 	Database::Destroy("ChatServer");
 	delete Game::server;
 	delete Game::logger;
+	delete Game::config;
 
-	exit(EXIT_SUCCESS);
 	return EXIT_SUCCESS;
 }
 

--- a/dCommon/Game.h
+++ b/dCommon/Game.h
@@ -5,7 +5,6 @@
 class dServer;
 class dLogger;
 class InstanceManager;
-class dpWorld;
 class dChatFilter;
 class dConfig;
 class RakPeerInterface;
@@ -16,7 +15,6 @@ namespace Game {
 	extern dLogger* logger;
 	extern dServer* server;
 	extern InstanceManager* im;
-	extern dpWorld* physicsWorld;
 	extern dChatFilter* chatFilter;
 	extern dConfig* config;
 	extern std::mt19937 randomEngine;

--- a/dMasterServer/InstanceManager.cpp
+++ b/dMasterServer/InstanceManager.cpp
@@ -74,7 +74,7 @@ Instance* InstanceManager::GetInstance(LWOMAPID mapID, bool isFriendTransfer, LW
 	cmd.append("&"); //Sends our next process to the background on Linux
 #endif
 
-	system(cmd.c_str());
+	auto ret = system(cmd.c_str());
 
 	m_Instances.push_back(instance);
 
@@ -322,7 +322,7 @@ Instance* InstanceManager::CreatePrivateInstance(LWOMAPID mapID, LWOCLONEID clon
 	cmd.append("&"); //Sends our next process to the background on Linux
 #endif
 
-	system(cmd.c_str());
+	auto ret = system(cmd.c_str());
 
 	m_Instances.push_back(instance);
 

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -79,8 +79,33 @@ int main(int argc, char** argv) {
 	Game::logger = SetupLogger();
 	if (!Game::logger) return EXIT_FAILURE;
 
-	Game::config = new dConfig("masterconfig.ini");
-	Game::logger->SetLogToConsole(bool(std::stoi(Game::config->GetValue("log_to_console"))));
+	if (!std::filesystem::exists(BinaryPathFinder::GetBinaryDir() / "authconfig.ini")) {
+		Game::logger->Log("MasterServer", "Couldnt find authconfig.ini");
+		return EXIT_FAILURE;
+	}
+
+	if (!std::filesystem::exists(BinaryPathFinder::GetBinaryDir() / "chatconfig.ini")) {
+		Game::logger->Log("MasterServer", "Couldnt find chatconfig.ini");
+		return EXIT_FAILURE;
+	}
+
+	if (!std::filesystem::exists(BinaryPathFinder::GetBinaryDir() / "masterconfig.ini")) {
+		Game::logger->Log("MasterServer", "Couldnt find masterconfig.ini");
+		return EXIT_FAILURE;
+	}
+
+	if (!std::filesystem::exists(BinaryPathFinder::GetBinaryDir() / "sharedconfig.ini")) {
+		Game::logger->Log("MasterServer", "Couldnt find sharedconfig.ini");
+		return EXIT_FAILURE;
+	}
+
+	if (!std::filesystem::exists(BinaryPathFinder::GetBinaryDir() / "worldconfig.ini")) {
+		Game::logger->Log("MasterServer", "Couldnt find worldconfig.ini");
+		return EXIT_FAILURE;
+	}
+
+	Game::config = new dConfig((BinaryPathFinder::GetBinaryDir() / "masterconfig.ini").string());
+	Game::logger->SetLogToConsole(Game::config->GetValue("log_to_console") != "0");
 	Game::logger->SetLogDebugStatements(Game::config->GetValue("log_debug_statements") == "1");
 
 	Game::logger->Log("MasterServer", "Starting Master server...");

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -43,11 +43,11 @@
 #include "FdbToSqlite.h"
 
 namespace Game {
-	dLogger* logger;
-	dServer* server;
-	InstanceManager* im;
-	dConfig* config;
-	AssetManager* assetManager;
+	dLogger* logger = nullptr;
+	dServer* server = nullptr;
+	InstanceManager* im = nullptr;
+	dConfig* config = nullptr;
+	AssetManager* assetManager = nullptr;
 } //namespace Game
 
 bool shutdownSequenceStarted = false;
@@ -79,13 +79,13 @@ int main(int argc, char** argv) {
 	Game::logger = SetupLogger();
 	if (!Game::logger) return EXIT_FAILURE;
 
-	Game::logger->Log("MasterServer", "Starting Master server...");
-	Game::logger->Log("MasterServer", "Version: %i.%i", PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR);
-	Game::logger->Log("MasterServer", "Compiled on: %s", __TIMESTAMP__);
-
 	Game::config = new dConfig("masterconfig.ini");
 	Game::logger->SetLogToConsole(bool(std::stoi(Game::config->GetValue("log_to_console"))));
 	Game::logger->SetLogDebugStatements(Game::config->GetValue("log_debug_statements") == "1");
+
+	Game::logger->Log("MasterServer", "Starting Master server...");
+	Game::logger->Log("MasterServer", "Version: %i.%i", PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR);
+	Game::logger->Log("MasterServer", "Compiled on: %s", __TIMESTAMP__);
 
 	//Connect to the MySQL Database
 	std::string mysql_host = Game::config->GetValue("mysql_host");
@@ -732,28 +732,28 @@ void HandlePacket(Packet* packet) {
 void StartChatServer() {
 #ifdef __APPLE__
 	//macOS doesn't need sudo to run on ports < 1024
-	system(((BinaryPathFinder::GetBinaryDir() / "ChatServer").string() + "&").c_str());
+	auto result = system(((BinaryPathFinder::GetBinaryDir() / "ChatServer").string() + "&").c_str());
 #elif _WIN32
-	system(("start " + (BinaryPathFinder::GetBinaryDir() / "ChatServer.exe").string()).c_str());
+	auto result = system(("start " + (BinaryPathFinder::GetBinaryDir() / "ChatServer.exe").string()).c_str());
 #else
 	if (std::atoi(Game::config->GetValue("use_sudo_chat").c_str())) {
-		system(("sudo " + (BinaryPathFinder::GetBinaryDir() / "ChatServer").string() + "&").c_str());
+		auto result = system(("sudo " + (BinaryPathFinder::GetBinaryDir() / "ChatServer").string() + "&").c_str());
 	} else {
-		system(((BinaryPathFinder::GetBinaryDir() / "ChatServer").string() + "&").c_str());
+		auto result = system(((BinaryPathFinder::GetBinaryDir() / "ChatServer").string() + "&").c_str());
 	}
 #endif
 }
 
 void StartAuthServer() {
 #ifdef __APPLE__
-	system(((BinaryPathFinder::GetBinaryDir() / "AuthServer").string() + "&").c_str());
+	auto result = system(((BinaryPathFinder::GetBinaryDir() / "AuthServer").string() + "&").c_str());
 #elif _WIN32
-	system(("start " + (BinaryPathFinder::GetBinaryDir() / "AuthServer.exe").string()).c_str());
+	auto result = system(("start " + (BinaryPathFinder::GetBinaryDir() / "AuthServer.exe").string()).c_str());
 #else
 	if (std::atoi(Game::config->GetValue("use_sudo_auth").c_str())) {
-		system(("sudo " + (BinaryPathFinder::GetBinaryDir() / "AuthServer").string() + "&").c_str());
+		auto result = system(("sudo " + (BinaryPathFinder::GetBinaryDir() / "AuthServer").string() + "&").c_str());
 	} else {
-		system(((BinaryPathFinder::GetBinaryDir() / "AuthServer").string() + "&").c_str());
+		auto result = system(((BinaryPathFinder::GetBinaryDir() / "AuthServer").string() + "&").c_str());
 	}
 #endif
 }

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -127,8 +127,8 @@ int main(int argc, char** argv) {
 	if (!Game::logger) return EXIT_FAILURE;
 
 	//Read our config:
-	Game::config = new dConfig("worldconfig.ini");
-	Game::logger->SetLogToConsole(bool(std::stoi(Game::config->GetValue("log_to_console"))));
+	Game::config = new dConfig((BinaryPathFinder::GetBinaryDir() / "worldconfig.ini").string());
+	Game::logger->SetLogToConsole(Game::config->GetValue("log_to_console") != "0");
 	Game::logger->SetLogDebugStatements(Game::config->GetValue("log_debug_statements") == "1");
 
 	Game::logger->Log("WorldServer", "Starting World server...");

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -61,17 +61,14 @@
 #include "ZCompression.h"
 
 namespace Game {
-	dLogger* logger;
-	dServer* server;
-	dZoneManager* zoneManager;
-	dpWorld* physicsWorld;
-	dChatFilter* chatFilter;
-	dConfig* config;
+	dLogger* logger = nullptr;
+	dServer* server = nullptr;
+	dpWorld* physicsWorld = nullptr;
+	dChatFilter* chatFilter = nullptr;
+	dConfig* config = nullptr;
+	AssetManager* assetManager = nullptr;
+	RakPeerInterface* chatServer = nullptr;
 	std::mt19937 randomEngine;
-
-	AssetManager* assetManager;
-
-	RakPeerInterface* chatServer;
 	SystemAddress chatSysAddr;
 }
 
@@ -127,26 +124,21 @@ int main(int argc, char** argv) {
 
 	//Create all the objects we need to run our service:
 	Game::logger = SetupLogger(zoneID, instanceID);
-	if (!Game::logger) return 0;
+	if (!Game::logger) return EXIT_FAILURE;
 
-	Game::logger->SetLogToConsole(true); //We want this info to always be logged.
+	//Read our config:
+	Game::config = new dConfig("worldconfig.ini");
+	Game::logger->SetLogToConsole(bool(std::stoi(Game::config->GetValue("log_to_console"))));
+	Game::logger->SetLogDebugStatements(Game::config->GetValue("log_debug_statements") == "1");
+
 	Game::logger->Log("WorldServer", "Starting World server...");
 	Game::logger->Log("WorldServer", "Version: %i.%i", PROJECT_VERSION_MAJOR, PROJECT_VERSION_MINOR);
 	Game::logger->Log("WorldServer", "Compiled on: %s", __TIMESTAMP__);
 
-#ifndef _DEBUG
-	Game::logger->SetLogToConsole(false); //By default, turn it back off if not in debug.
-#endif
-
-	//Read our config:
-	dConfig config("worldconfig.ini");
-	Game::config = &config;
-	Game::logger->SetLogToConsole(bool(std::stoi(config.GetValue("log_to_console"))));
-	Game::logger->SetLogDebugStatements(config.GetValue("log_debug_statements") == "1");
-	if (config.GetValue("disable_chat") == "1") chatDisabled = true;
+	if (Game::config->GetValue("disable_chat") == "1") chatDisabled = true;
 
 	try {
-		std::string clientPathStr = config.GetValue("client_location");
+		std::string clientPathStr = Game::config->GetValue("client_location");
 		if (clientPathStr.empty()) clientPathStr = "./res";
 		std::filesystem::path clientPath = std::filesystem::path(clientPathStr);
 		if (clientPath.is_relative()) {
@@ -166,28 +158,28 @@ int main(int argc, char** argv) {
 		Game::logger->Log("WorldServer", "Unable to connect to CDServer SQLite Database");
 		Game::logger->Log("WorldServer", "Error: %s", e.errorMessage());
 		Game::logger->Log("WorldServer", "Error Code: %i", e.errorCode());
-		return -1;
+		return EXIT_FAILURE;
 	}
 
 	CDClientManager::Instance()->Initialize();
 
 	//Connect to the MySQL Database
-	std::string mysql_host = config.GetValue("mysql_host");
-	std::string mysql_database = config.GetValue("mysql_database");
-	std::string mysql_username = config.GetValue("mysql_username");
-	std::string mysql_password = config.GetValue("mysql_password");
+	std::string mysql_host = Game::config->GetValue("mysql_host");
+	std::string mysql_database = Game::config->GetValue("mysql_database");
+	std::string mysql_username = Game::config->GetValue("mysql_username");
+	std::string mysql_password = Game::config->GetValue("mysql_password");
 
-	Diagnostics::SetProduceMemoryDump(config.GetValue("generate_dump") == "1");
+	Diagnostics::SetProduceMemoryDump(Game::config->GetValue("generate_dump") == "1");
 
-	if (!config.GetValue("dump_folder").empty()) {
-		Diagnostics::SetOutDirectory(config.GetValue("dump_folder"));
+	if (!Game::config->GetValue("dump_folder").empty()) {
+		Diagnostics::SetOutDirectory(Game::config->GetValue("dump_folder"));
 	}
 
 	try {
 		Database::Connect(mysql_host, mysql_database, mysql_username, mysql_password);
 	} catch (sql::SQLException& ex) {
 		Game::logger->Log("WorldServer", "Got an error while connecting to the database: %s", ex.what());
-		return 0;
+		return EXIT_FAILURE;
 	}
 
 	//Find out the master's IP:
@@ -206,13 +198,13 @@ int main(int argc, char** argv) {
 	ObjectIDManager::Instance()->Initialize();
 	UserManager::Instance()->Initialize();
 	LootGenerator::Instance();
-	Game::chatFilter = new dChatFilter(Game::assetManager->GetResPath().string() + "/chatplus_en_us", bool(std::stoi(config.GetValue("dont_generate_dcf"))));
+	Game::chatFilter = new dChatFilter(Game::assetManager->GetResPath().string() + "/chatplus_en_us", bool(std::stoi(Game::config->GetValue("dont_generate_dcf"))));
 
 	Game::server = new dServer(masterIP, ourPort, instanceID, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::World, Game::config, zoneID);
 
 	//Connect to the chat server:
 	int chatPort = 1501;
-	if (config.GetValue("chat_server_port") != "") chatPort = std::atoi(config.GetValue("chat_server_port").c_str());
+	if (Game::config->GetValue("chat_server_port") != "") chatPort = std::atoi(Game::config->GetValue("chat_server_port").c_str());
 
 	auto chatSock = SocketDescriptor(uint16_t(ourPort + 2), 0);
 	Game::chatServer = RakNetworkFactory::GetRakPeerInterface();
@@ -1279,16 +1271,15 @@ void WorldShutdownSequence() {
 }
 
 void FinalizeShutdown() {
-	//Delete our objects here:
-	if (Game::zoneManager) delete Game::zoneManager;
-
 	Game::logger->Log("WorldServer", "Shutdown complete, zone (%i), instance (%i)", Game::server->GetZoneID(), instanceID);
 
+	//Delete our objects here:
 	Metrics::Clear();
 	Database::Destroy("WorldServer");
-	delete Game::chatFilter;
-	delete Game::server;
-	delete Game::logger;
+	if (Game::chatFilter) delete Game::chatFilter;
+	if (Game::server) delete Game::server;
+	if (Game::logger) delete Game::logger;
+	if (Game::config) delete Game::config;
 
 	worldShutdownSequenceComplete = true;
 

--- a/tests/dGameTests/GameDependencies.cpp
+++ b/tests/dGameTests/GameDependencies.cpp
@@ -4,7 +4,6 @@ namespace Game {
 	dLogger* logger;
 	dServer* server;
 	dZoneManager* zoneManager;
-	dpWorld* physicsWorld;
 	dChatFilter* chatFilter;
 	dConfig* config;
 	std::mt19937 randomEngine;


### PR DESCRIPTION
Initialize dConfig first, before logger so we know whether or not to log to console

This also incidentally fixes an issue brought up by @luxaritas about master not logging some initial server info to the console

Initialize namespace Game variables to nullptr so they are a known value if accessed before initialization. Removed unused Game variables

Replaced config with a pointer instead of referencing something on the stack.  Saves us memory used on the stack since this is used until the program shutsdown.

Assign return values to system calls to silence warnings.

Tested that the server still compiles, runs and allows me to load into the game.