### PR TITLE
Implement Timer handlers in triggers and ontimerdone trigger event

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -1232,6 +1232,7 @@ void Entity::Update(const float deltaTime) {
 			for (CppScripts::Script* script : CppScripts::GetEntityScripts(this)) {
 				script->OnTimerDone(this, timerName);
 			}
+			TriggerEvent(eTriggerEventType::TIMER_DONE, this);
 		} else {
 			timerPosition++;
 		}

--- a/dGame/dComponents/SkillComponent.cpp
+++ b/dGame/dComponents/SkillComponent.cpp
@@ -36,8 +36,6 @@ bool SkillComponent::CastPlayerSkill(const uint32_t behaviorId, const uint32_t s
 
 	context->caster = m_Parent->GetObjectID();
 
-	context->skillID = skillID;
-
 	this->m_managedBehaviors.insert_or_assign(skillUid, context);
 
 	auto* behavior = Behavior::CreateBehavior(behaviorId);
@@ -247,6 +245,8 @@ SkillExecutionResult SkillComponent::CalculateBehavior(const uint32_t skillId, c
 	auto* context = new BehaviorContext(originatorOverride != LWOOBJID_EMPTY ? originatorOverride : this->m_Parent->GetObjectID(), true);
 
 	context->caster = m_Parent->GetObjectID();
+
+	context->skillID = skillId;
 
 	context->clientInitalized = clientInitalized;
 

--- a/dGame/dComponents/SkillComponent.cpp
+++ b/dGame/dComponents/SkillComponent.cpp
@@ -36,6 +36,8 @@ bool SkillComponent::CastPlayerSkill(const uint32_t behaviorId, const uint32_t s
 
 	context->caster = m_Parent->GetObjectID();
 
+	context->skillID = skillID;
+
 	this->m_managedBehaviors.insert_or_assign(skillUid, context);
 
 	auto* behavior = Behavior::CreateBehavior(behaviorId);

--- a/dGame/dComponents/TriggerComponent.cpp
+++ b/dGame/dComponents/TriggerComponent.cpp
@@ -83,8 +83,12 @@ void TriggerComponent::HandleTriggerCommand(LUTriggers::Command* command, Entity
 			case eTriggerCommandType::REPEL_OBJECT:
 				HandleRepelObject(targetEntity, command->args);
 				break;
-			case eTriggerCommandType::SET_TIMER: break;
-			case eTriggerCommandType::CANCEL_TIMER: break;
+			case eTriggerCommandType::SET_TIMER:
+				HandleSetTimer(targetEntity, argArray);
+				break;
+			case eTriggerCommandType::CANCEL_TIMER:
+				HandleCancelTimer(targetEntity, command->args);
+				break;
 			case eTriggerCommandType::PLAY_CINEMATIC:
 				HandlePlayCinematic(targetEntity, argArray);
 				break;
@@ -269,6 +273,17 @@ void TriggerComponent::HandleRepelObject(Entity* targetEntity, std::string args)
 	phantomPhysicsComponent->SetDirection(direction);
 
 	EntityManager::Instance()->SerializeEntity(m_Parent);
+}
+
+void TriggerComponent::HandleSetTimer(Entity* targetEntity, std::vector<std::string> argArray){
+	if (argArray.size() != 2) return;
+	float time = 0.0;
+	GeneralUtils::TryParse<float>(argArray.at(1), time);
+	m_Parent->AddTimer(argArray.at(0), time);
+}
+
+void TriggerComponent::HandleCancelTimer(Entity* targetEntity, std::string args){
+	m_Parent->CancelTimer(args);
 }
 
 void TriggerComponent::HandlePlayCinematic(Entity* targetEntity, std::vector<std::string> argArray) {

--- a/dGame/dComponents/TriggerComponent.cpp
+++ b/dGame/dComponents/TriggerComponent.cpp
@@ -155,7 +155,7 @@ void TriggerComponent::HandleTriggerCommand(LUTriggers::Command* command, Entity
 			case eTriggerCommandType::DEACTIVATE_MIXER_PROGRAM: break;
 			// DEPRECATED BLOCK END
 			default:
-				Game::logger->LogDebugDebug("TriggerComponent", "Event %i was not handled!", command->id);
+				Game::logger->LogDebug("TriggerComponent", "Event %i was not handled!", command->id);
 				break;
 		}
 	}
@@ -436,6 +436,6 @@ void TriggerComponent::HandleActivatePhysics(Entity* targetEntity, std::string a
 	} else if (args == "false"){
 		// TODO remove Phsyics entity if there is one
 	} else {
-		Game::logger->LogDebugDebug("TriggerComponent", "Invalid argument for ActivatePhysics Trigger: %s", args.c_str());
+		Game::logger->LogDebug("TriggerComponent", "Invalid argument for ActivatePhysics Trigger: %s", args.c_str());
 	}
 }

--- a/dGame/dComponents/TriggerComponent.cpp
+++ b/dGame/dComponents/TriggerComponent.cpp
@@ -155,7 +155,7 @@ void TriggerComponent::HandleTriggerCommand(LUTriggers::Command* command, Entity
 			case eTriggerCommandType::DEACTIVATE_MIXER_PROGRAM: break;
 			// DEPRECATED BLOCK END
 			default:
-				Game::logger->LogDebug("TriggerComponent", "Event %i was not handled!", command->id);
+				Game::logger->LogDebugDebug("TriggerComponent", "Event %i was not handled!", command->id);
 				break;
 		}
 	}
@@ -198,7 +198,7 @@ void TriggerComponent::HandleDestroyObject(Entity* targetEntity, std::string arg
 void TriggerComponent::HandleToggleTrigger(Entity* targetEntity, std::string args){
 	auto* triggerComponent = targetEntity->GetComponent<TriggerComponent>();
 	if (!triggerComponent) {
-		Game::logger->Log("TriggerComponent::HandleToggleTrigger", "Trigger component not found!");
+		Game::logger->LogDebug("TriggerComponent::HandleToggleTrigger", "Trigger component not found!");
 		return;
 	}
 	triggerComponent->SetTriggerEnabled(args == "1");
@@ -207,7 +207,7 @@ void TriggerComponent::HandleToggleTrigger(Entity* targetEntity, std::string arg
 void TriggerComponent::HandleResetRebuild(Entity* targetEntity, std::string args){
 	auto* rebuildComponent = targetEntity->GetComponent<RebuildComponent>();
 	if (!rebuildComponent) {
-		Game::logger->Log("TriggerComponent::HandleResetRebuild", "Rebuild component not found!");
+		Game::logger->LogDebug("TriggerComponent::HandleResetRebuild", "Rebuild component not found!");
 		return;
 	}
 	rebuildComponent->ResetRebuild(args == "1");
@@ -237,7 +237,7 @@ void TriggerComponent::HandleRotateObject(Entity* targetEntity, std::vector<std:
 void TriggerComponent::HandlePushObject(Entity* targetEntity, std::vector<std::string> argArray){
 	auto* phantomPhysicsComponent = m_Parent->GetComponent<PhantomPhysicsComponent>();
 	if (!phantomPhysicsComponent) {
-		Game::logger->Log("TriggerComponent::HandlePushObject", "Phantom Physics component not found!");
+		Game::logger->LogDebug("TriggerComponent::HandlePushObject", "Phantom Physics component not found!");
 		return;
 	}
 	phantomPhysicsComponent->SetPhysicsEffectActive(true);
@@ -254,7 +254,7 @@ void TriggerComponent::HandlePushObject(Entity* targetEntity, std::vector<std::s
 void TriggerComponent::HandleRepelObject(Entity* targetEntity, std::string args){
 	auto* phantomPhysicsComponent = m_Parent->GetComponent<PhantomPhysicsComponent>();
 	if (!phantomPhysicsComponent) {
-		Game::logger->Log("TriggerComponent::HandleRepelObject", "Phantom Physics component not found!");
+		Game::logger->LogDebug("TriggerComponent::HandleRepelObject", "Phantom Physics component not found!");
 		return;
 	}
 	float forceMultiplier;
@@ -276,7 +276,10 @@ void TriggerComponent::HandleRepelObject(Entity* targetEntity, std::string args)
 }
 
 void TriggerComponent::HandleSetTimer(Entity* targetEntity, std::vector<std::string> argArray){
-	if (argArray.size() != 2) return;
+	if (argArray.size() != 2) {
+		Game::logger->LogDebug("TriggerComponent::HandleSetTimer", "Not ehought variables!");
+		return;
+	}
 	float time = 0.0;
 	GeneralUtils::TryParse<float>(argArray.at(1), time);
 	m_Parent->AddTimer(argArray.at(0), time);
@@ -315,7 +318,7 @@ void TriggerComponent::HandlePlayCinematic(Entity* targetEntity, std::vector<std
 void TriggerComponent::HandleToggleBBB(Entity* targetEntity, std::string args) {
 	auto* character = targetEntity->GetCharacter();
 	if (!character) {
-		Game::logger->Log("TriggerComponent::HandleToggleBBB", "Character was not found!");
+		Game::logger->LogDebug("TriggerComponent::HandleToggleBBB", "Character was not found!");
 		return;
 	}
 	bool buildMode = !(character->GetBuildMode());
@@ -331,7 +334,7 @@ void TriggerComponent::HandleUpdateMission(Entity* targetEntity, std::vector<std
 	if (argArray.at(0) != "exploretask") return;
 	MissionComponent* missionComponent = targetEntity->GetComponent<MissionComponent>();
 	if (!missionComponent){
-		Game::logger->Log("TriggerComponent::HandleUpdateMission", "Mission component not found!");
+		Game::logger->LogDebug("TriggerComponent::HandleUpdateMission", "Mission component not found!");
 		return;
 	}
 	missionComponent->Progress(eMissionTaskType::EXPLORE, 0, 0, argArray.at(4));
@@ -350,7 +353,7 @@ void TriggerComponent::HandlePlayEffect(Entity* targetEntity, std::vector<std::s
 void TriggerComponent::HandleCastSkill(Entity* targetEntity, std::string args){
 	auto* skillComponent = targetEntity->GetComponent<SkillComponent>();
 	if (!skillComponent) {
-		Game::logger->Log("TriggerComponent::HandleCastSkill", "Skill component not found!");
+		Game::logger->LogDebug("TriggerComponent::HandleCastSkill", "Skill component not found!");
 		return;
 	}
 	uint32_t skillId;
@@ -361,7 +364,7 @@ void TriggerComponent::HandleCastSkill(Entity* targetEntity, std::string args){
 void TriggerComponent::HandleSetPhysicsVolumeEffect(Entity* targetEntity, std::vector<std::string> argArray) {
 	auto* phantomPhysicsComponent = targetEntity->GetComponent<PhantomPhysicsComponent>();
 	if (!phantomPhysicsComponent) {
-		Game::logger->Log("TriggerComponent::HandleSetPhysicsVolumeEffect", "Phantom Physics component not found!");
+		Game::logger->LogDebug("TriggerComponent::HandleSetPhysicsVolumeEffect", "Phantom Physics component not found!");
 		return;
 	}
 	phantomPhysicsComponent->SetPhysicsEffectActive(true);
@@ -396,7 +399,7 @@ void TriggerComponent::HandleSetPhysicsVolumeEffect(Entity* targetEntity, std::v
 void TriggerComponent::HandleSetPhysicsVolumeStatus(Entity* targetEntity, std::string args) {
 	auto* phantomPhysicsComponent = targetEntity->GetComponent<PhantomPhysicsComponent>();
 	if (!phantomPhysicsComponent) {
-		Game::logger->Log("TriggerComponent::HandleSetPhysicsVolumeEffect", "Phantom Physics component not found!");
+		Game::logger->LogDebug("TriggerComponent::HandleSetPhysicsVolumeEffect", "Phantom Physics component not found!");
 		return;
 	}
 	phantomPhysicsComponent->SetPhysicsEffectActive(args == "On");
@@ -433,6 +436,6 @@ void TriggerComponent::HandleActivatePhysics(Entity* targetEntity, std::string a
 	} else if (args == "false"){
 		// TODO remove Phsyics entity if there is one
 	} else {
-		Game::logger->LogDebug("TriggerComponent", "Invalid argument for ActivatePhysics Trigger: %s", args.c_str());
+		Game::logger->LogDebugDebug("TriggerComponent", "Invalid argument for ActivatePhysics Trigger: %s", args.c_str());
 	}
 }

--- a/dGame/dComponents/TriggerComponent.h
+++ b/dGame/dComponents/TriggerComponent.h
@@ -30,6 +30,8 @@ private:
 	void HandleRotateObject(Entity* targetEntity, std::vector<std::string> argArray);
 	void HandlePushObject(Entity* targetEntity, std::vector<std::string> argArray);
 	void HandleRepelObject(Entity* targetEntity, std::string args);
+	void HandleSetTimer(Entity* targetEntity, std::vector<std::string> argArray);
+	void HandleCancelTimer(Entity* targetEntity, std::string args);
 	void HandlePlayCinematic(Entity* targetEntity, std::vector<std::string> argArray);
 	void HandleToggleBBB(Entity* targetEntity, std::string args);
 	void HandleUpdateMission(Entity* targetEntity, std::vector<std::string> argArray);

--- a/dScripts/ai/AG/AgJetEffectServer.cpp
+++ b/dScripts/ai/AG/AgJetEffectServer.cpp
@@ -5,19 +5,18 @@
 #include "eReplicaComponentType.h"
 
 void AgJetEffectServer::OnUse(Entity* self, Entity* user) {
-	if (!inUse || self->GetLOT() == 6859) {
-		GameMessages::SendNotifyClientObject(
-			self->GetObjectID(), u"toggleInUse", 1, 0, LWOOBJID_EMPTY, "", UNASSIGNED_SYSTEM_ADDRESS
-		);
-		inUse = true;
+	if (inUse || !self->GetLOT() == 6859) return;
+	GameMessages::SendNotifyClientObject(
+		self->GetObjectID(), u"toggleInUse", 1, 0, LWOOBJID_EMPTY, "", UNASSIGNED_SYSTEM_ADDRESS
+	);
+	inUse = true;
 
-		auto entities = EntityManager::Instance()->GetEntitiesInGroup("Jet_FX");
-		if (entities.empty()) return;
-		GameMessages::SendPlayFXEffect(entities.at(0), 641, u"create", "radarDish", LWOOBJID_EMPTY, 1, 1, true);
-		self->AddTimer("radarDish", 2);
-		self->AddTimer("PlayEffect", 2.5);
-		self->AddTimer("CineDone", 7.5 + 5);
-	}
+	auto entities = EntityManager::Instance()->GetEntitiesInGroup("Jet_FX");
+	if (entities.empty()) return;
+	GameMessages::SendPlayFXEffect(entities.at(0), 641, u"create", "radarDish", LWOOBJID_EMPTY, 1, 1, true);
+	self->AddTimer("radarDish", 2.0f);
+	self->AddTimer("PlayEffect", 2.5f);
+	self->AddTimer("CineDone", 7.5f + 5.0f); // 7.5f is time the cinematic takes to play
 }
 
 void AgJetEffectServer::OnRebuildComplete(Entity* self, Entity* target) {
@@ -32,7 +31,7 @@ void AgJetEffectServer::OnRebuildComplete(Entity* self, Entity* target) {
 	auto groups = self->GetGroups();
 	if (!groups.empty() && groups.at(0) == "Base_Radar") {
 		self->AddTimer("PlayEffect", 2.5f);
-		self->AddTimer("CineDone", 7.5 + 5);
+		self->AddTimer("CineDone", 7.5f + 5.0f); // 7.5f is time the cinematic takes to play
 	}
 }
 

--- a/dScripts/ai/AG/AgJetEffectServer.cpp
+++ b/dScripts/ai/AG/AgJetEffectServer.cpp
@@ -5,113 +5,56 @@
 #include "eReplicaComponentType.h"
 
 void AgJetEffectServer::OnUse(Entity* self, Entity* user) {
-	if (inUse) {
-		return;
+	if (!inUse || self->GetLOT() == 6859) {
+		GameMessages::SendNotifyClientObject(
+			self->GetObjectID(), u"toggleInUse", 1, 0, LWOOBJID_EMPTY, "", UNASSIGNED_SYSTEM_ADDRESS
+		);
+		inUse = true;
+
+		auto entities = EntityManager::Instance()->GetEntitiesInGroup("Jet_FX");
+		if (entities.empty()) return;
+		GameMessages::SendPlayFXEffect(entities.at(0), 641, u"create", "radarDish", LWOOBJID_EMPTY, 1, 1, true);
+		self->AddTimer("radarDish", 2);
+		self->AddTimer("PlayEffect", 2.5);
+		self->AddTimer("CineDone", 7.5 + 5);
 	}
-
-	GameMessages::SendNotifyClientObject(
-		self->GetObjectID(),
-		u"isInUse",
-		0,
-		0,
-		LWOOBJID_EMPTY,
-		"",
-		UNASSIGNED_SYSTEM_ADDRESS
-	);
-
-	inUse = true;
-
-	auto entities = EntityManager::Instance()->GetEntitiesInGroup("Jet_FX");
-
-	if (entities.empty()) {
-		return;
-	}
-
-	auto* effect = entities[0];
-
-	GameMessages::SendPlayFXEffect(effect, 641, u"create", "radarDish", LWOOBJID_EMPTY, 1, 1, true);
-
-	self->AddTimer("radarDish", 2);
-	self->AddTimer("CineDone", 9);
 }
 
 void AgJetEffectServer::OnRebuildComplete(Entity* self, Entity* target) {
+	if (self->GetLOT() != 6209) return;
 	auto entities = EntityManager::Instance()->GetEntitiesInGroup("Jet_FX");
+	if (entities.empty()) return;
+	GameMessages::SendPlayAnimation(entities.at(0), u"jetFX");
 
-	if (entities.empty()) {
-		return;
-	}
-
-	auto* effect = entities[0];
-
-	auto groups = self->GetGroups();
-
-	if (groups.empty()) {
-		return;
-	}
-
+	// So we can give kill credit to person who build this
 	builder = target->GetObjectID();
 
-	const auto group = groups[0];
-
-	GameMessages::SendPlayAnimation(effect, u"jetFX");
-
-	self->AddTimer("PlayEffect", 2.5f);
-
-	if (group == "Base_Radar") {
-		self->AddTimer("CineDone", 5);
+	auto groups = self->GetGroups();
+	if (!groups.empty() && groups.at(0) == "Base_Radar") {
+		self->AddTimer("PlayEffect", 2.5f);
+		self->AddTimer("CineDone", 7.5 + 5);
 	}
 }
 
 void AgJetEffectServer::OnTimerDone(Entity* self, std::string timerName) {
 	if (timerName == "radarDish") {
 		GameMessages::SendStopFXEffect(self, true, "radarDish");
-
-		return;
-	}
-
-	if (timerName == "PlayEffect") {
+	} else if (timerName == "PlayEffect") {
 		auto entities = EntityManager::Instance()->GetEntitiesInGroup("mortarMain");
+		if (entities.empty()) return;
 
-		if (entities.empty()) {
-			return;
-		}
+		const auto selected = GeneralUtils::GenerateRandomNumber<int>(0, entities.size() - 1);
+		auto* mortar = entities.at(selected);
 
-		const auto size = entities.size();
-
-		if (size == 0) {
-			return;
-		}
-
-		const auto selected = GeneralUtils::GenerateRandomNumber<int>(0, size - 1);
-
-		auto* mortar = entities[selected];
-
-		Game::logger->Log("AgJetEffectServer", "Mortar (%i) (&d)", mortar->GetLOT(), mortar->HasComponent(eReplicaComponentType::SKILL));
-
+		// so we give proper credit to the builder for the kills from this skill
 		mortar->SetOwnerOverride(builder);
 
-		SkillComponent* skillComponent;
-		if (!mortar->TryGetComponent(eReplicaComponentType::SKILL, skillComponent)) {
-			return;
-		}
-
-		skillComponent->CalculateBehavior(318, 3727, LWOOBJID_EMPTY, true);
-
-		return;
-	}
-
-	if (timerName == "CineDone") {
+		auto* skillComponent = mortar->GetComponent<SkillComponent>();
+		if (skillComponent) skillComponent->CastSkill(318);
+	} else if (timerName == "CineDone") {
 		GameMessages::SendNotifyClientObject(
-			self->GetObjectID(),
-			u"toggleInUse",
-			-1,
-			0,
-			LWOOBJID_EMPTY,
-			"",
-			UNASSIGNED_SYSTEM_ADDRESS
+			self->GetObjectID(), u"toggleInUse", -1, 0, LWOOBJID_EMPTY, "", UNASSIGNED_SYSTEM_ADDRESS
 		);
-
 		inUse = false;
 	}
 }


### PR DESCRIPTION
This PR implements the timer command handlers (settimer and canceltimer) as well as the ontimerdone event
Additionally, the AGJetEffect Server has been cleaned up and made 100% live accurate, which is the main reason for adding the timer trigger stuff since the beacons use them
Tested that it works properly and doesn't crash.

After delving into the triggers more, the Jeteffect is the only place it was used in Live, the rest are remnants from older versions of worlds