### PR TITLE
Fix smashables not counting towards whole team

### DIFF
--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -700,7 +700,7 @@ void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType
 		auto* missions = owner->GetComponent<MissionComponent>();
 
 		if (missions != nullptr) {
-			if (team != nullptr && isEnemy) {
+			if (team != nullptr) {
 				for (const auto memberId : team->members) {
 					auto* member = EntityManager::Instance()->GetEntity(memberId);
 


### PR DESCRIPTION
Verified via Packet capture `GruntMonkey\Crux Prime\Sterland Powers rebuild computer to get data(ProtoStrongHulk asked me to join team of him,MuslcualrSkysurfer, and JetGothicRaven and asked to be friends but I had to leave after)` that an object was smashed at packet interval `8936` by `ProtoStrongHulk` and credit was given to ShastaFantastic, who was on a team with that person at that time.

Tested that teams properly progress smash missions