### PR TITLE
Correction: Remove intermediate read from bitstream in AMFDeserialize

### DIFF
--- a/dCommon/AMFDeserialize.cpp
+++ b/dCommon/AMFDeserialize.cpp
@@ -13,10 +13,8 @@ AMFBaseValue* AMFDeserialize::Read(RakNet::BitStream* inStream) {
 	if (!inStream) return nullptr;
 	AMFBaseValue* returnValue = nullptr;
 	// Read in the value type from the bitStream
-	uint8_t i;
-	inStream->Read(i);
-	if (i > static_cast<uint8_t>(eAmf::Dictionary)) return nullptr;
-	eAmf marker = static_cast<eAmf>(i);
+	eAmf marker;
+	inStream->Read(marker);
 	// Based on the typing, create the value associated with that and return the base value class
 	switch (marker) {
 	case eAmf::Undefined: {


### PR DESCRIPTION
Per ISO C++ standard 9.7.1 clause 8,
"For an enumeration whose underlying type is fixed, the values of the enumeration are the values of the
underlying type" it is not undefined behavior to set a scoped enum to a value outside of its constant range because all values of the underlying type can represent the scoped enum