### PR TITLE
feat: Update kill credit to give credit to first person to deal health damage.

### DIFF
--- a/dGame/dComponents/DestroyableComponent.h
+++ b/dGame/dComponents/DestroyableComponent.h
@@ -604,6 +604,8 @@ private:
 	uint32_t m_ImmuneToImaginationLossCount;
 	uint32_t m_ImmuneToQuickbuildInterruptCount;
 	uint32_t m_ImmuneToPullToPointCount;
+
+	LWOOBJID m_FirstAttackerId;
 };
 
 #endif // DESTROYABLECOMPONENT_H


### PR DESCRIPTION
Fixes #230 
Only give kill credit to the first person to deal life damage to an enemy.  Tested the following scenarios:
- Player A and Player B not on a team:
    - Player A gets the first hit on a spider and Player B kills the spider.  Player A got credit.
    - The same but for Player B.
- Player A and Player B on a team and a third Player C not on the team:
    - Player A and Player B got team credit for a kill when either of them hit a spider first and Player C got credit for the kill when they hit the spider first.
    - Player A and Player B got the dragon credit when they were the first to deal health damage to the dragon (not armor damage).
    - Player C got dragon kill credit when they were the first to deal health damage to the dragon.  
    - If an AI reset their health back to full, a new first damager was now possible, overriding the original.