### PR TITLE
Fix Trigger Missions

### DIFF
--- a/dGame/dComponents/TriggerComponent.cpp
+++ b/dGame/dComponents/TriggerComponent.cpp
@@ -163,19 +163,14 @@ void TriggerComponent::HandleSetPhysicsVolume(Entity* targetEntity, std::vector<
 void TriggerComponent::HandleUpdateMission(Entity* targetEntity, std::vector<std::string> argArray) {
 	CDMissionTasksTable* missionTasksTable = CDClientManager::Instance()->GetTable<CDMissionTasksTable>("MissionTasks");
 	std::vector<CDMissionTasks> missionTasks = missionTasksTable->Query([=](CDMissionTasks entry) {
-		std::string lowerTargetGroup;
-		for (char character : entry.targetGroup) {
-			lowerTargetGroup.push_back(std::tolower(character)); // make lowercase to ensure it works
-		}
-
-		return (lowerTargetGroup == argArray[4]);
+		return (entry.targetGroup == argArray.at(4));
 	});
 
 	for (const CDMissionTasks& task : missionTasks) {
 		MissionComponent* missionComponent = targetEntity->GetComponent<MissionComponent>();
 		if (!missionComponent) continue;
 
-		missionComponent->ForceProgress(task.id, task.uid, std::stoi(argArray[2]));
+		missionComponent->ForceProgress(task.id, task.uid, std::stoi(argArray.at(2)));
 	}
 }
 


### PR DESCRIPTION
Fix trigger missions as previously they were all compared as lowercase, but the code was change to be uppercase.  To keep consistent with the value in the mission and the value in the lutriggers file

Tested that Discover the Orange Path, Cobwebs!, and Insect Music all progressed correctly (they are all trigger progression)