### PR TITLE
add uncast to speed behavior

### DIFF
--- a/dGame/dBehaviors/SpeedBehavior.cpp
+++ b/dGame/dBehaviors/SpeedBehavior.cpp
@@ -29,6 +29,14 @@ void SpeedBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitSt
 	Handle(context, bitStream, branch);
 }
 
+void SpeedBehavior::UnCast(BehaviorContext* context, BehaviorBranchContext branch) {
+	End(context, branch, LWOOBJID_EMPTY);
+}
+
+void SpeedBehavior::Timer(BehaviorContext* context, BehaviorBranchContext branch, LWOOBJID second) {
+	End(context, branch, second);
+}
+
 void SpeedBehavior::End(BehaviorContext* context, BehaviorBranchContext branch, LWOOBJID second) {
 	auto* target = EntityManager::Instance()->GetEntity(branch.target);
 	if (!target) return;
@@ -38,10 +46,6 @@ void SpeedBehavior::End(BehaviorContext* context, BehaviorBranchContext branch, 
 
 	controllablePhysicsComponent->RemoveSpeedboost(m_RunSpeed);
 	EntityManager::Instance()->SerializeEntity(target);
-}
-
-void SpeedBehavior::Timer(BehaviorContext* context, BehaviorBranchContext branch, LWOOBJID second) {
-	End(context, branch, second);
 }
 
 void SpeedBehavior::Load() {

--- a/dGame/dBehaviors/SpeedBehavior.h
+++ b/dGame/dBehaviors/SpeedBehavior.h
@@ -15,6 +15,8 @@ public:
 
 	void Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) override;
 
+	void UnCast(BehaviorContext* context, BehaviorBranchContext branch) override;
+
 	void Timer(BehaviorContext* context, BehaviorBranchContext branch, LWOOBJID second) override;
 
 	void End(BehaviorContext* context, BehaviorBranchContext branch, LWOOBJID second) override;


### PR DESCRIPTION
This is to fix speedbehaviors that are onEquip ending when unequiped, such as with the faction crate disguises.
Tested that this properly ends the speedbehavior when unequiping the faction crates

also moved the timer function up to match the order in the header