### PR TITLE
Fix overread in projectile behavior and address broken stuns

### DIFF
--- a/dGame/dBehaviors/AttackDelayBehavior.cpp
+++ b/dGame/dBehaviors/AttackDelayBehavior.cpp
@@ -13,7 +13,7 @@ void AttackDelayBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bi
 	};
 
 	for (auto i = 0u; i < this->m_numIntervals; ++i) {
-		context->RegisterSyncBehavior(handle, this, branch);
+		context->RegisterSyncBehavior(handle, this, branch, m_ignoreInterrupts);
 	}
 }
 

--- a/dGame/dBehaviors/BehaviorContext.cpp
+++ b/dGame/dBehaviors/BehaviorContext.cpp
@@ -45,12 +45,13 @@ uint32_t BehaviorContext::GetUniqueSkillId() const {
 }
 
 
-void BehaviorContext::RegisterSyncBehavior(const uint32_t syncId, Behavior* behavior, const BehaviorBranchContext& branchContext) {
+void BehaviorContext::RegisterSyncBehavior(const uint32_t syncId, Behavior* behavior, const BehaviorBranchContext& branchContext, bool ignoreInterrupts) {
 	auto entry = BehaviorSyncEntry();
 
 	entry.handle = syncId;
 	entry.behavior = behavior;
 	entry.branchContext = branchContext;
+	entry.ignoreInterrupts = ignoreInterrupts;
 
 	this->syncEntries.push_back(entry);
 }

--- a/dGame/dBehaviors/BehaviorContext.h
+++ b/dGame/dBehaviors/BehaviorContext.h
@@ -80,7 +80,7 @@ struct BehaviorContext
 
 	uint32_t GetUniqueSkillId() const;
 
-	void RegisterSyncBehavior(uint32_t syncId, Behavior* behavior, const BehaviorBranchContext& branchContext);
+	void RegisterSyncBehavior(uint32_t syncId, Behavior* behavior, const BehaviorBranchContext& branchContext, bool ignoreInterrupts = false);
 
 	void RegisterTimerBehavior(Behavior* behavior, const BehaviorBranchContext& branchContext, LWOOBJID second = LWOOBJID_EMPTY);
 

--- a/dGame/dBehaviors/ProjectileAttackBehavior.cpp
+++ b/dGame/dBehaviors/ProjectileAttackBehavior.cpp
@@ -31,14 +31,6 @@ void ProjectileAttackBehavior::Handle(BehaviorContext* context, RakNet::BitStrea
 		return;
 	}
 
-	if (m_useMouseposit) {
-		NiPoint3 targetPosition = NiPoint3::ZERO;
-		if (!bitStream->Read(targetPosition)) {
-			Game::logger->Log("ProjectileAttackBehavior", "Unable to read targetPosition from bitStream, aborting Handle! %i", bitStream->GetNumberOfUnreadBits());
-			return;
-		};
-	}
-
 	auto* targetEntity = EntityManager::Instance()->GetEntity(target);
 
 	for (auto i = 0u; i < this->m_projectileCount; ++i) {

--- a/dGame/dBehaviors/ProjectileAttackBehavior.cpp
+++ b/dGame/dBehaviors/ProjectileAttackBehavior.cpp
@@ -31,6 +31,14 @@ void ProjectileAttackBehavior::Handle(BehaviorContext* context, RakNet::BitStrea
 		return;
 	}
 
+	if (m_ProjectileType == 1) {
+		NiPoint3 targetPosition = NiPoint3::ZERO;
+		if (!bitStream->Read(targetPosition)) {
+			Game::logger->Log("ProjectileAttackBehavior", "Unable to read targetPosition from bitStream, aborting Handle! %i", bitStream->GetNumberOfUnreadBits());
+			return;
+		};
+	}
+
 	auto* targetEntity = EntityManager::Instance()->GetEntity(target);
 
 	for (auto i = 0u; i < this->m_projectileCount; ++i) {
@@ -149,4 +157,6 @@ void ProjectileAttackBehavior::Load() {
 	this->m_trackRadius = GetFloat("track_radius");
 
 	this->m_useMouseposit = GetBoolean("use_mouseposit");
+
+	this->m_ProjectileType = GetInt("projectile_type");
 }

--- a/dGame/dBehaviors/ProjectileAttackBehavior.h
+++ b/dGame/dBehaviors/ProjectileAttackBehavior.h
@@ -23,6 +23,8 @@ public:
 
 	bool m_useMouseposit;
 
+	int32_t m_ProjectileType;
+
 	/*
 	 * Inherited
 	 */


### PR DESCRIPTION
When this reading existed, the logic failed with the number of unread bits being exactly 64.  A NiPoint3 is 96 bits (3 floats) so this reading is not correct and caused the plunger gun in Avant Gardens to not work.

Tested that the plunger gun now correctly destroys targets.