### PR TITLE
Hardcore mode

### DIFF
--- a/resources/worldconfig.ini
+++ b/resources/worldconfig.ini
@@ -46,3 +46,15 @@ max_number_of_best_friends=5
 
 # Disables loot drops
 disable_drops=0
+
+# Hardcore mode settings
+hardcore_enabled=0
+
+# Drop your entire inventory on death + coins (drops on the ground, so can be retrieved)
+hardcore_dropinventory=1
+
+# Enemies drop their max hp * this value. 0 will effectively disable it.
+hardcore_uscore_enemies_multiplier=2
+
+# Percentage of u-score to lose on player death
+hardcore_lose_uscore_on_death_percent=10


### PR DESCRIPTION
adds a "hardcore mode" to DLU. 
All it does is set through the worldconfig, where you can enable/disable the mode entirely (off by default), or certain parts of it.

Includes:
- Drops coins and item inventory on death (can be picked up again if you make it in time)
- Loses u-score on death. By default, 10%
- Awards u-score per kill. Calculated by taking the enemies' max HP * the multiplier from the config.