### PR TITLE
Up end of match timer for Battle of Nimbus Station to 60 seconds

### DIFF
--- a/dScripts/02_server/Map/NS/Waves/ZoneNsWaves.cpp
+++ b/dScripts/02_server/Map/NS/Waves/ZoneNsWaves.cpp
@@ -439,7 +439,7 @@ std::vector<Wave> ZoneNsWaves::GetWaves() {
 																									5.0f,
 																									(uint32_t)-1,
 																									true,
-																									30,
+																									60,
 																								},
 	};
 }


### PR DESCRIPTION
as per the live script