### PR TITLE
Fix vehicle serialization during races

### DIFF
--- a/dGame/dComponents/VehiclePhysicsComponent.cpp
+++ b/dGame/dComponents/VehiclePhysicsComponent.cpp
@@ -19,32 +19,45 @@ VehiclePhysicsComponent::~VehiclePhysicsComponent() {
 }
 
 void VehiclePhysicsComponent::SetPosition(const NiPoint3& pos) {
+	if (pos == m_Position) return;
+	m_DirtyPosition = true;
 	m_Position = pos;
 }
 
 void VehiclePhysicsComponent::SetRotation(const NiQuaternion& rot) {
+	if (rot == m_Rotation) return;
 	m_DirtyPosition = true;
 	m_Rotation = rot;
 }
 
 void VehiclePhysicsComponent::SetVelocity(const NiPoint3& vel) {
+	if (vel == m_Velocity) return;
 	m_DirtyPosition = true;
 	m_Velocity = vel;
 }
 
 void VehiclePhysicsComponent::SetAngularVelocity(const NiPoint3& vel) {
+	if (vel == m_AngularVelocity) return;
 	m_DirtyPosition = true;
 	m_AngularVelocity = vel;
 }
 
 void VehiclePhysicsComponent::SetIsOnGround(bool val) {
+	if (val == m_IsOnGround) return;
 	m_DirtyPosition = true;
 	m_IsOnGround = val;
 }
 
 void VehiclePhysicsComponent::SetIsOnRail(bool val) {
+	if (val == m_IsOnRail) return;
 	m_DirtyPosition = true;
 	m_IsOnRail = val;
+}
+
+void VehiclePhysicsComponent::SetRemoteInputInfo(const RemoteInputInfo& remoteInputInfo) {
+	if (m_RemoteInputInfo == remoteInputInfo) return;
+	this->m_RemoteInputInfo = remoteInputInfo;
+	m_DirtyRemoteInput = true;
 }
 
 void VehiclePhysicsComponent::SetDirtyPosition(bool val) {
@@ -63,9 +76,15 @@ void VehiclePhysicsComponent::Serialize(RakNet::BitStream* outBitStream, bool bI
 	outBitStream->Write(bIsInitialUpdate || m_DirtyPosition);
 
 	if (bIsInitialUpdate || m_DirtyPosition) {
-		outBitStream->Write(m_Position);
+		m_DirtyPosition = false;
+		outBitStream->Write(m_Position.x);
+		outBitStream->Write(m_Position.y);
+		outBitStream->Write(m_Position.z);
 
-		outBitStream->Write(m_Rotation);
+		outBitStream->Write(m_Rotation.x);
+		outBitStream->Write(m_Rotation.y);
+		outBitStream->Write(m_Rotation.z);
+		outBitStream->Write(m_Rotation.w);
 
 		outBitStream->Write(m_IsOnGround);
 		outBitStream->Write(m_IsOnRail);
@@ -73,20 +92,33 @@ void VehiclePhysicsComponent::Serialize(RakNet::BitStream* outBitStream, bool bI
 		outBitStream->Write(bIsInitialUpdate || m_DirtyVelocity);
 
 		if (bIsInitialUpdate || m_DirtyVelocity) {
-			outBitStream->Write(m_Velocity);
+			outBitStream->Write(m_Velocity.x);
+			outBitStream->Write(m_Velocity.y);
+			outBitStream->Write(m_Velocity.z);
+			m_DirtyVelocity = false;
 		}
 
 		outBitStream->Write(bIsInitialUpdate || m_DirtyAngularVelocity);
 
 		if (bIsInitialUpdate || m_DirtyAngularVelocity) {
-			outBitStream->Write(m_AngularVelocity);
+			outBitStream->Write(m_AngularVelocity.x);
+			outBitStream->Write(m_AngularVelocity.y);
+			outBitStream->Write(m_AngularVelocity.z);
+			m_DirtyAngularVelocity = false;
 		}
 
-		outBitStream->Write0();
+		outBitStream->Write0(); // local_space_info. TODO: Implement this
 
-		outBitStream->Write0();
+		outBitStream->Write(m_DirtyRemoteInput || bIsInitialUpdate); // remote_input_info
+		if (m_DirtyRemoteInput || bIsInitialUpdate) {
+			outBitStream->Write(m_RemoteInputInfo.m_RemoteInputX);
+			outBitStream->Write(m_RemoteInputInfo.m_RemoteInputY);
+			outBitStream->Write(m_RemoteInputInfo.m_IsPowersliding);
+			outBitStream->Write(m_RemoteInputInfo.m_IsModified);
+			m_DirtyRemoteInput = false;
+		}
 
-		outBitStream->Write(0.0f);
+		outBitStream->Write(125.0f); // remote_input_ping TODO: Figure out how this should be calculated as it seems to be constant through the whole race.
 
 		if (!bIsInitialUpdate) {
 			outBitStream->Write0();
@@ -95,7 +127,7 @@ void VehiclePhysicsComponent::Serialize(RakNet::BitStream* outBitStream, bool bI
 
 	if (bIsInitialUpdate) {
 		outBitStream->Write<uint8_t>(m_EndBehavior);
-		outBitStream->Write1();
+		outBitStream->Write1(); // is input locked?
 	}
 
 	outBitStream->Write0();
@@ -104,7 +136,6 @@ void VehiclePhysicsComponent::Serialize(RakNet::BitStream* outBitStream, bool bI
 void VehiclePhysicsComponent::Update(float deltaTime) {
 	if (m_SoftUpdate > 5) {
 		EntityManager::Instance()->SerializeEntity(m_Parent);
-
 		m_SoftUpdate = 0;
 	} else {
 		m_SoftUpdate += deltaTime;

--- a/dGame/dComponents/VehiclePhysicsComponent.h
+++ b/dGame/dComponents/VehiclePhysicsComponent.h
@@ -6,7 +6,6 @@
 #include "eReplicaComponentType.h"
 
 struct RemoteInputInfo {
-	// make an operator= for this
 	void operator=(const RemoteInputInfo& other) {
 		m_RemoteInputX = other.m_RemoteInputX;
 		m_RemoteInputY = other.m_RemoteInputY;

--- a/dGame/dComponents/VehiclePhysicsComponent.h
+++ b/dGame/dComponents/VehiclePhysicsComponent.h
@@ -5,6 +5,25 @@
 #include "Component.h"
 #include "eReplicaComponentType.h"
 
+struct RemoteInputInfo {
+	// make an operator= for this
+	void operator=(const RemoteInputInfo& other) {
+		m_RemoteInputX = other.m_RemoteInputX;
+		m_RemoteInputY = other.m_RemoteInputY;
+		m_IsPowersliding = other.m_IsPowersliding;
+		m_IsModified = other.m_IsModified;
+	}
+
+	bool operator==(const RemoteInputInfo& other) {
+		return m_RemoteInputX == other.m_RemoteInputX && m_RemoteInputY == other.m_RemoteInputY && m_IsPowersliding == other.m_IsPowersliding && m_IsModified == other.m_IsModified;
+	}
+
+	float m_RemoteInputX;
+	float m_RemoteInputY;
+	bool m_IsPowersliding;
+	bool m_IsModified;
+};
+
 /**
  * Physics component for vehicles.
  */
@@ -94,6 +113,7 @@ public:
 	void SetDirtyPosition(bool val);
 	void SetDirtyVelocity(bool val);
 	void SetDirtyAngularVelocity(bool val);
+	void SetRemoteInputInfo(const RemoteInputInfo&);
 
 private:
 	bool m_DirtyPosition;
@@ -110,4 +130,6 @@ private:
 
 	float m_SoftUpdate = 0;
 	uint32_t m_EndBehavior;
+	RemoteInputInfo m_RemoteInputInfo;
+	bool m_DirtyRemoteInput;
 };

--- a/dNet/ClientPackets.cpp
+++ b/dNet/ClientPackets.cpp
@@ -136,6 +136,34 @@ void ClientPackets::HandleClientPositionUpdate(const SystemAddress& sysAddr, Pac
 		inStream.Read(angVelocity.z);
 	}
 
+	// TODO figure out how to use these. Ignoring for now, but reading in if they exist.
+	bool hasLocalSpaceInfo{};
+	LWOOBJID objectId{};
+	NiPoint3 localSpacePosition{};
+	bool hasLinearVelocity{};
+	NiPoint3 linearVelocity{};
+	if (inStream.Read(hasLocalSpaceInfo) && hasLocalSpaceInfo) {
+		inStream.Read(objectId);
+		inStream.Read(localSpacePosition.x);
+		inStream.Read(localSpacePosition.y);
+		inStream.Read(localSpacePosition.z);
+		if (inStream.Read(hasLinearVelocity) && hasLinearVelocity) {
+			inStream.Read(linearVelocity.x);
+			inStream.Read(linearVelocity.y);
+			inStream.Read(linearVelocity.z);
+		}
+	}
+	bool hasRemoteInputInfo{};
+	RemoteInputInfo remoteInput{};
+
+	if (inStream.Read(hasRemoteInputInfo) && hasRemoteInputInfo) {
+		// read 8 bits at a time until we get to the end
+		inStream.Read(remoteInput.m_RemoteInputX);
+		inStream.Read(remoteInput.m_RemoteInputY);
+		inStream.Read(remoteInput.m_IsPowersliding);
+		inStream.Read(remoteInput.m_IsModified);
+	}
+
 	bool updateChar = true;
 
 	if (possessorComponent != nullptr) {
@@ -151,7 +179,6 @@ void ClientPackets::HandleClientPositionUpdate(const SystemAddress& sysAddr, Pac
 			auto* vehiclePhysicsComponent = possassableEntity->GetComponent<VehiclePhysicsComponent>();
 			if (vehiclePhysicsComponent != nullptr) {
 				// This is flipped for whatever reason
-				rotation = NiQuaternion(rotation.z, rotation.y, rotation.x, rotation.w);
 
 				vehiclePhysicsComponent->SetPosition(position);
 				vehiclePhysicsComponent->SetRotation(rotation);
@@ -161,6 +188,7 @@ void ClientPackets::HandleClientPositionUpdate(const SystemAddress& sysAddr, Pac
 				vehiclePhysicsComponent->SetDirtyVelocity(velocityFlag);
 				vehiclePhysicsComponent->SetAngularVelocity(angVelocity);
 				vehiclePhysicsComponent->SetDirtyAngularVelocity(angVelocityFlag);
+				vehiclePhysicsComponent->SetRemoteInputInfo(remoteInput);
 			} else {
 				// Need to get the mount's controllable physics
 				auto* controllablePhysicsComponent = possassableEntity->GetComponent<ControllablePhysicsComponent>();

--- a/dNet/ClientPackets.cpp
+++ b/dNet/ClientPackets.cpp
@@ -177,8 +177,6 @@ void ClientPackets::HandleClientPositionUpdate(const SystemAddress& sysAddr, Pac
 
 			auto* vehiclePhysicsComponent = possassableEntity->GetComponent<VehiclePhysicsComponent>();
 			if (vehiclePhysicsComponent != nullptr) {
-				// This is flipped for whatever reason
-
 				vehiclePhysicsComponent->SetPosition(position);
 				vehiclePhysicsComponent->SetRotation(rotation);
 				vehiclePhysicsComponent->SetIsOnGround(onGround);

--- a/dNet/ClientPackets.cpp
+++ b/dNet/ClientPackets.cpp
@@ -157,7 +157,6 @@ void ClientPackets::HandleClientPositionUpdate(const SystemAddress& sysAddr, Pac
 	RemoteInputInfo remoteInput{};
 
 	if (inStream.Read(hasRemoteInputInfo) && hasRemoteInputInfo) {
-		// read 8 bits at a time until we get to the end
 		inStream.Read(remoteInput.m_RemoteInputX);
 		inStream.Read(remoteInput.m_RemoteInputY);
 		inStream.Read(remoteInput.m_IsPowersliding);


### PR DESCRIPTION
- Add missing frame stats reading
- correct the inversion of rotation
- correct serialization order
- use proper dirty flags

Tested that racers are no longer sideways on certain vertical slopes and stay in sync throughout the whole race.
![image](https://github.com/DarkflameUniverse/DarkflameServer/assets/39972741/f4cad46c-3c29-40e7-9da1-5d1b2a0ef952)
Observe how in the image players are no longer eating the track.

Fixes #753 