### PR TITLE
Fix: Some platforms not using the same RNG for every roll

### DIFF
--- a/dWorldServer/ObjectIDManager.cpp
+++ b/dWorldServer/ObjectIDManager.cpp
@@ -1,8 +1,5 @@
 #include "ObjectIDManager.h"
 
-// Std
-#include <random>
-
 // Custom Classes
 #include "MasterPackets.h"
 #include "Database.h"
@@ -48,11 +45,7 @@ void ObjectIDManager::HandleRequestPersistentIDResponse(uint64_t requestID, uint
 
 //! Handles cases where we have to get a unique object ID synchronously
 uint32_t ObjectIDManager::GenerateRandomObjectID() {
-	std::random_device rd;
-
-	std::mt19937 rng(rd());
-
-	return  uni(rng);
+	return  uni(Game::randomEngine);
 }
 
 

--- a/dWorldServer/ObjectIDManager.cpp
+++ b/dWorldServer/ObjectIDManager.cpp
@@ -48,11 +48,17 @@ void ObjectIDManager::HandleRequestPersistentIDResponse(uint64_t requestID, uint
 
 //! Handles cases where we have to get a unique object ID synchronously
 uint32_t ObjectIDManager::GenerateRandomObjectID() {
-	std::random_device rd;
-
-	std::mt19937 rng(rd());
-
-	return  uni(rng);
+	auto* objidmgr = ObjectIDManager::Instance();
+	bool coinFlip = rand() % 2;
+	if (objidmgr && coinFlip) {
+		Game::logger->Log("ObjectIDManager", "using new version");
+		return uni(objidmgr->rng);
+	} else {
+		Game::logger->Log("ObjectIDManager", "using old version");
+		std::random_device rd;
+		std::mt19937 rng(rd());
+		return uni(rng);
+	}
 }
 
 

--- a/dWorldServer/ObjectIDManager.cpp
+++ b/dWorldServer/ObjectIDManager.cpp
@@ -48,17 +48,11 @@ void ObjectIDManager::HandleRequestPersistentIDResponse(uint64_t requestID, uint
 
 //! Handles cases where we have to get a unique object ID synchronously
 uint32_t ObjectIDManager::GenerateRandomObjectID() {
-	auto* objidmgr = ObjectIDManager::Instance();
-	bool coinFlip = rand() % 2;
-	if (objidmgr && coinFlip) {
-		Game::logger->Log("ObjectIDManager", "using new version");
-		return uni(objidmgr->rng);
-	} else {
-		Game::logger->Log("ObjectIDManager", "using old version");
-		std::random_device rd;
-		std::mt19937 rng(rd());
-		return uni(rng);
-	}
+	std::random_device rd;
+
+	std::mt19937 rng(rd());
+
+	return  uni(rng);
 }
 
 

--- a/dWorldServer/ObjectIDManager.h
+++ b/dWorldServer/ObjectIDManager.h
@@ -3,6 +3,7 @@
 // C++
 #include <functional>
 #include <vector>
+#include <random>
 #include <stdint.h>
 
 /*!

--- a/dWorldServer/ObjectIDManager.h
+++ b/dWorldServer/ObjectIDManager.h
@@ -27,12 +27,17 @@ private:
 
 	uint32_t currentObjectID;                   //!< The current object ID
 
+	std::random_device rd;
+
+	std::mt19937 rng;
+
 public:
 
 	//! The singleton instance
 	static ObjectIDManager* Instance() {
 		if (m_Address == 0) {
 			m_Address = new ObjectIDManager;
+			m_Address->rng = std::mt19937(m_Address->rd());
 		}
 
 		return m_Address;

--- a/dWorldServer/ObjectIDManager.h
+++ b/dWorldServer/ObjectIDManager.h
@@ -3,7 +3,6 @@
 // C++
 #include <functional>
 #include <vector>
-#include <random>
 #include <stdint.h>
 
 /*!

--- a/dWorldServer/ObjectIDManager.h
+++ b/dWorldServer/ObjectIDManager.h
@@ -27,17 +27,12 @@ private:
 
 	uint32_t currentObjectID;                   //!< The current object ID
 
-	std::random_device rd;
-
-	std::mt19937 rng;
-
 public:
 
 	//! The singleton instance
 	static ObjectIDManager* Instance() {
 		if (m_Address == 0) {
 			m_Address = new ObjectIDManager;
-			m_Address->rng = std::mt19937(m_Address->rd());
 		}
 
 		return m_Address;


### PR DESCRIPTION
Not sure why this happens, but it does.  Original code was inefficient anyways so this is a net gain.

fixes #1100
If they reply that the bug is fixed on their end I will consider this tested enough