### PR TITLE
Patch ghosting exclusions

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -727,7 +727,7 @@ void Entity::Initialize() {
 
 	if (!m_Character && EntityManager::Instance()->GetGhostingEnabled()) {
 		// Don't ghost what is likely large scene elements
-		if (m_Components.size() == 2 && HasComponent(eReplicaComponentType::SIMPLE_PHYSICS) && HasComponent(eReplicaComponentType::RENDER)) {
+		if (HasComponent(eReplicaComponentType::SIMPLE_PHYSICS) && HasComponent(eReplicaComponentType::RENDER) && (m_Components.size() == 2 || (HasComponent(eReplicaComponentType::TRIGGER) && m_Components.size() == 3))) {
 			goto no_ghosting;
 		}
 


### PR DESCRIPTION
Resolves Brig Rock not rendering in until you get extremely close.

Tested that Brig Rock properly doesn't ghost when you are outside its range.