### PR TITLE
Fix Wingreaper birds not moving

### DIFF
--- a/dGame/dComponents/MovementAIComponent.cpp
+++ b/dGame/dComponents/MovementAIComponent.cpp
@@ -307,13 +307,12 @@ float MovementAIComponent::GetBaseSpeed(LOT lot) {
 
 foundComponent:
 
-	float speed;
+	// Client defaults speed to 10 and if the speed is also null in the table, it defaults to 10.
+	float speed = 10.0f;
 
-	if (physicsComponent == nullptr) {
-		speed = 8;
-	} else {
-		speed = physicsComponent->speed;
-	}
+	if (physicsComponent) speed = physicsComponent->speed;
+
+	if (speed == -1.0f) speed = 10.0f;
 
 	m_PhysicsSpeedCache[lot] = speed;
 

--- a/dGame/dComponents/MovementAIComponent.cpp
+++ b/dGame/dComponents/MovementAIComponent.cpp
@@ -312,7 +312,9 @@ foundComponent:
 
 	if (physicsComponent) speed = physicsComponent->speed;
 
-	if (speed == -1.0f) speed = 10.0f;
+	float delta = fabs(speed) - 1.0f;
+
+	if (delta <= std::numeric_limits<float>::epsilon()) speed = 10.0f;
 
 	m_PhysicsSpeedCache[lot] = speed;
 


### PR DESCRIPTION
Fixes #1030 

The client seems to do the following for getting the speed from the ControllablePhysics table (of which there is only ever 1 fetch of this field and it is in a ControllablePhysicsComponent):
Default speed set to 10.0f
Check the PhysicsComponent table for the column speed and if it exists set speed to that value and if the value was null set it to the default again.

Tested that the birds of the Wingreaper now properly move towards their enemy.  Tested that the dragons in Forbidden Valley dragon battle still do not move (since they have null speed too).  Tested that enemies with specifically zero speed remain at zero speed as set in their PhysicsComponent entry.