### PR TITLE
Make Movement Switch Behavior more Live accurate

### DIFF
--- a/dGame/dBehaviors/MovementSwitchBehavior.cpp
+++ b/dGame/dBehaviors/MovementSwitchBehavior.cpp
@@ -4,17 +4,17 @@
 #include "dLogger.h"
 
 void MovementSwitchBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, const BehaviorBranchContext branch) {
-	if (this->m_groundAction->m_templateId == BehaviorTemplates::BEHAVIOR_EMPTY &&
-		this->m_jumpAction->m_templateId == BehaviorTemplates::BEHAVIOR_EMPTY &&
-		this->m_fallingAction->m_templateId == BehaviorTemplates::BEHAVIOR_EMPTY &&
-		this->m_doubleJumpAction->m_templateId == BehaviorTemplates::BEHAVIOR_EMPTY &&
-		this->m_airAction->m_templateId == BehaviorTemplates::BEHAVIOR_EMPTY &&
-		this->m_jetpackAction->m_templateId == BehaviorTemplates::BEHAVIOR_EMPTY) {
-		return;
-	}
-
 	uint32_t movementType{};
 	if (!bitStream->Read(movementType)) {
+		if (this->m_groundAction->m_templateId == BehaviorTemplates::BEHAVIOR_EMPTY &&
+			this->m_jumpAction->m_templateId == BehaviorTemplates::BEHAVIOR_EMPTY &&
+			this->m_fallingAction->m_templateId == BehaviorTemplates::BEHAVIOR_EMPTY &&
+			this->m_doubleJumpAction->m_templateId == BehaviorTemplates::BEHAVIOR_EMPTY &&
+			this->m_airAction->m_templateId == BehaviorTemplates::BEHAVIOR_EMPTY &&
+			this->m_jetpackAction->m_templateId == BehaviorTemplates::BEHAVIOR_EMPTY &&
+			this->m_movingAction->m_templateId == BehaviorTemplates::BEHAVIOR_EMPTY) {
+			return;
+		}
 		Game::logger->Log("MovementSwitchBehavior", "Unable to read movementType from bitStream, aborting Handle! %i", bitStream->GetNumberOfUnreadBits());
 		return;
 	};
@@ -27,33 +27,40 @@ void MovementSwitchBehavior::Handle(BehaviorContext* context, RakNet::BitStream*
 		this->m_jumpAction->Handle(context, bitStream, branch);
 		break;
 	case 3:
-		this->m_fallingAction->Handle(context, bitStream, branch);
+		this->m_airAction->Handle(context, bitStream, branch);
 		break;
 	case 4:
 		this->m_doubleJumpAction->Handle(context, bitStream, branch);
 		break;
 	case 5:
-		this->m_airAction->Handle(context, bitStream, branch);
+		this->m_fallingAction->Handle(context, bitStream, branch);
 		break;
 	case 6:
 		this->m_jetpackAction->Handle(context, bitStream, branch);
 		break;
 	default:
-		Game::logger->Log("MovementSwitchBehavior", "Invalid movement behavior type (%i)!", movementType);
+		this->m_groundAction->Handle(context, bitStream, branch);
 		break;
 	}
 }
 
+Behavior* MovementSwitchBehavior::LoadMovementType(std::string movementType) {
+	float actionValue = GetFloat(movementType, -1.0f);
+	auto loadedBehavior = GetAction(actionValue != -1.0f ? actionValue : 0.0f);
+	if (actionValue == -1.0f && loadedBehavior->m_templateId == BehaviorTemplates::BEHAVIOR_EMPTY) {
+		loadedBehavior = this->m_groundAction;
+	}
+	return loadedBehavior;
+}
+
 void MovementSwitchBehavior::Load() {
-	this->m_airAction = GetAction("air_action");
+	float groundActionValue = GetFloat("ground_action", -1.0f);
+	this->m_groundAction = GetAction(groundActionValue != -1.0f ? groundActionValue : 0.0f);
 
-	this->m_doubleJumpAction = GetAction("double_jump_action");
-
-	this->m_fallingAction = GetAction("falling_action");
-
-	this->m_groundAction = GetAction("ground_action");
-
-	this->m_jetpackAction = GetAction("jetpack_action");
-
-	this->m_jumpAction = GetAction("jump_action");
+	this->m_airAction = LoadMovementType("air_action");
+	this->m_doubleJumpAction = LoadMovementType("double_jump_action");
+	this->m_fallingAction = LoadMovementType("falling_action");
+	this->m_jetpackAction = LoadMovementType("jetpack_action");
+	this->m_jumpAction = LoadMovementType("jump_action");
+	this->m_movingAction = LoadMovementType("moving_action");
 }

--- a/dGame/dBehaviors/MovementSwitchBehavior.h
+++ b/dGame/dBehaviors/MovementSwitchBehavior.h
@@ -3,7 +3,7 @@
 
 class MovementSwitchBehavior final : public Behavior
 {
-public:
+private:
 	/*
 	 * Members
 	 */
@@ -19,6 +19,17 @@ public:
 
 	Behavior* m_jumpAction;
 
+	Behavior* m_movingAction;
+
+	/**
+	 * @brief Loads a movement type from the database into a behavior
+	 * 
+	 * @param movementType The movement type to lookup in the database
+	 * @param behaviorToLoad The Behavior where the result will be stored
+	 */
+	Behavior* LoadMovementType(std::string movementType);
+
+public:
 	/*
 	 * Inherited
 	 */


### PR DESCRIPTION
Fixes #491 

Addresses movement switch disagreements between the client and the server.
Tested that I am able to fight a dragon and use the firework after getting hit by the ground pound aoe.
Tested that I can use The Big One! shortly after falling off a ledge.
Tested that no other unexpected disagreements showed up with existing movement states.

Some notes:
Yes, you must use a behavior or id zero if it it explicitly specified. See [this behavior](https://explorer.lu/skills/behaviors/37108/37108) for more info. It is unable to be used while in jetpack mode on the client so i've mimicked that behavior on the server.
If a parameterID does _not_ exist for a movement type, you must default to the ground behavior.  This is what was done in the live client.
We got Falling and Air action backwards.  The order in this PR is correct.
We're technically supposed to check if the player is moving at all for the default action, and if they are do the moving action, however I was experiencing many desyncs when using the ControllablePhysicsComponent->GetVelocity so I opted to just default to ground in all cases.  The client defaults to the following:
if movement and ground are the same, just do ground
if not moving, do ground
else do moving.
both of these are serialized with a movement type of 1 however there are only 6 items in the live game that have moving and ground as different values (craftable items in Ninjago, so leaving them out is fine in 99% of cases)