### PR TITLE
fix: not everything attached to a path is a moving platform

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -690,11 +690,30 @@ void Entity::Initialize() {
 	}
 
 	std::string pathName = GetVarAsString(u"attached_path");
+	const Path* path = dZoneManager::Instance()->GetZone()->GetPath(pathName);
 
-	int32_t movingPlatformComponentId = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MOVING_PLATFORM, -1);
-	if (movingPlatformComponentId >= 0 || !pathName.empty()) {
-		MovingPlatformComponent* plat = new MovingPlatformComponent(this, pathName);
-		m_Components.insert(std::make_pair(eReplicaComponentType::MOVING_PLATFORM, plat));
+	//Check to see if we have an attached path and add the appropiate component to handle it:
+	if (path){
+		// if we have a moving platform path, then we need a moving platform component
+		if (path->pathType == PathType::MovingPlatform) {
+			MovingPlatformComponent* plat = new MovingPlatformComponent(this, pathName);
+			m_Components.insert(std::make_pair(eReplicaComponentType::MOVING_PLATFORM, plat));
+		// else if we are a movement path
+		} /*else if (path->pathType == PathType::Movement) {
+			auto movementAIcomp = GetComponent<MovementAIComponent>();
+			if (movementAIcomp){
+				// TODO: set path in existing movementAIComp
+			} else {
+				// TODO: create movementAIcomp and set path
+			}
+		}*/
+	} else {
+		// else we still need to setup moving platform if it has a moving platform comp but no path
+		int32_t movingPlatformComponentId = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MOVING_PLATFORM, -1);
+		if (movingPlatformComponentId >= 0) {
+			MovingPlatformComponent* plat = new MovingPlatformComponent(this, pathName);
+			m_Components.insert(std::make_pair(eReplicaComponentType::MOVING_PLATFORM, plat));
+		}
 	}
 
 	int proximityMonitorID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::PROXIMITY_MONITOR);


### PR DESCRIPTION
This PR reverts #1088 and fixes what #1088 was trying to fix, but without breaking every entity with an attached path, since not everything with a path is a moving platform. Most are just NPC's that will follow a movement path, once that server side logic is implemented.

Tested to make sure that the entities tested in #1088 still serialize correctly and do not generate deserialization error on the client