### PR TITLE
Remove extra bit in BasicAttackBehavior Calculate write

### DIFF
--- a/dGame/dBehaviors/BasicAttackBehavior.cpp
+++ b/dGame/dBehaviors/BasicAttackBehavior.cpp
@@ -147,7 +147,7 @@ void BasicAttackBehavior::Calculate(BehaviorContext* context, RakNet::BitStream*
 	DoBehaviorCalculation(context, bitStream, branch);
 
 	const auto endAddress = bitStream->GetWriteOffset();
-	const uint16_t allocate = endAddress - startAddress + 1;
+	const uint16_t allocate = endAddress - startAddress;
 
 	bitStream->SetWriteOffset(allocatedAddress);
 	bitStream->Write(allocate);


### PR DESCRIPTION
With newfound modding work, we have gotten a skill debugger working for the live client and can observe many debugging features in the live client. With this information, we have learned that every Calculated behavior from the server writes an extra bit on the calculation so I have removed this extra bit write.

The client no longer complains that the read offset mis-matches where it should be.  No other observed changes.