### PR TITLE
Allow landing animation in Return to the Venture Explorer

### DIFF
--- a/dGame/dComponents/CharacterComponent.cpp
+++ b/dGame/dComponents/CharacterComponent.cpp
@@ -43,7 +43,6 @@ bool CharacterComponent::LandingAnimDisabled(int zoneID) {
 	switch (zoneID) {
 	case 0:
 	case 556:
-	case 1001:
 	case 1101:
 	case 1202:
 	case 1203:


### PR DESCRIPTION
Fixes #975 
Live footage of the landing:
https://www.youtube.com/watch?v=kdLvEMP09PM&list=PL9EFB8500E625ADC7&index=42