### PR TITLE
Fix bounds check for dpEntity moving

### DIFF
--- a/dPhysics/dpGrid.cpp
+++ b/dPhysics/dpGrid.cpp
@@ -63,13 +63,13 @@ void dpGrid::Move(dpEntity* entity, float x, float z) {
 
 	if (cellX < 0) cellX = 0;
 	if (cellZ < 0) cellZ = 0;
-	if (cellX > NUM_CELLS) cellX = NUM_CELLS;
-	if (cellZ > NUM_CELLS) cellZ = NUM_CELLS;
+	if (cellX >= NUM_CELLS) cellX = NUM_CELLS - 1;
+	if (cellZ >= NUM_CELLS) cellZ = NUM_CELLS - 1;
 
 	if (oldCellX < 0) oldCellX = 0;
 	if (oldCellZ < 0) oldCellZ = 0;
-	if (oldCellX > NUM_CELLS) oldCellX = NUM_CELLS;
-	if (oldCellZ > NUM_CELLS) oldCellZ = NUM_CELLS;
+	if (oldCellX >= NUM_CELLS) oldCellX = NUM_CELLS - 1;
+	if (oldCellZ >= NUM_CELLS) oldCellZ = NUM_CELLS - 1;
 
 	if (oldCellX == cellX && oldCellZ == cellZ) return;
 


### PR DESCRIPTION
Regressed and crashed as expected when travelling far outside of Crux, added back the changes here and the crash did not happen anymore.  