### PR TITLE
Allow default scripts for vanity NPC

### DIFF
--- a/dGame/dUtilities/VanityUtilities.cpp
+++ b/dGame/dUtilities/VanityUtilities.cpp
@@ -119,7 +119,7 @@ void VanityUtilities::SpawnVanity() {
 
 		auto* scriptComponent = npcEntity->GetComponent<ScriptComponent>();
 
-		if (scriptComponent != nullptr) {
+		if (scriptComponent && !npc.m_Script.empty()) {
 			scriptComponent->SetScript(npc.m_Script);
 			scriptComponent->SetSerialized(false);
 


### PR DESCRIPTION
Fix an issue where vanity script overwrote always

Tested that lot 13834 does not have its script overwritten when spawned via vanity NPC