### PR TITLE
Fix SwitchMultiple incorrect handling

### DIFF
--- a/dGame/dBehaviors/InterruptBehavior.cpp
+++ b/dGame/dBehaviors/InterruptBehavior.cpp
@@ -46,6 +46,8 @@ void InterruptBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitS
 
 	if (target == nullptr) return;
 
+	if (target->GetLOT() == 1) return;
+
 	auto* skillComponent = target->GetComponent<SkillComponent>();
 
 	if (skillComponent == nullptr) return;
@@ -70,6 +72,8 @@ void InterruptBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* b
 	auto* target = EntityManager::Instance()->GetEntity(branch.target);
 
 	if (target == nullptr) return;
+
+	if (target->GetLOT() == 1) return;
 
 	auto* skillComponent = target->GetComponent<SkillComponent>();
 

--- a/dGame/dBehaviors/InterruptBehavior.cpp
+++ b/dGame/dBehaviors/InterruptBehavior.cpp
@@ -46,8 +46,6 @@ void InterruptBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitS
 
 	if (target == nullptr) return;
 
-	if (target->GetLOT() == 1) return;
-
 	auto* skillComponent = target->GetComponent<SkillComponent>();
 
 	if (skillComponent == nullptr) return;
@@ -72,8 +70,6 @@ void InterruptBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* b
 	auto* target = EntityManager::Instance()->GetEntity(branch.target);
 
 	if (target == nullptr) return;
-
-	if (target->GetLOT() == 1) return;
 
 	auto* skillComponent = target->GetComponent<SkillComponent>();
 

--- a/dGame/dBehaviors/SwitchMultipleBehavior.cpp
+++ b/dGame/dBehaviors/SwitchMultipleBehavior.cpp
@@ -22,13 +22,9 @@ void SwitchMultipleBehavior::Handle(BehaviorContext* context, RakNet::BitStream*
 	for (unsigned int i = 0; i < this->m_behaviors.size(); i++) {
 
 		const double data = this->m_behaviors.at(i).first;
+		trigger = i;
 
-		if (value <= data) {
-
-			trigger = i;
-
-			break;
-		}
+		if (value <= data) break;
 	}
 
 	auto* behavior = this->m_behaviors.at(trigger).second;


### PR DESCRIPTION
The client calculates the SwitchMultiple action as follows:
take your value and compare it to the list of values associated with this behavior.  If you encounter a value that is lower than your current, save it as the next to be executed.  If you find a value that is greater than break and execute the saved value.  Because of this, we would attempt to do behavior logic that was not intentional but was stopped in some cases, namely the wormholer due to the BitStream being empty.

Tested that the WormHoler no longer erroneously logs unable to read from BitStream errors.
Tested that the WormHoler still does damage with its long charge up attack
Tested that the WormHoler still does damage with its short charge up attack.

This also means we can technically delete one of the migrations (the Serratorizer fix so i'm wonder if we should do that as well or leave it in since we have already made the patch.)