### PR TITLE
Fix Spider Queen boss battle crash when no eggs are present and remove script code comments

### DIFF
--- a/dScripts/02_server/Enemy/AG/BossSpiderQueenEnemyServer.cpp
+++ b/dScripts/02_server/Enemy/AG/BossSpiderQueenEnemyServer.cpp
@@ -48,8 +48,6 @@ void BossSpiderQueenEnemyServer::OnStartup(Entity* self) {
 	m_CurrentBossStage = 1;
 
 	// Obtain faction and collision group to save for subsequent resets
-	//self : SetVar("SBFactionList", self:GetFaction().factionList)
-	//self : SetVar("SBCollisionGroup", self:GetCollisionGroup().colGroup)
 }
 
 void BossSpiderQueenEnemyServer::OnDie(Entity* self, Entity* killer) {
@@ -60,8 +58,6 @@ void BossSpiderQueenEnemyServer::OnDie(Entity* self, Entity* killer) {
 
 		missionComponent->CompleteMission(instanceMissionID);
 	}
-
-	Game::logger->Log("BossSpiderQueenEnemyServer", "Starting timer...");
 
 	// There is suppose to be a 0.1 second delay here but that may be admitted?
 	auto* controller = EntityManager::Instance()->GetZoneControlEntity();
@@ -165,9 +161,6 @@ void BossSpiderQueenEnemyServer::SpawnSpiderWave(Entity* self, int spiderCount) 
 	// The Spider Queen Boss is withdrawing and requesting the spawn
 	// of a hatchling wave
 
-	/*auto SpiderEggNetworkID = self->GetI64(u"SpiderEggNetworkID");
-	if (SpiderEggNetworkID == 0) return;*/
-
 	// Clamp invalid Spiderling number requests to the maximum amount of eggs available
 	if ((spiderCount > maxSpiderEggCnt) || (spiderCount < 0))
 		spiderCount = maxSpiderEggCnt;
@@ -176,43 +169,12 @@ void BossSpiderQueenEnemyServer::SpawnSpiderWave(Entity* self, int spiderCount) 
 	hatchCounter = spiderCount;
 	hatchList = {};
 
-	Game::logger->Log("SpiderQueen", "Trying to spawn %i spiders", hatchCounter);
-
-
 	// Run the wave manager
 	SpiderWaveManager(self);
-
 }
 
 void BossSpiderQueenEnemyServer::SpiderWaveManager(Entity* self) {
 	auto SpiderEggNetworkID = self->GetI64(u"SpiderEggNetworkID");
-
-	// Reset the spider egg spawner network to ensure a maximum number of eggs
-	//SpiderEggNetworkID:SpawnerReset()
-
-	// Obtain a list of all the eggs on the egg spawner network
-
-	//auto spiderEggList = SpiderEggNetworkID:SpawnerGetAllObjectIDsSpawned().objects;
-
-	//if (table.maxn(spiderEggList) <= 0) {
-	//	self->AddTimer("PollSpiderWaveManager", 1.0f);
-	//	return;
-	//}
-	//
-	//// A check for (wave mangement across multiple spawn iterations
-	//if(hatchCounter < spiderWaveCnt) {
-	//	// We have already prepped some objects for (hatching,
-	//	// remove them from our list for (random egg pulls
-	//	for (i, sVal in ipairs(spiderEggList) {
-	//		if(hatchList[sVal:GetID()]) {
-	//			// We have found a prepped egg, remove it from the spiderEggList
-	//			spiderEggList[i] = nil
-	//		}
-	//	}
-
-	//}
-
-
 
 	std::vector<LWOOBJID> spiderEggs{};
 
@@ -223,44 +185,43 @@ void BossSpiderQueenEnemyServer::SpiderWaveManager(Entity* self) {
 
 	// Select a number of random spider eggs from the list equal to the
 	// current number needed to complete the current wave
-	for (int i = 0; i < hatchCounter; i++) {
-		// Select a random spider egg
-		auto randomEggLoc = GeneralUtils::GenerateRandomNumber<int>(0, spiderEggs.size() - 1);
-		auto randomEgg = spiderEggs[randomEggLoc];
+	if (!spiderEggs.empty()) {
+		for (int i = 0; i < hatchCounter; i++) {
+			// Select a random spider egg
+			auto randomEggLoc = GeneralUtils::GenerateRandomNumber<int>(0, spiderEggs.size() - 1);
+			auto randomEgg = spiderEggs[randomEggLoc];
 
-		//Just a quick check to try and prevent dupes:
-		for (auto en : hatchList) {
-			if (en == randomEgg) {
-				randomEggLoc++;
-				randomEgg = spiderEggs[randomEggLoc];
-			}
-		}
-
-		if (randomEgg) {
-			auto* eggEntity = EntityManager::Instance()->GetEntity(randomEgg);
-
-			if (eggEntity == nullptr) {
-				continue;
+			//Just a quick check to try and prevent dupes:
+			for (auto en : hatchList) {
+				if (en == randomEgg) {
+					randomEggLoc++;
+					randomEgg = spiderEggs[randomEggLoc];
+				}
 			}
 
-			// Prep the selected spider egg
-			//randomEgg:FireEvent{s}erID=self, args="prepEgg"}
-			eggEntity->OnFireEventServerSide(self, "prepEgg");
-			Game::logger->Log("SpiderQueen", "Prepping egg %llu", eggEntity->GetObjectID());
+			if (randomEgg) {
+				auto* eggEntity = EntityManager::Instance()->GetEntity(randomEgg);
 
-			// Add the prepped egg to our hatchList
-			hatchList.push_back(eggEntity->GetObjectID());
+				if (eggEntity == nullptr) {
+					continue;
+				}
 
-			// Decrement the hatchCounter
-			hatchCounter = hatchCounter - 1;
-		}
+				// Prep the selected spider egg
+				eggEntity->OnFireEventServerSide(self, "prepEgg");
 
-		// Remove it from our spider egg list
-		//table.remove(spiderEggList, randomEggLoc);
-		spiderEggs[randomEggLoc] = LWOOBJID_EMPTY;
+				// Add the prepped egg to our hatchList
+				hatchList.push_back(eggEntity->GetObjectID());
 
-		if (spiderEggs.size() <= 0 || (hatchCounter <= 0)) {
-			break;
+				// Decrement the hatchCounter
+				hatchCounter = hatchCounter - 1;
+			}
+
+			// Remove it from our spider egg list
+			spiderEggs[randomEggLoc] = LWOOBJID_EMPTY;
+
+			if (spiderEggs.size() <= 0 || (hatchCounter <= 0)) {
+				break;
+			}
 		}
 	}
 
@@ -279,14 +240,12 @@ void BossSpiderQueenEnemyServer::SpiderWaveManager(Entity* self) {
 			}
 
 			eggEntity->OnFireEventServerSide(self, "hatchEgg");
-			Game::logger->Log("SpiderQueen", "hatching egg %llu", eggEntity->GetObjectID());
 
 			auto time = PlayAnimAndReturnTime(self, spiderWithdrawIdle);
 			combat->SetStunImmune(false);
 			combat->Stun(time += 6.0f);
 			combat->SetStunImmune(true);
 
-			//self->AddTimer("disableWaitForIdle", defaultAnimPause);
 			self->AddTimer("checkForSpiders", 6.0f);
 
 		}
@@ -397,10 +356,6 @@ void BossSpiderQueenEnemyServer::RapidFireShooterManager(Entity* self) {
 }
 
 void BossSpiderQueenEnemyServer::RunRapidFireShooter(Entity* self) {
-	/*
-	const auto targets = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::CHARACTER);
-	*/
-
 	const auto targets = self->GetTargetsInPhantom();
 
 	if (self->GetBoolean(u"stoppedFlag")) {
@@ -432,8 +387,6 @@ void BossSpiderQueenEnemyServer::RunRapidFireShooter(Entity* self) {
 	RapidFireShooterManager(self);
 
 	PlayAnimAndReturnTime(self, spiderSingleShot);
-
-	Game::logger->Log("BossSpiderQueenEnemyServer", "Ran RFS");
 
 	self->AddTimer("RFS", GeneralUtils::GenerateRandomNumber<float>(10, 15));
 }
@@ -556,26 +509,6 @@ void BossSpiderQueenEnemyServer::OnTimerDone(Entity* self, const std::string tim
 		GameMessages::SendPlayEmbeddedEffectOnAllClientsNearObject(self, u"camshake-bridge", self->GetObjectID(), 100.0f);
 
 	} else if (timerName == "AdvanceComplete") {
-		//Reset faction and collision
-		/*local SBFactionList = self:GetVar("SBFactionList")
-		local SBCollisionGroup = self:GetVar("SBCollisionGroup")
-
-		for i, fVal in ipairs(SBFactionList) {
-			if(i == 1) {
-				//Our first faction - flush and add
-				self:SetFaction{faction = fVal}
-			else
-				//Add
-				self:ModifyFaction{factionID = fVal, bAddFaction = true}
-			}
-		}*/
-
-		/*
-		auto SBCollisionGroup = self->GetI32(u"SBCollisionGroup");
-
-		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"SetColGroup", SBCollisionGroup, 0, LWOOBJID_EMPTY, "", UNASSIGNED_SYSTEM_ADDRESS);
-		*/
-
 		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"SetColGroup", 11, 0, 0, "", UNASSIGNED_SYSTEM_ADDRESS);
 
 		//Wind up, telegraphing next round
@@ -625,7 +558,6 @@ void BossSpiderQueenEnemyServer::OnTimerDone(Entity* self, const std::string tim
 		//Did we queue a spcial attack?
 		if (self->GetBoolean(u"bSpecialQueued")) {
 			self->SetBoolean(u"bSpecialQueued", false);
-			//SpiderSkillManager(self, true);
 		}
 	}
 }
@@ -673,17 +605,6 @@ void BossSpiderQueenEnemyServer::OnUpdate(Entity* self) {
 	controllable->SetStatic(true);
 
 	EntityManager::Instance()->SerializeEntity(self);
-
-	//if (waitForIdle) return;
-
-	////Play the Spider Boss' mountain idle anim
-	//PlayAnimAndReturnTime(self, spiderWithdrawIdle);
-
-	////If there are still baby spiders, don't do anyhting either
-	//auto spooders = EntityManager::Instance()->GetEntitiesInGroup("BabySpider");
-	//if (spooders.size() > 0) return;
-	//else
-	//	WithdrawSpider(self, false);
 }
 
 //----------------------------------------------


### PR DESCRIPTION
Tested that the spider queen boss battle no longer crashes if no eggs are present.