### PR TITLE
Fix racing spawn positions

### DIFF
--- a/dGame/dComponents/RacingControlComponent.h
+++ b/dGame/dComponents/RacingControlComponent.h
@@ -123,7 +123,7 @@ public:
 	 * @param player The player who's vehicle to initialize.
 	 * @param initialLoad Is this the first time the player is loading in this race?
 	 */
-	void LoadPlayerVehicle(Entity* player, bool initialLoad = false);
+	void LoadPlayerVehicle(Entity* player, uint32_t positionNumber, bool initialLoad = false);
 
 	/**
 	 * Invoked when the client says it has loaded in.


### PR DESCRIPTION
From looking at the LUZ file, the entity 4843 is used in racing with the LDF data `placement` with the corresponding position to place the player in based on the value of the key.

Tested that a player at position 1 and at position 6 both spawned at the positions specified by this lot.