### PR TITLE
Dont respawn players at end of bons

### DIFF
--- a/dScripts/02_server/Map/NS/Waves/ZoneNsWaves.h
+++ b/dScripts/02_server/Map/NS/Waves/ZoneNsWaves.h
@@ -1,6 +1,8 @@
 #pragma once
 #include "BaseWavesServer.h"
 
+#include "dCommonVars.h"
+
 enum SpawnerName {
 	interior_A,
 	interior_B,

--- a/dScripts/BaseWavesServer.cpp
+++ b/dScripts/BaseWavesServer.cpp
@@ -430,7 +430,7 @@ void BaseWavesServer::SpawnWave(Entity* self) {
 
 		for (const auto& playerID : state.players) {
 			auto* player = EntityManager::Instance()->GetEntity(playerID);
-			if (player != nullptr) {
+			if (player && player->GetIsDead()) {
 				player->Resurrect();
 			}
 		}


### PR DESCRIPTION
Fixes #1016 

Tested that players who are alive no longer are teleported to the bons respawn area