### PR TITLE
add bounds check to prevent crashing on AG monument race goal

### DIFF
--- a/dScripts/02_server/Map/AG/AgMonumentRaceGoal.cpp
+++ b/dScripts/02_server/Map/AG/AgMonumentRaceGoal.cpp
@@ -7,9 +7,9 @@ void AgMonumentRaceGoal::OnStartup(Entity* self) {
 }
 
 void AgMonumentRaceGoal::OnProximityUpdate(Entity* self, Entity* entering, std::string name, std::string status) {
-	if (name == "RaceGoal" && entering->IsPlayer() && status == "ENTER") {
-		auto* manager = EntityManager::Instance()->GetEntitiesInGroup("race_manager")[0];
-
-		manager->OnFireEventServerSide(entering, "course_finish");
+	if (name == "RaceGoal" && entering && entering->IsPlayer() && status == "ENTER") {
+		auto managers = EntityManager::Instance()->GetEntitiesInGroup("race_manager");
+		if (managers.empty() || !managers.at(0)) return;
+		managers.at(0)->OnFireEventServerSide(entering, "course_finish");
 	}
 }


### PR DESCRIPTION
prevents this crash

```c++
[15-02-23 21:30:34] [Diagnostics] Encountered signal 11, creating crash dump crash_World_22979.log
[15-02-23 21:30:34] [Diagnostics] [00] /home/user/dlu/build/WorldServer(_Z14CatchUnhandledi+0x1e8) [0x5626a0d02a38]
[15-02-23 21:30:34] [Diagnostics] [01] /lib/x86_64-linux-gnu/libpthread.so.0(+0x12980) [0x7f3a58e6d980]
[15-02-23 21:30:34] [Diagnostics] [02] /home/user/dlu/build/WorldServer(_ZN18AgMonumentRaceGoal17OnProximityUpdateEP6EntityS1_SsSs+0xc4) [0x5626a0ecd994]
[15-02-23 21:30:34] [Diagnostics] [03] /home/user/dlu/build/WorldServer(_ZN6Entity20OnCollisionProximityElRKSsS1_+0x116) [0x5626a0d94b06]
[15-02-23 21:30:34] [Diagnostics] [04] /home/user/dlu/build/WorldServer(_ZN25ProximityMonitorComponent6UpdateEf+0xc4) [0x5626a0e03cc4]
[15-02-23 21:30:34] [Diagnostics] [05] /home/user/dlu/build/WorldServer(_ZN6Entity6UpdateEf+0x4bd) [0x5626a0d98c8d]
[15-02-23 21:30:34] [Diagnostics] [06] /home/user/dlu/build/WorldServer(_ZN13EntityManager14UpdateEntitiesEf+0x4f) [0x5626a0daac4f]
[15-02-23 21:30:34] [Diagnostics] [07] /home/user/dlu/build/WorldServer(main+0x1908) [0x5626a0ceacb8]
[15-02-23 21:30:34] [Diagnostics] [08] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xe7) [0x7f3a57b2cc87]
[15-02-23 21:30:34] [Diagnostics] [09] /home/user/dlu/build/WorldServer(_start+0x2a) [0x5626a0cf6e2a]

```