### PR TITLE
Implement lower cap datagram / MTU size

### DIFF
--- a/dNet/dServer.cpp
+++ b/dNet/dServer.cpp
@@ -67,7 +67,7 @@ dServer::dServer(const std::string& ip, int port, int instanceID, int maxConnect
 	} else { mLogger->Log("dServer", "FAILED TO START SERVER ON IP/PORT: %s:%i", ip.c_str(), port); return; }
 
 	mLogger->SetLogToConsole(prevLogSetting);
-
+	mPeer->SetMTUSize(1228); // This is hard coded by lu for some reason.
 	//Connect to master if we are not master:
 	if (serverType != ServerType::Master) {
 		SetupForMasterConnection();


### PR DESCRIPTION
LEGO Universe uses a lower datagram / MTU size so we are also going to use this.  May also address other issues, we'll see.

Tested that the server compiles and boots.  

Will test that I can login with a substantially sized Create Character packet in the morning