### PR TITLE
Correct incorrect inventory types

### DIFF
--- a/dGame/dInventory/Inventory.cpp
+++ b/dGame/dInventory/Inventory.cpp
@@ -242,9 +242,9 @@ eInventoryType Inventory::FindInventoryTypeForLot(const LOT lot) {
 		return PROPERTY_DEEDS;
 
 	case eItemType::MODEL:
-	case eItemType::VEHICLE:
+	case eItemType::PET_INVENTORY_ITEM:
 	case eItemType::LOOT_MODEL:
-	case eItemType::LUP_MODEL:
+	case eItemType::VEHICLE:
 	case eItemType::MOUNT:
 		return MODELS;
 
@@ -261,9 +261,8 @@ eInventoryType Inventory::FindInventoryTypeForLot(const LOT lot) {
 	case eItemType::CHEST:
 	case eItemType::EGG:
 	case eItemType::PET_FOOD:
-	case eItemType::PET_INVENTORY_ITEM:
 	case eItemType::PACKAGE:
-
+	case eItemType::LUP_MODEL:
 		return ITEMS;
 
 	case eItemType::QUEST_OBJECT:


### PR DESCRIPTION
Reverse Engineering in the client has revealed that this is the precise correct inventory type mapping for items by item type.

Will test that LUP_MODELS appear in the models inventory as opposed to items