### PR TITLE
Fix misleading crash

### DIFF
--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -248,8 +248,6 @@ int main(int argc, char** argv) {
 
 		std::cout << "Account created successfully!\n";
 
-		Database::Destroy("MasterServer");
-		delete Game::logger;
 
 		return EXIT_SUCCESS;
 	}


### PR DESCRIPTION
Let finalizeShutdown take care of it with `atexit()`

While this affected no functionality, the server now doesn't crash when you create an account.