### PR TITLE
Add more null checks and split out code

### DIFF
--- a/dGame/EntityManager.h
+++ b/dGame/EntityManager.h
@@ -85,6 +85,10 @@ public:
 	const uint32_t GetHardcoreUscoreEnemiesMultiplier() { return m_HardcoreUscoreEnemiesMultiplier; };
 
 private:
+	void SerializeEntities();
+	void KillEntities();
+	void DeleteEntities();
+
 	static EntityManager* m_Address; //For singleton method
 	static std::vector<LWOMAPID> m_GhostingExcludedZones;
 	static std::vector<LOT> m_GhostingExcludedLOTs;

--- a/dScripts/ai/MINIGAME/SG_GF/SERVER/SGCannon.cpp
+++ b/dScripts/ai/MINIGAME/SG_GF/SERVER/SGCannon.cpp
@@ -275,6 +275,11 @@ void SGCannon::OnActivityTimerDone(Entity* self, const std::string& name) {
 				toSpawn.spawnPaths.at(pathIndex)
 			);
 
+			if (!path) {
+				Game::logger->Log("SGCannon", "Path %s at index %i is null", toSpawn.spawnPaths.at(pathIndex).c_str(), pathIndex);
+				return;
+			}
+
 			auto info = EntityInfo{};
 			info.lot = toSpawn.lot;
 			info.spawnerID = self->GetObjectID();
@@ -294,31 +299,29 @@ void SGCannon::OnActivityTimerDone(Entity* self, const std::string& name) {
 			auto* enemy = EntityManager::Instance()->CreateEntity(info, nullptr, self);
 			EntityManager::Instance()->ConstructEntity(enemy);
 
-			if (true) {
-				auto* movementAI = new MovementAIComponent(enemy, {});
+			auto* movementAI = new MovementAIComponent(enemy, {});
 
-				enemy->AddComponent(eReplicaComponentType::MOVEMENT_AI, movementAI);
+			enemy->AddComponent(eReplicaComponentType::MOVEMENT_AI, movementAI);
 
-				movementAI->SetSpeed(toSpawn.initialSpeed);
-				movementAI->SetCurrentSpeed(toSpawn.initialSpeed);
-				movementAI->SetHaltDistance(0.0f);
+			movementAI->SetSpeed(toSpawn.initialSpeed);
+			movementAI->SetCurrentSpeed(toSpawn.initialSpeed);
+			movementAI->SetHaltDistance(0.0f);
 
-				std::vector<NiPoint3> pathWaypoints;
+			std::vector<NiPoint3> pathWaypoints;
 
-				for (const auto& waypoint : path->pathWaypoints) {
-					pathWaypoints.push_back(waypoint.position);
-				}
-
-				if (GeneralUtils::GenerateRandomNumber<float_t>(0, 1) < 0.5f) {
-					std::reverse(pathWaypoints.begin(), pathWaypoints.end());
-				}
-
-				movementAI->SetPath(pathWaypoints);
-
-				enemy->AddDieCallback([this, self, enemy, name]() {
-					RegisterHit(self, enemy, name);
-					});
+			for (const auto& waypoint : path->pathWaypoints) {
+				pathWaypoints.push_back(waypoint.position);
 			}
+
+			if (GeneralUtils::GenerateRandomNumber<float_t>(0, 1) < 0.5f) {
+				std::reverse(pathWaypoints.begin(), pathWaypoints.end());
+			}
+
+			movementAI->SetPath(pathWaypoints);
+
+			enemy->AddDieCallback([this, self, enemy, name]() {
+				RegisterHit(self, enemy, name);
+				});
 
 			// Save the enemy and tell it to start pathing
 			if (enemy != nullptr) {
@@ -577,7 +580,7 @@ void SGCannon::StopGame(Entity* self, bool cancel) {
 
 		self->SetNetworkVar<std::u16string>(u"UI_Rewards",
 			GeneralUtils::to_u16string(self->GetVar<uint32_t>(TotalScoreVariable)) + u"_0_0_0_0_0_0"
-			);
+		);
 
 		GameMessages::SendRequestActivitySummaryLeaderboardData(
 			player->GetObjectID(),


### PR DESCRIPTION
Makes crash logs more apparent for what stage they crashed in for the engine updating.
Also no need to cast an entity to a player.  The virtual destructor takes care of that for us.


I walked around the worlds and things were getting updated