### PR TITLE
Fix baseEnemyApe stuns and fix IdleFlags serialization

### DIFF
--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -3930,7 +3930,9 @@ void GameMessages::SendChangeIdleFlags(LWOOBJID objectId, eAnimationFlags flagsO
 
 	bitStream.Write(objectId);
 	bitStream.Write(GAME_MSG::GAME_MSG_CHANGE_IDLE_FLAGS);
+	bitStream.Write<bool>(flagsOff != eAnimationFlags::IDLE_NONE);
 	if (flagsOff != eAnimationFlags::IDLE_NONE) bitStream.Write(flagsOff);
+	bitStream.Write<bool>(flagsOn != eAnimationFlags::IDLE_NONE);
 	if (flagsOn != eAnimationFlags::IDLE_NONE) bitStream.Write(flagsOn);
 
 	SEND_PACKET_BROADCAST;

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -3924,14 +3924,14 @@ void GameMessages::SendDisplayChatBubble(LWOOBJID objectId, const std::u16string
 }
 
 
-void GameMessages::SendChangeIdleFlags(LWOOBJID objectId, eAnimationFlags FlagsOn, eAnimationFlags FlagsOff, const SystemAddress& sysAddr) {
+void GameMessages::SendChangeIdleFlags(LWOOBJID objectId, eAnimationFlags flagsOn, eAnimationFlags flagsOff, const SystemAddress& sysAddr) {
 	CBITSTREAM;
 	CMSGHEADER;
 
 	bitStream.Write(objectId);
 	bitStream.Write(GAME_MSG::GAME_MSG_CHANGE_IDLE_FLAGS);
-	bitStream.Write(FlagsOff);
-	bitStream.Write(FlagsOn);
+	if (flagsOff != eAnimationFlags::IDLE_NONE) bitStream.Write(flagsOff);
+	if (flagsOn != eAnimationFlags::IDLE_NONE) bitStream.Write(flagsOn);
 
 	SEND_PACKET_BROADCAST;
 }

--- a/dScripts/02_server/Enemy/General/BaseEnemyApe.cpp
+++ b/dScripts/02_server/Enemy/General/BaseEnemyApe.cpp
@@ -31,9 +31,12 @@ void BaseEnemyApe::OnHit(Entity* self, Entity* attacker) {
 	if (destroyableComponent != nullptr && destroyableComponent->GetArmor() < 1 && !self->GetBoolean(u"knockedOut")) {
 		StunApe(self, true);
 		self->CancelTimer("spawnQBTime");
-
+		auto* skillComponent = self->GetComponent<SkillComponent>();
+		if (skillComponent) {
+			skillComponent->Reset();
+		}
 		GameMessages::SendPlayAnimation(self, u"disable", 1.7f);
-
+		GameMessages::SendChangeIdleFlags(self->GetObjectID(), eAnimationFlags::IDLE_NONE, eAnimationFlags::IDLE_COMBAT, UNASSIGNED_SYSTEM_ADDRESS);
 		const auto reviveTime = self->GetVar<float_t>(u"reviveTime") != 0.0f
 			? self->GetVar<float_t>(u"reviveTime") : 12.0f;
 		self->AddTimer("reviveTime", reviveTime);
@@ -50,6 +53,7 @@ void BaseEnemyApe::OnTimerDone(Entity* self, std::string timerName) {
 			destroyableComponent->SetArmor(destroyableComponent->GetMaxArmor() / timesStunned);
 		}
 		EntityManager::Instance()->SerializeEntity(self);
+		GameMessages::SendChangeIdleFlags(self->GetObjectID(), eAnimationFlags::IDLE_COMBAT, eAnimationFlags::IDLE_NONE, UNASSIGNED_SYSTEM_ADDRESS);
 		self->SetVar<uint32_t>(u"timesStunned", timesStunned + 1);
 		StunApe(self, false);
 


### PR DESCRIPTION
Live LUA script called CancelSkillCast, which I presume is to stop the ape from casting its skills since the ape cannot have any of their skills interrupted.

Also addresses an issue where IdleFlags was not being serialized correctly.  Idle flags have defaults as seen in Reverse Engineered source code and as is documented [here](https://lcdruniverse.org/lu_packets/src/lu_packets/world/gm/client/mod.rs.html#1363-1368)

Tested that no longer do their ground pound silently upon getting out of stun, even if they were stunned while winding the skill up.

Fixes #905 