### PR TITLE
Prevent users from logging into the wrong world

### DIFF
--- a/dGame/User.h
+++ b/dGame/User.h
@@ -50,6 +50,9 @@ public:
 	time_t GetMuteExpire() const;
 	void SetMuteExpire(time_t value);
 
+	bool GetHasChosenCharacter() { return m_HasChosenCharacter; };
+	void SetHasChosenCharacter(bool value) { m_HasChosenCharacter = value; };
+
 	// Added for GameMessageHandler
 	std::unordered_map<uint32_t, BehaviorParams> uiBehaviorHandles;
 
@@ -69,6 +72,13 @@ private:
 	std::unordered_map<std::string, bool> m_IsBestFriendMap;
 
 	bool m_LastChatMessageApproved = false;
+
+	/**
+	 * Used to determine if a player has chosen a character or not.
+	 * Prevents players from selecting a second character twice during character select
+	 * which would send them to the wrong world.
+	 */
+	bool m_HasChosenCharacter = false;
 	int m_AmountOfTimesOutOfSync = 0;
 	const int m_MaxDesyncAllowed = 12;
 	time_t m_MuteExpire;

--- a/dGame/UserManager.cpp
+++ b/dGame/UserManager.cpp
@@ -193,7 +193,7 @@ bool UserManager::IsNamePreapproved(const std::string& requestedName) {
 void UserManager::RequestCharacterList(const SystemAddress& sysAddr) {
 	User* u = GetUser(sysAddr);
 	if (!u) return;
-
+	u->SetHasChosenCharacter(false);
 	sql::PreparedStatement* stmt = Database::CreatePreppedStmt("SELECT id FROM charinfo WHERE account_id=? ORDER BY last_login DESC LIMIT 4;");
 	stmt->setUInt(1, u->GetAccountID());
 

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -973,6 +973,10 @@ void HandlePacket(Packet* packet) {
 		auto user = UserManager::Instance()->GetUser(packet->systemAddress);
 
 		if (user) {
+			if (user->GetHasChosenCharacter()) {
+				Game::logger->Log("WorldServer", "User %s has already chosen a character, ignoring request.", user->GetUsername().c_str());
+				return;
+			}
 			auto lastCharacter = user->GetLoggedInChar();
 			// This means we swapped characters and we need to remove the previous player from the container.
 			if (static_cast<uint32_t>(lastCharacter) != playerID) {
@@ -981,9 +985,9 @@ void HandlePacket(Packet* packet) {
 				bitStream.Write(lastCharacter);
 				Game::chatServer->Send(&bitStream, SYSTEM_PRIORITY, RELIABLE, 0, Game::chatSysAddr, false);
 			}
+			user->SetHasChosenCharacter(true);
+			UserManager::Instance()->LoginCharacter(packet->systemAddress, static_cast<uint32_t>(playerID));
 		}
-
-		UserManager::Instance()->LoginCharacter(packet->systemAddress, static_cast<uint32_t>(playerID));
 		break;
 	}
 


### PR DESCRIPTION
Prevents users from selecting multiple character during character select, causing them to appear in the wrong world.

I am unable to reproduce the actual issue to confirm if this patch works.  However since this is the only place to choose a character, and all other use cases still allow a player to login, this should address allowing people to choose multiple characters in a single request of the character list.