### PR TITLE
Fix and fully implement ChangeOrientation behavior

### DIFF
--- a/dGame/dBehaviors/ChangeOrientationBehavior.cpp
+++ b/dGame/dBehaviors/ChangeOrientationBehavior.cpp
@@ -15,17 +15,13 @@ void ChangeOrientationBehavior::Calculate(BehaviorContext* context, RakNet::BitS
 		else destinationEntity = EntityManager::Instance()->GetEntity(context->originator);
 		if (!destinationEntity) return;
 
-		const auto source = sourceEntity->GetPosition();
-		const auto destination = destinationEntity->GetPosition();
-		sourceEntity->SetRotation(NiQuaternion::LookAt(source, destination));
+		sourceEntity->SetRotation(
+			NiQuaternion::LookAt(sourceEntity->GetPosition(), destinationEntity->GetPosition())
+		);
 	} else if (this->m_toAngle){
 		auto baseAngle = NiPoint3(this->m_angle, 0, 0);
-		if (this->m_relative){
-			auto sourceAngle = sourceEntity->GetRotation().GetEulerAngles();
-			baseAngle += sourceAngle;
-		}
-		auto newRotation = NiQuaternion::FromEulerAngles(baseAngle);
-		sourceEntity->SetRotation(newRotation);
+		if (this->m_relative) baseAngle += sourceEntity->GetRotation().GetEulerAngles();
+		sourceEntity->SetRotation(NiQuaternion::FromEulerAngles(baseAngle));
 	} else return;
 	EntityManager::Instance()->SerializeEntity(sourceEntity);
 	return;

--- a/dGame/dBehaviors/ChangeOrientationBehavior.cpp
+++ b/dGame/dBehaviors/ChangeOrientationBehavior.cpp
@@ -19,8 +19,8 @@ void ChangeOrientationBehavior::Calculate(BehaviorContext* context, RakNet::BitS
 			NiQuaternion::LookAt(sourceEntity->GetPosition(), destinationEntity->GetPosition())
 		);
 	} else if (this->m_toAngle){
-		auto baseAngle = NiPoint3(this->m_angle, 0, 0);
-		if (this->m_relative) baseAngle += sourceEntity->GetRotation().GetEulerAngles();
+		auto baseAngle = NiPoint3(0, 0, this->m_angle);
+		if (this->m_relative) baseAngle += sourceEntity->GetRotation().GetForwardVector();
 		sourceEntity->SetRotation(NiQuaternion::FromEulerAngles(baseAngle));
 	} else return;
 	EntityManager::Instance()->SerializeEntity(sourceEntity);

--- a/dGame/dBehaviors/ChangeOrientationBehavior.cpp
+++ b/dGame/dBehaviors/ChangeOrientationBehavior.cpp
@@ -16,7 +16,7 @@ void ChangeOrientationBehavior::Calculate(BehaviorContext* context, RakNet::BitS
 	if (self == nullptr || other == nullptr) return;
 
 	const auto source = self->GetPosition();
-	const auto destination = self->GetPosition();
+	const auto destination = other->GetPosition();
 
 	if (m_OrientCaster) {
 		auto* baseCombatAIComponent = self->GetComponent<BaseCombatAIComponent>();

--- a/dGame/dBehaviors/ChangeOrientationBehavior.cpp
+++ b/dGame/dBehaviors/ChangeOrientationBehavior.cpp
@@ -9,7 +9,6 @@ void ChangeOrientationBehavior::Calculate(BehaviorContext* context, RakNet::BitS
 	else sourceEntity = EntityManager::Instance()->GetEntity(branch.target);
 	if (!sourceEntity) return;
 
-
 	if (this->m_toTarget) {
 		Entity* destinationEntity;
 		if (this->m_orientCaster) destinationEntity = EntityManager::Instance()->GetEntity(branch.target);

--- a/dGame/dBehaviors/ChangeOrientationBehavior.h
+++ b/dGame/dBehaviors/ChangeOrientationBehavior.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Behavior.h"
-#include <vector>
 
 class ChangeOrientationBehavior final : public Behavior {
 public:

--- a/dGame/dBehaviors/ChangeOrientationBehavior.h
+++ b/dGame/dBehaviors/ChangeOrientationBehavior.h
@@ -1,25 +1,17 @@
 #pragma once
 
 #include "Behavior.h"
-
 #include <vector>
 
-class ChangeOrientationBehavior final : public Behavior
-{
+class ChangeOrientationBehavior final : public Behavior {
 public:
-	bool m_OrientCaster;
-	bool m_ToTarget;
-
-	/*
-	 * Inherited
-	 */
-
-	explicit ChangeOrientationBehavior(const uint32_t behaviorId) : Behavior(behaviorId) {
-	}
-
-	void Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) override;
-
+	explicit ChangeOrientationBehavior(const uint32_t behaviorId) : Behavior(behaviorId) {}
 	void Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) override;
-
 	void Load() override;
+private:
+	bool m_orientCaster;
+	bool m_toTarget;
+	bool m_toAngle;
+	float m_angle;
+	bool m_relative;
 };


### PR DESCRIPTION
Tested that this works as intended.
to_angle in unused in behaviors in live but has handling in the client.
to_point in unused in both, so not implementing it, even in where it is used in the cdclient, it doesn't make sense sine there i no point associated with it to orient to.

Tested that this works as intended now.
See Epsilon or the Sentinel Guards in AG. they will look at what they are shooting at now