### PR TITLE
fix: incorrect kick out of rebuilds that caused negative imagination to complete it

### DIFF
--- a/dGame/dComponents/RebuildComponent.cpp
+++ b/dGame/dComponents/RebuildComponent.cpp
@@ -180,7 +180,7 @@ void RebuildComponent::Update(float deltaTime) {
 	{
 		Entity* builder = GetBuilder();
 
-		if (builder == nullptr) {
+		if (!builder) {
 			ResetRebuild(false);
 
 			return;
@@ -198,16 +198,16 @@ void RebuildComponent::Update(float deltaTime) {
 			if (!destComp) break;
 
 			int newImagination = destComp->GetImagination();
-			if (newImagination <= 0) {
-				CancelRebuild(builder, eQuickBuildFailReason::OUT_OF_IMAGINATION, true);
-				break;
-			}
 
 			++m_DrainedImagination;
 			--newImagination;
 			destComp->SetImagination(newImagination);
 			EntityManager::Instance()->SerializeEntity(builder);
 
+			if (newImagination <= 0) {
+				CancelRebuild(builder, eQuickBuildFailReason::OUT_OF_IMAGINATION, true);
+				break;
+			}
 
 		}
 
@@ -482,7 +482,7 @@ void RebuildComponent::CompleteRebuild(Entity* user) {
 					if (missionComponent) missionComponent->Progress(eMissionTaskType::ACTIVITY, m_ActivityId);
 				}
 			}
-		} else{
+		} else {
 			auto* missionComponent = builder->GetComponent<MissionComponent>();
 			if (missionComponent) missionComponent->Progress(eMissionTaskType::ACTIVITY, m_ActivityId);
 		}


### PR DESCRIPTION
Tested that if you build a build with only 2 imagination and it takes 3 to complete, the build correctly shows it needs 1 more imagination to complete as opposed to now where it will let you keep building and then the build needs negative imagination