### PR TITLE
fix: orient player correctly when using pirate mast in FV

### DIFF
--- a/dScripts/02_server/Map/GF/MastTeleport.cpp
+++ b/dScripts/02_server/Map/GF/MastTeleport.cpp
@@ -43,10 +43,12 @@ void MastTeleport::OnTimerDone(Entity* self, std::string timerName) {
 		GameMessages::SendTeleport(playerId, position, rotation, player->GetSystemAddress(), true);
 
 		// Hacky fix for odd rotations
-		if (self->GetVar<std::u16string>(u"MastName") != u"Jail") {
+		if (self->GetVar<std::u16string>(u"MastName") == u"Elephant") {
 			GameMessages::SendOrientToAngle(playerId, true, (M_PI / 180) * 140.0f, player->GetSystemAddress());
-		} else {
+		} else if (self->GetVar<std::u16string>(u"MastName") == u"Jail") {
 			GameMessages::SendOrientToAngle(playerId, true, (M_PI / 180) * 100.0f, player->GetSystemAddress());
+		} else if (self->GetVar<std::u16string>(u"MastName") == u""){
+			GameMessages::SendOrientToAngle(playerId, true, (M_PI / 180) * 203.0f, player->GetSystemAddress());
 		}
 
 		const auto cinematic = GeneralUtils::UTF16ToWTF8(self->GetVar<std::u16string>(u"Cinematic"));

--- a/dScripts/02_server/Map/GF/MastTeleport.cpp
+++ b/dScripts/02_server/Map/GF/MastTeleport.cpp
@@ -43,11 +43,12 @@ void MastTeleport::OnTimerDone(Entity* self, std::string timerName) {
 		GameMessages::SendTeleport(playerId, position, rotation, player->GetSystemAddress(), true);
 
 		// Hacky fix for odd rotations
-		if (self->GetVar<std::u16string>(u"MastName") == u"Elephant") {
+		auto mastName = self->GetVar<std::u16string>(u"MastName");
+		if (mastName == u"Elephant") {
 			GameMessages::SendOrientToAngle(playerId, true, (M_PI / 180) * 140.0f, player->GetSystemAddress());
-		} else if (self->GetVar<std::u16string>(u"MastName") == u"Jail") {
+		} else if (mastName == u"Jail") {
 			GameMessages::SendOrientToAngle(playerId, true, (M_PI / 180) * 100.0f, player->GetSystemAddress());
-		} else if (self->GetVar<std::u16string>(u"MastName") == u""){
+		} else if (mastName == u""){
 			GameMessages::SendOrientToAngle(playerId, true, (M_PI / 180) * 203.0f, player->GetSystemAddress());
 		}
 


### PR DESCRIPTION
Fixes #1066 
Tried to make a simpler fix overall to have have these magic numbers, but could not find an overall solution to eliminate the root issue and need for the hacky fixes.

While this "works" we should probably try to investigate the real issue and fix it.