### PR TITLE
add missing returns in tacarc and switch multiple

### DIFF
--- a/dGame/dBehaviors/SwitchMultipleBehavior.cpp
+++ b/dGame/dBehaviors/SwitchMultipleBehavior.cpp
@@ -14,6 +14,7 @@ void SwitchMultipleBehavior::Handle(BehaviorContext* context, RakNet::BitStream*
 
 	if (!bitStream->Read(value)) {
 		Game::logger->Log("SwitchMultipleBehavior", "Unable to read value from bitStream, aborting Handle! %i", bitStream->GetNumberOfUnreadBits());
+		return;
 	};
 
 	uint32_t trigger = 0;

--- a/dGame/dBehaviors/TacArcBehavior.cpp
+++ b/dGame/dBehaviors/TacArcBehavior.cpp
@@ -22,6 +22,7 @@ void TacArcBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStre
 
 	if (!bitStream->Read(hit)) {
 		Game::logger->Log("TacArcBehavior", "Unable to read hit from bitStream, aborting Handle! %i", bitStream->GetNumberOfUnreadBits());
+		return;
 	};
 
 	if (this->m_checkEnv) {
@@ -29,6 +30,7 @@ void TacArcBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStre
 
 		if (!bitStream->Read(blocked)) {
 			Game::logger->Log("TacArcBehavior", "Unable to read blocked from bitStream, aborting Handle! %i", bitStream->GetNumberOfUnreadBits());
+			return;
 		};
 
 		if (blocked) {
@@ -43,6 +45,7 @@ void TacArcBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStre
 
 		if (!bitStream->Read(count)) {
 			Game::logger->Log("TacArcBehavior", "Unable to read count from bitStream, aborting Handle! %i", bitStream->GetNumberOfUnreadBits());
+			return;
 		};
 
 		if (count > m_maxTargets && m_maxTargets > 0) {
@@ -56,6 +59,7 @@ void TacArcBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStre
 
 			if (!bitStream->Read(id)) {
 				Game::logger->Log("TacArcBehavior", "Unable to read id from bitStream, aborting Handle! %i", bitStream->GetNumberOfUnreadBits());
+				return;
 			};
 
 			targets.push_back(id);


### PR DESCRIPTION
No expected behavior change in tacarc since everything was false and 0 to begin with so nothing would happen, however being explicit here and returning early is more ideal.  

Tested that the server still compiles but don't know how to purposefully trigger a bitstream overread.  