### PR TITLE
Enable artifact uploading and replace upload parameters

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -36,22 +36,16 @@ jobs:
         testPreset: "ci-${{matrix.os}}"
     - name: artifacts
       uses: actions/upload-artifact@v3
-      if: ${{ github.ref == 'ref/head/main' }}
       with:
         name: build-${{matrix.os}}
         path: |
-          build
-          !build/tests
-          !build/Testing
-          !build/CMakeFiles
-          !build/DartConfiguration.tcl
-          !build/CTestTestfile.cmake
-          !build/CMakeCache.txt
-          !build/build.ninja
-          !build/_deps
-          !build/cmake_install.cmake
-          !build/*.a
-          !build/*.lib
-          !build/*.dir
-          !build/*.vcxproj
-          !build/*.vcxproj.filters
+          build/*Server*
+          build/*.ini
+          build/*.so
+          build/*.dll
+          build/vanity/
+          build/navmeshes/
+          build/migrations/
+          build/*.dcf
+          !build/*.pdb
+          !build/d*/


### PR DESCRIPTION
[Here](https://github.com/DarkflameUniverse/DarkflameServer/actions/runs/4968581928#artifacts) is a run of it in a seperate branch as to not dirty the commity history.

This simply uploads all CI runs to Github storage to allow for them to be downloaded, nothing is different as far as how we run CI we just now save the runs.