### PR TITLE
Fix chat crash and reinforce other servers handling packets

### DIFF
--- a/dAuthServer/AuthServer.cpp
+++ b/dAuthServer/AuthServer.cpp
@@ -171,6 +171,8 @@ dLogger* SetupLogger() {
 }
 
 void HandlePacket(Packet* packet) {
+	if (packet->length < 4) return;
+
 	if (packet->data[0] == ID_USER_PACKET_ENUM) {
 		if (static_cast<eConnectionType>(packet->data[1]) == eConnectionType::SERVER) {
 			if (static_cast<eServerMessageType>(packet->data[3]) == eServerMessageType::VERSION_CONFIRM) {

--- a/dChatServer/ChatServer.cpp
+++ b/dChatServer/ChatServer.cpp
@@ -203,6 +203,8 @@ void HandlePacket(Packet* packet) {
 		Game::logger->Log("ChatServer", "A server is connecting, awaiting user list.");
 	}
 
+	if (packet->length < 4) return; // Nothing left to process.  Need 4 bytes to continue.
+
 	if (static_cast<eConnectionType>(packet->data[1]) == eConnectionType::CHAT_INTERNAL) {
 		switch (static_cast<eChatInternalMessageType>(packet->data[3])) {
 		case eChatInternalMessageType::PLAYER_ADDED_NOTIFICATION:

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -495,6 +495,8 @@ void HandlePacket(Packet* packet) {
 		}
 	}
 
+	if (packet->length < 4) return;
+
 	if (static_cast<eConnectionType>(packet->data[1]) == eConnectionType::MASTER) {
 		switch (static_cast<eMasterMessageType>(packet->data[3])) {
 		case eMasterMessageType::REQUEST_PERSISTENT_ID: {

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -728,7 +728,7 @@ void HandlePacket(Packet* packet) {
 		Game::server->SendToMaster(&bitStream);
 	}
 
-	if (packet->data[0] != ID_USER_PACKET_ENUM) return;
+	if (packet->data[0] != ID_USER_PACKET_ENUM || packet->length < 4) return;
 	if (static_cast<eConnectionType>(packet->data[1]) == eConnectionType::SERVER) {
 		if (static_cast<eServerMessageType>(packet->data[3]) == eServerMessageType::VERSION_CONFIRM) {
 			AuthPackets::HandleHandshake(Game::server, packet);


### PR DESCRIPTION
Fix Chat Crash

Tested that servers are still functional and handle packets as normal.  