### PR TITLE
fix: remove hardcoded rotations now that vehicles orient correctly

### DIFF
--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -995,17 +995,7 @@ void InventoryComponent::HandlePossession(Item* item) {
 
 	// Check to see if the mount is a vehicle, if so, flip it
 	auto* vehicleComponent = mount->GetComponent<VehiclePhysicsComponent>();
-	if (vehicleComponent) {
-		auto angles = startRotation.GetEulerAngles();
-		// Make it right side up
-		angles.x -= PI;
-		// Make it going in the direction of the player
-		angles.y -= PI;
-		startRotation = NiQuaternion::FromEulerAngles(angles);
-		mount->SetRotation(startRotation);
-		// We're pod racing now
-		characterComponent->SetIsRacing(true);
-	}
+	if (vehicleComponent) characterComponent->SetIsRacing(true);
 
 	// Setup the destroyable stats
 	auto* destroyableComponent = mount->GetComponent<DestroyableComponent>();

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -1267,18 +1267,6 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			return;
 		}
 
-		auto vehiclePhysicsComponent = newEntity->GetComponent<VehiclePhysicsComponent>();
-		if (vehiclePhysicsComponent) {
-			auto newRot = newEntity->GetRotation();
-			auto angles = newRot.GetEulerAngles();
-			// make it right side up
-			angles.x -= PI;
-			// make it going in the direction of the player
-			angles.y -= PI;
-			newRot = NiQuaternion::FromEulerAngles(angles);
-			newEntity->SetRotation(newRot);
-		}
-
 		EntityManager::Instance()->ConstructEntity(newEntity);
 	}
 


### PR DESCRIPTION
Tested that equipping and spawning work as intended
fixes #1131 