### PR TITLE
Fix serratorizer chargeup time

### DIFF
--- a/migrations/cdserver/5_serratorizer_chargeup_fix.sql
+++ b/migrations/cdserver/5_serratorizer_chargeup_fix.sql
@@ -1,0 +1,1 @@
+UPDATE behaviorParameter SET value = 20 WHERE behaviorID = 21001 AND parameterID = "value 2";


### PR DESCRIPTION
The Serratorizers charge up time is limited at 20 as shown [here](https://explorer.squareville.org/skills/behaviors/20933/20999) however its following switch multiples' value 2 is limited at 2, which is not in line with any other valiant weapon which have value 2 at 20.  This migration addresses this issue.

Tested that the serratorizer can be used after charging for longer than 2 seconds