### PR TITLE
Serialization fixes for Components

### DIFF
--- a/dGame/dComponents/BaseCombatAIComponent.h
+++ b/dGame/dComponents/BaseCombatAIComponent.h
@@ -244,6 +244,12 @@ private:
 	std::vector<LWOOBJID> GetTargetWithinAggroRange() const;
 
 	/**
+	 * @brief Sets the AiState and prepares the entity for serialization next frame.
+	 * 
+	 */
+	void SetAiState(AiState newState);
+
+	/**
 	 * The current state of the AI
 	 */
 	AiState m_State;
@@ -373,6 +379,12 @@ private:
 	 * If the threat list should be updated
 	 */
 	bool m_DirtyThreat = false;
+
+	/**
+	 * Whether or not the Component has dirty information and should update next frame
+	 * 
+	 */
+	bool m_DirtyStateOrTarget = false;
 
 	/**
 	 * Whether the current entity is a mech enemy, needed as mechs tether radius works differently

--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -59,7 +59,7 @@ std::map<LOT, uint32_t> PetComponent::petFlags = {
 		{ 13067, 838 }, // Skeleton dragon
 };
 
-PetComponent::PetComponent(Entity* parent, uint32_t componentId) : Component(parent) {
+PetComponent::PetComponent(Entity* parent, uint32_t componentId): Component(parent) {
 	m_ComponentId = componentId;
 
 	m_Interaction = LWOOBJID_EMPTY;
@@ -118,21 +118,23 @@ void PetComponent::Serialize(RakNet::BitStream* outBitStream, bool bIsInitialUpd
 		outBitStream->Write(m_Owner);
 	}
 
-	outBitStream->Write(tamed);
-	if (tamed) {
-		outBitStream->Write(m_ModerationStatus);
+	if (bIsInitialUpdate) {
+		outBitStream->Write(tamed);
+		if (tamed) {
+			outBitStream->Write(m_ModerationStatus);
 
-		const auto nameData = GeneralUtils::UTF8ToUTF16(m_Name);
-		const auto ownerNameData = GeneralUtils::UTF8ToUTF16(m_OwnerName);
+			const auto nameData = GeneralUtils::UTF8ToUTF16(m_Name);
+			const auto ownerNameData = GeneralUtils::UTF8ToUTF16(m_OwnerName);
 
-		outBitStream->Write(static_cast<uint8_t>(nameData.size()));
-		for (const auto c : nameData) {
-			outBitStream->Write(c);
-		}
+			outBitStream->Write(static_cast<uint8_t>(nameData.size()));
+			for (const auto c : nameData) {
+				outBitStream->Write(c);
+			}
 
-		outBitStream->Write(static_cast<uint8_t>(ownerNameData.size()));
-		for (const auto c : ownerNameData) {
-			outBitStream->Write(c);
+			outBitStream->Write(static_cast<uint8_t>(ownerNameData.size()));
+			for (const auto c : ownerNameData) {
+				outBitStream->Write(c);
+			}
 		}
 	}
 }
@@ -916,16 +918,16 @@ void PetComponent::AddDrainImaginationTimer(Item* item, bool fromTaming) {
 			return;
 		}
 
-		// If we are out of imagination despawn the pet.
-		if (playerDestroyableComponent->GetImagination() == 0) {
-			this->Deactivate();
-			auto playerEntity = playerDestroyableComponent->GetParent();
-			if (!playerEntity) return;
+	// If we are out of imagination despawn the pet.
+	if (playerDestroyableComponent->GetImagination() == 0) {
+		this->Deactivate();
+		auto playerEntity = playerDestroyableComponent->GetParent();
+		if (!playerEntity) return;
 
-			GameMessages::SendUseItemRequirementsResponse(playerEntity->GetObjectID(), playerEntity->GetSystemAddress(), UseItemResponse::NoImaginationForPet);
-		}
+		GameMessages::SendUseItemRequirementsResponse(playerEntity->GetObjectID(), playerEntity->GetSystemAddress(), UseItemResponse::NoImaginationForPet);
+	}
 
-		this->AddDrainImaginationTimer(item);
+	this->AddDrainImaginationTimer(item);
 		});
 }
 

--- a/dGame/dComponents/PlayerForcedMovementComponent.cpp
+++ b/dGame/dComponents/PlayerForcedMovementComponent.cpp
@@ -7,8 +7,8 @@ PlayerForcedMovementComponent::PlayerForcedMovementComponent(Entity* parent) : C
 PlayerForcedMovementComponent::~PlayerForcedMovementComponent() {}
 
 void PlayerForcedMovementComponent::Serialize(RakNet::BitStream* outBitStream, bool bIsInitialUpdate, unsigned int& flags) {
-	outBitStream->Write(m_DirtyInfo);
-	if (m_DirtyInfo) {
+	outBitStream->Write(m_DirtyInfo || bIsInitialUpdate);
+	if (m_DirtyInfo || bIsInitialUpdate) {
 		outBitStream->Write(m_PlayerOnRail);
 		outBitStream->Write(m_ShowBillboard);
 	}


### PR DESCRIPTION
Address some easy fixes for components:
Implement Delta Compression for the BaseCombatAIComponent to save data sent over the wire.
Only serialize the PetComponent tamed pet name on construction
Serialize PlayerForcedMovement on construction

Tested that no serialization errors appeared in the client logs.
Tested that pet names still show up for myself and other players
Tested that enemies have no combat change