### PR TITLE
Allow player skills to be interrupted

### DIFF
--- a/dGame/dComponents/SkillComponent.cpp
+++ b/dGame/dComponents/SkillComponent.cpp
@@ -181,17 +181,11 @@ void SkillComponent::Reset() {
 }
 
 void SkillComponent::Interrupt() {
-	if (m_Parent->IsPlayer()) return;
-
+	// TODO: need to check immunities on the destroyable component, but they aren't implemented
 	auto* combat = m_Parent->GetComponent<BaseCombatAIComponent>();
+	if (combat != nullptr && combat->GetStunImmune()) return;
 
-	if (combat != nullptr && combat->GetStunImmune()) {
-		return;
-	}
-
-	for (const auto& behavior : this->m_managedBehaviors) {
-		behavior.second->Interrupt();
-	}
+	for (const auto& behavior : this->m_managedBehaviors) behavior.second->Interrupt();
 }
 
 void SkillComponent::RegisterCalculatedProjectile(const LWOOBJID projectileId, BehaviorContext* context, const BehaviorBranchContext& branch, const LOT lot, const float maxTime,


### PR DESCRIPTION
This fixes behaviors not ending when the client sends an interrupt to the player.
This will infinite speed stacking when it was additive to the multiplier (or rather, permanent speed boost once that PR is merged what removes stacking speed boosts).

Tested several different scenarios behaviors for the player being interrupted to make sure they are handled sanely
