### PR TITLE
Fix lobbies not resetting the timer if all players leave

### DIFF
--- a/dGame/dComponents/ScriptedActivityComponent.cpp
+++ b/dGame/dComponents/ScriptedActivityComponent.cpp
@@ -208,7 +208,7 @@ void ScriptedActivityComponent::PlayerLeave(LWOOBJID playerID) {
 }
 
 void ScriptedActivityComponent::Update(float deltaTime) {
-
+	std::vector<Lobby*> lobbiesToRemove{};
 	// Ticks all the lobbies, not applicable for non-instance activities
 	for (Lobby* lobby : m_Queue) {
 		for (LobbyPlayer* player : lobby->players) {
@@ -217,6 +217,11 @@ void ScriptedActivityComponent::Update(float deltaTime) {
 				PlayerLeave(player->entityID);
 				return;
 			}
+		}
+
+		if (lobby->players.empty()) {
+			lobbiesToRemove.push_back(lobby);
+			continue;
 		}
 
 		// Update the match time for all players
@@ -262,12 +267,16 @@ void ScriptedActivityComponent::Update(float deltaTime) {
 		// The timer has elapsed, start the instance
 		if (lobby->timer <= 0.0f) {
 			Game::logger->Log("ScriptedActivityComponent", "Setting up instance.");
-
 			ActivityInstance* instance = NewInstance();
 			LoadPlayersIntoInstance(instance, lobby->players);
-			RemoveLobby(lobby);
 			instance->StartZone();
+			lobbiesToRemove.push_back(lobby);
 		}
+	}
+
+	while (!lobbiesToRemove.empty()) {
+		RemoveLobby(lobbiesToRemove.front());
+		lobbiesToRemove.erase(lobbiesToRemove.begin());
 	}
 }
 


### PR DESCRIPTION
Addresses an issue where lobbies did not reset their timer if all players left that lobby.

Fixes #530

Tested that a player joining a lobby, readying up, leaving that lobby, and joining a new one properly deletes the old, unpopulated lobby.
Tested the following scenario:
2 players in one spider queen lobby and a third in a second lobby
the 2 players leaving their lobby properly delete the lobby and the single player is still able to join theirs
all players leaving their lobbies deletes the two lobbies.
