### PR TITLE
Fix typo in forcemovement behavior

### DIFF
--- a/dGame/dBehaviors/ForceMovementBehavior.cpp
+++ b/dGame/dBehaviors/ForceMovementBehavior.cpp
@@ -75,5 +75,5 @@ void ForceMovementBehavior::SyncCalculation(BehaviorContext* context, RakNet::Bi
 
 	this->m_hitAction->Calculate(context, bitStream, branch);
 	this->m_hitEnemyAction->Calculate(context, bitStream, branch);
-	this->m_hitEnemyAction->Calculate(context, bitStream, branch);
+	this->m_hitFactionAction->Calculate(context, bitStream, branch);
 }


### PR DESCRIPTION
This fixes the bug with the schooner hitting twice, since it was calling that behavior twice.
This probably fixes other behaviors hitting twice.
Tested that the schooner only hits once