### PR TITLE
Revert playerflags functions to uint

### DIFF
--- a/dGame/Character.cpp
+++ b/dGame/Character.cpp
@@ -418,7 +418,7 @@ void Character::WriteToDatabase() {
 	delete printer;
 }
 
-void Character::SetPlayerFlag(const int32_t flagId, const bool value) {
+void Character::SetPlayerFlag(const uint32_t flagId, const bool value) {
 	// If the flag is already set, we don't have to recalculate it
 	if (GetPlayerFlag(flagId) == value) return;
 
@@ -465,7 +465,7 @@ void Character::SetPlayerFlag(const int32_t flagId, const bool value) {
 	GameMessages::SendNotifyClientFlagChange(m_ObjectID, flagId, value, m_ParentUser->GetSystemAddress());
 }
 
-bool Character::GetPlayerFlag(const int32_t flagId) const {
+bool Character::GetPlayerFlag(const uint32_t flagId) const {
 	// Calculate the index first
 	const auto flagIndex = uint32_t(std::floor(flagId / 64));
 

--- a/dGame/Character.h
+++ b/dGame/Character.h
@@ -415,14 +415,14 @@ public:
 	 * @param flagId the ID of the flag to set
 	 * @param value the value to set for the flag
 	 */
-	void SetPlayerFlag(int32_t flagId, bool value);
+	void SetPlayerFlag(uint32_t flagId, bool value);
 
 	/**
 	 * Gets the value for a certain character flag
 	 * @param flagId the ID of the flag to get a value for
 	 * @return the value of the flag given the ID (the default is false, obviously)
 	 */
-	bool GetPlayerFlag(int32_t flagId) const;
+	bool GetPlayerFlag(uint32_t flagId) const;
 
 	/**
 	 * Notifies the character that they're now muted


### PR DESCRIPTION
Whoops!  Looks like we missed this one in QA.  

Fixes weird mission progression when passing in -1 as a flag to check.

Tested that on main a mission that would progress 2 now correctly progresses only once.

Fixes #1128 