### PR TITLE
fix: make vanity npc's use default equipment if none is specified

### DIFF
--- a/dGame/dUtilities/VanityUtilities.cpp
+++ b/dGame/dUtilities/VanityUtilities.cpp
@@ -163,7 +163,7 @@ Entity* VanityUtilities::SpawnNPC(LOT lot, const std::string& name, const NiPoin
 
 	auto* inventoryComponent = entity->GetComponent<InventoryComponent>();
 
-	if (inventoryComponent != nullptr) {
+	if (inventoryComponent && !inventory.empty()) {
 		inventoryComponent->SetNPCItems(inventory);
 	}
 


### PR DESCRIPTION
small QoL fix