### PR TITLE
Inventory command improvements

### DIFF
--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -552,21 +552,42 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		return;
 	}
 
-	if ((chatCommand == "setinventorysize" || chatCommand == "setinvsize") && entity->GetGMLevel() >= GAME_MASTER_LEVEL_DEVELOPER) {
-		if (args.size() != 1) return;
-
+	if ((chatCommand == "setinventorysize" || chatCommand == "setinvsize") && entity->GetGMLevel() >= GAME_MASTER_LEVEL_DEVELOPER && args.size() >= 1) {
 		uint32_t size;
 
-		if (!GeneralUtils::TryParse(args[0], size)) {
+		if (!GeneralUtils::TryParse(args.at(0), size)) {
 			ChatPackets::SendSystemMessage(sysAddr, u"Invalid size.");
 			return;
 		}
 
-		InventoryComponent* inventory = static_cast<InventoryComponent*>(entity->GetComponent(eReplicaComponentType::INVENTORY));
-		if (inventory) {
-			auto* items = inventory->GetInventory(ITEMS);
+		eInventoryType selectedInventory = eInventoryType::ITEMS;
 
-			items->SetSize(size);
+		// a possible inventory was provided if we got more than 1 argument
+		if (args.size() >= 2) {
+			selectedInventory = eInventoryType::INVALID;
+			if (!GeneralUtils::TryParse(args.at(1), selectedInventory)) {
+				// In this case, we treat the input as a string and try to find it in the reflection list
+				std::transform(args.at(1).begin(), args.at(1).end(), args.at(1).begin(), ::toupper);
+				for (uint32_t index = 0; index < NUMBER_OF_INVENTORIES; index++) {
+					if (std::string_view(args.at(1)) == std::string_view(InventoryType::InventoryTypeToString(static_cast<eInventoryType>(index)))) selectedInventory = static_cast<eInventoryType>(index);
+				}
+			}
+			if (selectedInventory == eInventoryType::INVALID) {
+				ChatPackets::SendSystemMessage(sysAddr, u"Invalid inventory.");
+				return;
+			}
+
+			ChatPackets::SendSystemMessage(sysAddr, u"Setting inventory " +
+				GeneralUtils::ASCIIToUTF16(args.at(1)) +
+				u" to size " +
+				GeneralUtils::to_u16string(size));
+		} else ChatPackets::SendSystemMessage(sysAddr, u"Setting inventory ITEMS to size " + GeneralUtils::to_u16string(size));
+
+		auto* inventoryComponent = entity->GetComponent<InventoryComponent>();
+		if (inventoryComponent) {
+			auto* inventory = inventoryComponent->GetInventory(selectedInventory);
+
+			inventory->SetSize(size);
 		}
 
 		return;
@@ -581,10 +602,10 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 		auto buf = Game::assetManager->GetFileAsBuffer(("macros/" + args[0] + ".scm").c_str());
 
-		 if (!buf.m_Success){
+		if (!buf.m_Success) {
 			ChatPackets::SendSystemMessage(sysAddr, u"Unknown macro! Is the filename right?");
 			return;
-		 }
+		}
 
 		std::istream infile(&buf);
 
@@ -1331,9 +1352,8 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		eLootSourceType lootType = eLootSourceType::LOOT_SOURCE_MODERATION;
 
 		int32_t type;
-		if (args.size() >= 2 && GeneralUtils::TryParse(args[1], type))
-		{
-			lootType = (eLootSourceType) type;
+		if (args.size() >= 2 && GeneralUtils::TryParse(args[1], type)) {
+			lootType = (eLootSourceType)type;
 		}
 
 		GameMessages::SendModifyLEGOScore(entity, entity->GetSystemAddress(), uscore, lootType);
@@ -1814,7 +1834,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		eInventoryType inventoryType = eInventoryType::INVALID;
 		if (!GeneralUtils::TryParse(args[0], inventoryType)) {
 			// In this case, we treat the input as a string and try to find it in the reflection list
-			std::transform(args[0].begin(), args[0].end(),args[0].begin(), ::toupper);
+			std::transform(args[0].begin(), args[0].end(), args[0].begin(), ::toupper);
 			Game::logger->Log("SlashCommandHandler", "looking for inventory %s", args[0].c_str());
 			for (uint32_t index = 0; index < NUMBER_OF_INVENTORIES; index++) {
 				if (std::string_view(args[0]) == std::string_view(InventoryType::InventoryTypeToString(static_cast<eInventoryType>(index)))) inventoryType = static_cast<eInventoryType>(index);
@@ -1988,7 +2008,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 				}
 
 				auto* triggerComponent = closest->GetComponent<TriggerComponent>();
-				if (triggerComponent){
+				if (triggerComponent) {
 					auto trigger = triggerComponent->GetTrigger();
 					if (trigger) {
 						ChatPackets::SendSystemMessage(sysAddr, u"Trigger: " + (GeneralUtils::to_u16string(trigger->id)));

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -92,7 +92,7 @@ These commands are primarily for development and testing. The usage of many of t
 |setcontrolscheme|`/setcontrolscheme <scheme number>`|Sets the character control scheme to the specified number.|8|
 |setcurrency|`/setcurrency <coins>`|Sets your coins.|8|
 |setflag|`/setflag (value) <flag id>`|Sets the given inventory or health flag to the given value, where value can be one of "on" or "off". If no value is given, by default this adds the flag to your character (equivalent of calling `/setflag on <flag id>`).|8|
-|setinventorysize|`/setinventorysize <size>`|Sets your inventory size to the given size. Alias: `/setinvsize`|8|
+|setinventorysize|`/setinventorysize <size> (inventory)`|Sets your inventory size to the given size. If `inventory` is provided, the number or string will be used to set that inventory to the requested size. Alias: `/setinvsize`|8|
 |setuistate|`/setuistate <ui state>`|Changes UI state.|8|
 |spawn|`/spawn <id>`|Spawns an object at your location by id.|8|
 |speedboost|`/speedboost <amount>`|Sets the speed multiplier to the given amount. `/speedboost 1.5` will set the speed multiplier to 1.5x the normal speed.|8|


### PR DESCRIPTION
Improve the setinvsize command to take an optional inventory type to resize, either by number or name.

Tested the following:
running `/setinvsize` does not crash the game
running `/setinvsize 1` sets the item inventory size to 1
running `/setinvsize 15 0` sets the item inventory size to 15
running `/setinvsize 15 items` sets the item inventory size to 15
running `/setinvsize 15 ItEmS` sets the item inventory size to 15
running `/setinvsize f` does not crash
running `/setinvsize 1 f` does not crash