### PR TITLE
Move EntityManager to Game namespace

### DIFF
--- a/dCommon/Game.h
+++ b/dCommon/Game.h
@@ -10,6 +10,7 @@ class dConfig;
 class RakPeerInterface;
 class AssetManager;
 struct SystemAddress;
+class EntityManager;
 
 namespace Game {
 	extern dLogger* logger;
@@ -22,4 +23,5 @@ namespace Game {
 	extern AssetManager* assetManager;
 	extern SystemAddress chatSysAddr;
 	extern bool shouldShutdown;
+	extern EntityManager* entityManager;
 }

--- a/dCommon/dEnums/dCommonVars.h
+++ b/dCommon/dEnums/dCommonVars.h
@@ -56,7 +56,6 @@ const uint32_t LWOCLONEID_INVALID = -1;     //!< Invalid LWOCLONEID
 const uint16_t LWOINSTANCEID_INVALID = -1;  //!< Invalid LWOINSTANCEID
 const uint16_t LWOMAPID_INVALID = -1;       //!< Invalid LWOMAPID
 const uint64_t LWOZONEID_INVALID = 0;       //!< Invalid LWOZONEID
-constexpr LOT LOT_ZONE_CONTROL = 2365;
 
 const float PI = 3.14159f;
 

--- a/dCommon/dEnums/dCommonVars.h
+++ b/dCommon/dEnums/dCommonVars.h
@@ -56,6 +56,7 @@ const uint32_t LWOCLONEID_INVALID = -1;     //!< Invalid LWOCLONEID
 const uint16_t LWOINSTANCEID_INVALID = -1;  //!< Invalid LWOINSTANCEID
 const uint16_t LWOMAPID_INVALID = -1;       //!< Invalid LWOMAPID
 const uint64_t LWOZONEID_INVALID = 0;       //!< Invalid LWOZONEID
+constexpr LOT LOT_ZONE_CONTROL = 2365;
 
 const float PI = 3.14159f;
 

--- a/dGame/Character.cpp
+++ b/dGame/Character.cpp
@@ -290,7 +290,7 @@ void Character::DoQuickXMLDataParse() {
 
 void Character::UnlockEmote(int emoteID) {
 	m_UnlockedEmotes.push_back(emoteID);
-	GameMessages::SendSetEmoteLockState(EntityManager::Instance()->GetEntity(m_ObjectID), false, emoteID);
+	GameMessages::SendSetEmoteLockState(Game::entityManager->GetEntity(m_ObjectID), false, emoteID);
 }
 
 void Character::SetBuildMode(bool buildMode) {
@@ -424,7 +424,7 @@ void Character::SetPlayerFlag(const uint32_t flagId, const bool value) {
 
 	if (value) {
 		// Update the mission component:
-		auto* player = EntityManager::Instance()->GetEntity(m_ObjectID);
+		auto* player = Game::entityManager->GetEntity(m_ObjectID);
 
 		if (player != nullptr) {
 			auto* missionComponent = player->GetComponent<MissionComponent>();
@@ -602,7 +602,7 @@ void Character::SetCoins(int64_t newCoins, eLootSourceType lootSource) {
 
 	m_Coins = newCoins;
 
-	GameMessages::SendSetCurrency(EntityManager::Instance()->GetEntity(m_ObjectID), m_Coins, 0, 0, 0, 0, true, lootSource);
+	GameMessages::SendSetCurrency(Game::entityManager->GetEntity(m_ObjectID), m_Coins, 0, 0, 0, 0, true, lootSource);
 }
 
 bool Character::HasBeenToWorld(LWOMAPID mapID) const {

--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -263,7 +263,7 @@ void Entity::Initialize() {
 				NiQuaternion rot;
 
 				const auto& targetSceneName = m_Character->GetTargetScene();
-				auto* targetScene = EntityManager::Instance()->GetSpawnPointEntity(targetSceneName);
+				auto* targetScene = Game::entityManager->GetSpawnPointEntity(targetSceneName);
 
 				if (m_Character->HasBeenToWorld(mapID) && targetSceneName.empty()) {
 					pos = m_Character->GetRespawnPoint(mapID);
@@ -735,7 +735,7 @@ void Entity::Initialize() {
 		}
 		});
 
-	if (!m_Character && EntityManager::Instance()->GetGhostingEnabled()) {
+	if (!m_Character && Game::entityManager->GetGhostingEnabled()) {
 		// Don't ghost what is likely large scene elements
 		if (HasComponent(eReplicaComponentType::SIMPLE_PHYSICS) && HasComponent(eReplicaComponentType::RENDER) && (m_Components.size() == 2 || (HasComponent(eReplicaComponentType::TRIGGER) && m_Components.size() == 3))) {
 			goto no_ghosting;
@@ -1284,12 +1284,12 @@ void Entity::Update(const float deltaTime) {
 	}
 
 	if (m_ShouldDestroyAfterUpdate) {
-		EntityManager::Instance()->DestroyEntity(this->GetObjectID());
+		Game::entityManager->DestroyEntity(this->GetObjectID());
 	}
 }
 
 void Entity::OnCollisionProximity(LWOOBJID otherEntity, const std::string& proxName, const std::string& status) {
-	Entity* other = EntityManager::Instance()->GetEntity(otherEntity);
+	Entity* other = Game::entityManager->GetEntity(otherEntity);
 	if (!other) return;
 
 	for (CppScripts::Script* script : CppScripts::GetEntityScripts(this)) {
@@ -1303,7 +1303,7 @@ void Entity::OnCollisionProximity(LWOOBJID otherEntity, const std::string& proxN
 }
 
 void Entity::OnCollisionPhantom(const LWOOBJID otherEntity) {
-	auto* other = EntityManager::Instance()->GetEntity(otherEntity);
+	auto* other = Game::entityManager->GetEntity(otherEntity);
 	if (!other) return;
 
 	for (CppScripts::Script* script : CppScripts::GetEntityScripts(this)) {
@@ -1350,7 +1350,7 @@ void Entity::OnCollisionPhantom(const LWOOBJID otherEntity) {
 }
 
 void Entity::OnCollisionLeavePhantom(const LWOOBJID otherEntity) {
-	auto* other = EntityManager::Instance()->GetEntity(otherEntity);
+	auto* other = Game::entityManager->GetEntity(otherEntity);
 	if (!other) return;
 
 	for (CppScripts::Script* script : CppScripts::GetEntityScripts(this)) {
@@ -1504,13 +1504,13 @@ void Entity::Smash(const LWOOBJID source, const eKillType killType, const std::u
 
 	auto* destroyableComponent = GetComponent<DestroyableComponent>();
 	if (destroyableComponent == nullptr) {
-		Kill(EntityManager::Instance()->GetEntity(source));
+		Kill(Game::entityManager->GetEntity(source));
 		return;
 	}
 	auto* possessorComponent = GetComponent<PossessorComponent>();
 	if (possessorComponent) {
 		if (possessorComponent->GetPossessable() != LWOOBJID_EMPTY) {
-			auto* mount = EntityManager::Instance()->GetEntity(possessorComponent->GetPossessable());
+			auto* mount = Game::entityManager->GetEntity(possessorComponent->GetPossessable());
 			if (mount) possessorComponent->Dismount(mount, true);
 		}
 	}
@@ -1538,7 +1538,7 @@ void Entity::Kill(Entity* murderer) {
 	}
 
 	if (!IsPlayer()) {
-		EntityManager::Instance()->DestroyEntity(this);
+		Game::entityManager->DestroyEntity(this);
 	}
 
 	const auto& grpNameQBShowBricks = GetVar<std::string>(u"grpNameQBShowBricks");
@@ -1719,7 +1719,7 @@ void Entity::CancelCallbackTimers() {
 
 void Entity::ScheduleKillAfterUpdate(Entity* murderer) {
 	//if (m_Info.spawner) m_Info.spawner->ScheduleKill(this);
-	EntityManager::Instance()->ScheduleForKill(this);
+	Game::entityManager->ScheduleForKill(this);
 
 	if (murderer) m_ScheduleKiller = murderer;
 }
@@ -1763,7 +1763,7 @@ void Entity::TriggerEvent(eTriggerEventType event, Entity* optionalTarget) {
 
 Entity* Entity::GetOwner() const {
 	if (m_OwnerOverride != LWOOBJID_EMPTY) {
-		auto* other = EntityManager::Instance()->GetEntity(m_OwnerOverride);
+		auto* other = Game::entityManager->GetEntity(m_OwnerOverride);
 
 		if (other != nullptr) {
 			return other->GetOwner();
@@ -1907,7 +1907,7 @@ void Entity::SetPosition(NiPoint3 position) {
 		vehicel->SetPosition(position);
 	}
 
-	EntityManager::Instance()->SerializeEntity(this);
+	Game::entityManager->SerializeEntity(this);
 }
 
 void Entity::SetRotation(NiQuaternion rotation) {
@@ -1935,7 +1935,7 @@ void Entity::SetRotation(NiQuaternion rotation) {
 		vehicel->SetRotation(rotation);
 	}
 
-	EntityManager::Instance()->SerializeEntity(this);
+	Game::entityManager->SerializeEntity(this);
 }
 
 bool Entity::GetBoolean(const std::u16string& name) const {
@@ -1987,7 +1987,7 @@ std::vector<LWOOBJID>& Entity::GetTargetsInPhantom() {
 	for (auto i = 0u; i < m_TargetsInPhantom.size(); ++i) {
 		const auto id = m_TargetsInPhantom.at(i);
 
-		auto* entity = EntityManager::Instance()->GetEntity(id);
+		auto* entity = Game::entityManager->GetEntity(id);
 
 		if (entity == nullptr) {
 			continue;

--- a/dGame/EntityManager.cpp
+++ b/dGame/EntityManager.cpp
@@ -25,8 +25,6 @@
 #include "eReplicaComponentType.h"
 #include "eReplicaPacketType.h"
 
-EntityManager* EntityManager::m_Address = nullptr;
-
 // Configure which zones have ghosting disabled, mostly small worlds.
 std::vector<LWOMAPID> EntityManager::m_GhostingExcludedZones = {
 	// Small zones
@@ -78,9 +76,6 @@ void EntityManager::Initialize() {
 	// If cloneID is not zero, then hardcore mode is disabled
 	// aka minigames and props
 	if (dZoneManager::Instance()->GetZoneID().GetCloneID() != 0) m_HardcoreMode = false;
-}
-
-EntityManager::~EntityManager() {
 }
 
 Entity* EntityManager::CreateEntity(EntityInfo info, User* user, Entity* parentEntity, const bool controller, const LWOOBJID explicitId) {

--- a/dGame/EntityManager.h
+++ b/dGame/EntityManager.h
@@ -1,11 +1,12 @@
 #ifndef ENTITYMANAGER_H
 #define ENTITYMANAGER_H
 
-#include "dCommonVars.h"
 #include <map>
 #include <stack>
 #include <vector>
 #include <unordered_map>
+
+#include "dCommonVars.h"
 
 class Entity;
 class EntityInfo;
@@ -17,18 +18,7 @@ struct SystemAddress;
 
 class EntityManager {
 public:
-	static EntityManager* Instance() {
-		if (!m_Address) {
-			m_Address = new EntityManager();
-			m_Address->Initialize();
-		}
-
-		return m_Address;
-	}
-
 	void Initialize();
-
-	~EntityManager();
 
 	void UpdateEntities(float deltaTime);
 	Entity* CreateEntity(EntityInfo info, User* user = nullptr, Entity* parentEntity = nullptr, bool controller = false, LWOOBJID explicitId = LWOOBJID_EMPTY);
@@ -89,7 +79,6 @@ private:
 	void KillEntities();
 	void DeleteEntities();
 
-	static EntityManager* m_Address; //For singleton method
 	static std::vector<LWOMAPID> m_GhostingExcludedZones;
 	static std::vector<LOT> m_GhostingExcludedLOTs;
 

--- a/dGame/LeaderboardManager.cpp
+++ b/dGame/LeaderboardManager.cpp
@@ -66,14 +66,14 @@ uint32_t Leaderboard::GetInfoType() const {
 }
 
 void Leaderboard::Send(LWOOBJID targetID) const {
-	auto* player = EntityManager::Instance()->GetEntity(relatedPlayer);
+	auto* player = Game::entityManager->GetEntity(relatedPlayer);
 	if (player != nullptr) {
 		GameMessages::SendActivitySummaryLeaderboardData(targetID, this, player->GetSystemAddress());
 	}
 }
 
 void LeaderboardManager::SaveScore(LWOOBJID playerID, uint32_t gameID, uint32_t score, uint32_t time) {
-	const auto* player = EntityManager::Instance()->GetEntity(playerID);
+	const auto* player = Game::entityManager->GetEntity(playerID);
 	if (player == nullptr)
 		return;
 
@@ -235,7 +235,7 @@ Leaderboard* LeaderboardManager::GetLeaderboard(uint32_t gameID, InfoType infoTy
 	if (infoType == Standings || infoType == Friends) {
 		auto characterID = 0;
 
-		const auto* player = EntityManager::Instance()->GetEntity(playerID);
+		const auto* player = Game::entityManager->GetEntity(playerID);
 		if (player != nullptr) {
 			auto* character = player->GetCharacter();
 			if (character != nullptr)

--- a/dGame/Player.cpp
+++ b/dGame/Player.cpp
@@ -85,7 +85,7 @@ void Player::SendToZone(LWOMAPID zoneId, LWOCLONEID cloneId) {
 	const auto objid = GetObjectID();
 
 	ZoneInstanceManager::Instance()->RequestZoneTransfer(Game::server, zoneId, cloneId, false, [objid](bool mythranShift, uint32_t zoneID, uint32_t zoneInstance, uint32_t zoneClone, std::string serverIP, uint16_t serverPort) {
-		auto* entity = EntityManager::Instance()->GetEntity(objid);
+		auto* entity = Game::entityManager->GetEntity(objid);
 
 		if (entity == nullptr) {
 			return;
@@ -108,7 +108,7 @@ void Player::SendToZone(LWOMAPID zoneId, LWOCLONEID cloneId) {
 
 		WorldPackets::SendTransferToWorld(sysAddr, serverIP, serverPort, mythranShift);
 
-		EntityManager::Instance()->DestructEntity(entity);
+		Game::entityManager->DestructEntity(entity);
 		return;
 		});
 }
@@ -135,13 +135,13 @@ void Player::RemoveLimboConstruction(LWOOBJID objectId) {
 
 void Player::ConstructLimboEntities() {
 	for (const auto objectId : m_LimboConstructions) {
-		auto* entity = EntityManager::Instance()->GetEntity(objectId);
+		auto* entity = Game::entityManager->GetEntity(objectId);
 
 		if (entity == nullptr) {
 			continue;
 		}
 
-		EntityManager::Instance()->ConstructEntity(entity, m_SystemAddress);
+		Game::entityManager->ConstructEntity(entity, m_SystemAddress);
 	}
 
 	m_LimboConstructions.clear();
@@ -224,7 +224,7 @@ Player* Player::GetPlayer(const SystemAddress& sysAddr) {
 }
 
 Player* Player::GetPlayer(const std::string& name) {
-	const auto characters = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::CHARACTER);
+	const auto characters = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::CHARACTER);
 
 	for (auto* character : characters) {
 		if (!character->IsPlayer()) continue;
@@ -269,7 +269,7 @@ Player::~Player() {
 			continue;
 		}
 
-		auto* entity = EntityManager::Instance()->GetGhostCandidate(id);
+		auto* entity = Game::entityManager->GetGhostCandidate(id);
 
 		if (entity != nullptr) {
 			entity->SetObservers(entity->GetObservers() - 1);
@@ -285,12 +285,12 @@ Player::~Player() {
 	}
 
 	if (IsPlayer()) {
-		Entity* zoneControl = EntityManager::Instance()->GetZoneControlEntity();
+		Entity* zoneControl = Game::entityManager->GetZoneControlEntity();
 		for (CppScripts::Script* script : CppScripts::GetEntityScripts(zoneControl)) {
 			script->OnPlayerExit(zoneControl, this);
 		}
 
-		std::vector<Entity*> scriptedActs = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::SCRIPTED_ACTIVITY);
+		std::vector<Entity*> scriptedActs = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SCRIPTED_ACTIVITY);
 		for (Entity* scriptEntity : scriptedActs) {
 			if (scriptEntity->GetObjectID() != zoneControl->GetObjectID()) { // Don't want to trigger twice on instance worlds
 				for (CppScripts::Script* script : CppScripts::GetEntityScripts(scriptEntity)) {

--- a/dGame/TradingManager.cpp
+++ b/dGame/TradingManager.cpp
@@ -40,11 +40,11 @@ LWOOBJID Trade::GetParticipantB() const {
 }
 
 Entity* Trade::GetParticipantAEntity() const {
-	return EntityManager::Instance()->GetEntity(m_ParticipantA);
+	return Game::entityManager->GetEntity(m_ParticipantA);
 }
 
 Entity* Trade::GetParticipantBEntity() const {
-	return EntityManager::Instance()->GetEntity(m_ParticipantB);
+	return Game::entityManager->GetEntity(m_ParticipantB);
 }
 
 void Trade::SetCoins(LWOOBJID participant, uint64_t coins) {

--- a/dGame/UserManager.cpp
+++ b/dGame/UserManager.cpp
@@ -220,7 +220,7 @@ void UserManager::RequestCharacterList(const SystemAddress& sysAddr) {
 				skillComponent->Reset();
 			}
 
-			EntityManager::Instance()->DestroyEntity(chars[i]->GetEntity());
+			Game::entityManager->DestroyEntity(chars[i]->GetEntity());
 
 			chars[i]->SaveXMLToDatabase();
 

--- a/dGame/dBehaviors/AirMovementBehavior.cpp
+++ b/dGame/dBehaviors/AirMovementBehavior.cpp
@@ -39,7 +39,7 @@ void AirMovementBehavior::Sync(BehaviorContext* context, RakNet::BitStream* bitS
 
 	auto* behavior = CreateBehavior(behaviorId);
 
-	if (EntityManager::Instance()->GetEntity(target) != nullptr) {
+	if (Game::entityManager->GetEntity(target) != nullptr) {
 		branch.target = target;
 	}
 

--- a/dGame/dBehaviors/ApplyBuffBehavior.cpp
+++ b/dGame/dBehaviors/ApplyBuffBehavior.cpp
@@ -6,7 +6,7 @@
 
 
 void ApplyBuffBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* entity = EntityManager::Instance()->GetEntity(branch.target == LWOOBJID_EMPTY ? context->originator : branch.target);
+	auto* entity = Game::entityManager->GetEntity(branch.target == LWOOBJID_EMPTY ? context->originator : branch.target);
 
 	if (entity == nullptr) return;
 
@@ -19,7 +19,7 @@ void ApplyBuffBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitS
 }
 
 void ApplyBuffBehavior::UnCast(BehaviorContext* context, BehaviorBranchContext branch) {
-	auto* entity = EntityManager::Instance()->GetEntity(branch.target);
+	auto* entity = Game::entityManager->GetEntity(branch.target);
 
 	if (entity == nullptr) return;
 

--- a/dGame/dBehaviors/AreaOfEffectBehavior.cpp
+++ b/dGame/dBehaviors/AreaOfEffectBehavior.cpp
@@ -47,7 +47,7 @@ void AreaOfEffectBehavior::Handle(BehaviorContext* context, RakNet::BitStream* b
 }
 
 void AreaOfEffectBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* self = EntityManager::Instance()->GetEntity(context->caster);
+	auto* self = Game::entityManager->GetEntity(context->caster);
 	if (self == nullptr) {
 		Game::logger->Log("AreaOfEffectBehavior", "Invalid self for (%llu)!", context->originator);
 
@@ -58,7 +58,7 @@ void AreaOfEffectBehavior::Calculate(BehaviorContext* context, RakNet::BitStream
 
 	std::vector<Entity*> targets;
 
-	auto* presetTarget = EntityManager::Instance()->GetEntity(branch.target);
+	auto* presetTarget = Game::entityManager->GetEntity(branch.target);
 
 	if (presetTarget != nullptr) {
 		if (this->m_radius * this->m_radius >= Vector3::DistanceSquared(reference, presetTarget->GetPosition())) {
@@ -75,7 +75,7 @@ void AreaOfEffectBehavior::Calculate(BehaviorContext* context, RakNet::BitStream
 
 	// Gets all of the valid targets, passing in if should target enemies and friends
 	for (auto validTarget : context->GetValidTargets(m_ignoreFaction, includeFaction, m_TargetSelf == 1, m_targetEnemy == 1, m_targetFriend == 1)) {
-		auto* entity = EntityManager::Instance()->GetEntity(validTarget);
+		auto* entity = Game::entityManager->GetEntity(validTarget);
 
 		if (entity == nullptr) {
 			Game::logger->Log("AreaOfEffectBehavior", "Invalid target (%llu) for (%llu)!", validTarget, context->originator);

--- a/dGame/dBehaviors/BasicAttackBehavior.cpp
+++ b/dGame/dBehaviors/BasicAttackBehavior.cpp
@@ -9,7 +9,7 @@
 
 void BasicAttackBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
 	if (context->unmanaged) {
-		auto* entity = EntityManager::Instance()->GetEntity(branch.target);
+		auto* entity = Game::entityManager->GetEntity(branch.target);
 
 		auto* destroyableComponent = entity->GetComponent<DestroyableComponent>();
 		if (destroyableComponent != nullptr) {
@@ -38,7 +38,7 @@ void BasicAttackBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bi
 }
 
 void BasicAttackBehavior::DoHandleBehavior(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* targetEntity = EntityManager::Instance()->GetEntity(branch.target);
+	auto* targetEntity = Game::entityManager->GetEntity(branch.target);
 	if (!targetEntity) {
 		Game::logger->Log("BasicAttackBehavior", "Target targetEntity %llu not found.", branch.target);
 		return;
@@ -61,7 +61,7 @@ void BasicAttackBehavior::DoHandleBehavior(BehaviorContext* context, RakNet::Bit
 
 	if (isBlocked) {
 		destroyableComponent->SetAttacksToBlock(std::min(destroyableComponent->GetAttacksToBlock() - 1, 0U));
-		EntityManager::Instance()->SerializeEntity(targetEntity);
+		Game::entityManager->SerializeEntity(targetEntity);
 		this->m_OnFailBlocked->Handle(context, bitStream, branch);
 		return;
 	}
@@ -155,7 +155,7 @@ void BasicAttackBehavior::Calculate(BehaviorContext* context, RakNet::BitStream*
 }
 
 void BasicAttackBehavior::DoBehaviorCalculation(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* targetEntity = EntityManager::Instance()->GetEntity(branch.target);
+	auto* targetEntity = Game::entityManager->GetEntity(branch.target);
 	if (!targetEntity) {
 		Game::logger->Log("BasicAttackBehavior", "Target entity %llu is null!", branch.target);
 		return;
@@ -173,7 +173,7 @@ void BasicAttackBehavior::DoBehaviorCalculation(BehaviorContext* context, RakNet
 
 	if (isBlocking) {
 		destroyableComponent->SetAttacksToBlock(destroyableComponent->GetAttacksToBlock() - 1);
-		EntityManager::Instance()->SerializeEntity(targetEntity);
+		Game::entityManager->SerializeEntity(targetEntity);
 		this->m_OnFailBlocked->Calculate(context, bitStream, branch);
 		return;
 	}

--- a/dGame/dBehaviors/Behavior.cpp
+++ b/dGame/dBehaviors/Behavior.cpp
@@ -314,7 +314,7 @@ BehaviorTemplates Behavior::GetBehaviorTemplate(const uint32_t behaviorId) {
 
 // For use with enemies, to display the correct damage animations on the players
 void Behavior::PlayFx(std::u16string type, const LWOOBJID target, const LWOOBJID secondary) {
-	auto* targetEntity = EntityManager::Instance()->GetEntity(target);
+	auto* targetEntity = Game::entityManager->GetEntity(target);
 
 	if (targetEntity == nullptr) {
 		return;

--- a/dGame/dBehaviors/BehaviorContext.cpp
+++ b/dGame/dBehaviors/BehaviorContext.cpp
@@ -27,7 +27,7 @@ BehaviorEndEntry::BehaviorEndEntry() {
 }
 
 uint32_t BehaviorContext::GetUniqueSkillId() const {
-	auto* entity = EntityManager::Instance()->GetEntity(this->originator);
+	auto* entity = Game::entityManager->GetEntity(this->originator);
 
 	if (entity == nullptr) {
 		Game::logger->Log("BehaviorContext", "Invalid entity for (%llu)!", this->originator);
@@ -94,11 +94,11 @@ void BehaviorContext::ScheduleUpdate(const LWOOBJID id) {
 
 void BehaviorContext::ExecuteUpdates() {
 	for (const auto& id : this->scheduledUpdates) {
-		auto* entity = EntityManager::Instance()->GetEntity(id);
+		auto* entity = Game::entityManager->GetEntity(id);
 
 		if (entity == nullptr) continue;
 
-		EntityManager::Instance()->SerializeEntity(entity);
+		Game::entityManager->SerializeEntity(entity);
 	}
 
 	this->scheduledUpdates.clear();
@@ -308,7 +308,7 @@ void BehaviorContext::Reset() {
 }
 
 std::vector<LWOOBJID> BehaviorContext::GetValidTargets(int32_t ignoreFaction, int32_t includeFaction, bool targetSelf, bool targetEnemy, bool targetFriend) const {
-	auto* entity = EntityManager::Instance()->GetEntity(this->caster);
+	auto* entity = Game::entityManager->GetEntity(this->caster);
 
 	std::vector<LWOOBJID> targets;
 
@@ -320,7 +320,7 @@ std::vector<LWOOBJID> BehaviorContext::GetValidTargets(int32_t ignoreFaction, in
 
 	if (!ignoreFaction && !includeFaction) {
 		for (auto entry : entity->GetTargetsInPhantom()) {
-			auto* instance = EntityManager::Instance()->GetEntity(entry);
+			auto* instance = Game::entityManager->GetEntity(entry);
 
 			if (instance == nullptr) {
 				continue;
@@ -336,7 +336,7 @@ std::vector<LWOOBJID> BehaviorContext::GetValidTargets(int32_t ignoreFaction, in
 			return targets;
 		}
 
-		auto entities = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::CONTROLLABLE_PHYSICS);
+		auto entities = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::CONTROLLABLE_PHYSICS);
 		for (auto* candidate : entities) {
 			const auto id = candidate->GetObjectID();
 

--- a/dGame/dBehaviors/BlockBehavior.cpp
+++ b/dGame/dBehaviors/BlockBehavior.cpp
@@ -10,7 +10,7 @@
 void BlockBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
 	const auto target = context->originator;
 
-	auto* entity = EntityManager::Instance()->GetEntity(target);
+	auto* entity = Game::entityManager->GetEntity(target);
 
 	if (entity == nullptr) {
 		Game::logger->Log("DamageAbsorptionBehavior", "Failed to find target (%llu)!", branch.target);
@@ -40,7 +40,7 @@ void BlockBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitSt
 void BlockBehavior::UnCast(BehaviorContext* context, BehaviorBranchContext branch) {
 	const auto target = context->originator;
 
-	auto* entity = EntityManager::Instance()->GetEntity(target);
+	auto* entity = Game::entityManager->GetEntity(target);
 
 	if (entity == nullptr) {
 		Game::logger->Log("DamageAbsorptionBehavior", "Failed to find target (%llu)!", branch.target);

--- a/dGame/dBehaviors/BuffBehavior.cpp
+++ b/dGame/dBehaviors/BuffBehavior.cpp
@@ -10,7 +10,7 @@
 void BuffBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
 	const auto target = branch.target != LWOOBJID_EMPTY ? branch.target : context->originator;
 
-	auto* entity = EntityManager::Instance()->GetEntity(target);
+	auto* entity = Game::entityManager->GetEntity(target);
 
 	if (entity == nullptr) {
 		Game::logger->Log("BuffBehavior", "Invalid target (%llu)!", target);
@@ -30,7 +30,7 @@ void BuffBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream
 	component->SetMaxArmor(component->GetMaxArmor() + this->m_armor);
 	component->SetMaxImagination(component->GetMaxImagination() + this->m_imagination);
 
-	EntityManager::Instance()->SerializeEntity(entity);
+	Game::entityManager->SerializeEntity(entity);
 
 	if (!context->unmanaged) {
 		if (branch.duration > 0) {
@@ -44,7 +44,7 @@ void BuffBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream
 void BuffBehavior::UnCast(BehaviorContext* context, BehaviorBranchContext branch) {
 	const auto target = branch.target != LWOOBJID_EMPTY ? branch.target : context->originator;
 
-	auto* entity = EntityManager::Instance()->GetEntity(target);
+	auto* entity = Game::entityManager->GetEntity(target);
 
 	if (entity == nullptr) {
 		Game::logger->Log("BuffBehavior", "Invalid target (%llu)!", target);
@@ -64,7 +64,7 @@ void BuffBehavior::UnCast(BehaviorContext* context, BehaviorBranchContext branch
 	component->SetMaxArmor(component->GetMaxArmor() - this->m_armor);
 	component->SetMaxImagination(component->GetMaxImagination() - this->m_imagination);
 
-	EntityManager::Instance()->SerializeEntity(entity);
+	Game::entityManager->SerializeEntity(entity);
 }
 
 void BuffBehavior::Timer(BehaviorContext* context, const BehaviorBranchContext branch, LWOOBJID second) {

--- a/dGame/dBehaviors/CarBoostBehavior.cpp
+++ b/dGame/dBehaviors/CarBoostBehavior.cpp
@@ -11,7 +11,7 @@
 void CarBoostBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
 	GameMessages::SendVehicleAddPassiveBoostAction(branch.target, UNASSIGNED_SYSTEM_ADDRESS);
 
-	auto* entity = EntityManager::Instance()->GetEntity(context->originator);
+	auto* entity = Game::entityManager->GetEntity(context->originator);
 
 	if (entity == nullptr) {
 		return;
@@ -22,7 +22,7 @@ void CarBoostBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitSt
 	auto* possessableComponent = entity->GetComponent<PossessableComponent>();
 	if (possessableComponent != nullptr) {
 
-		auto* possessor = EntityManager::Instance()->GetEntity(possessableComponent->GetPossessor());
+		auto* possessor = Game::entityManager->GetEntity(possessableComponent->GetPossessor());
 		if (possessor != nullptr) {
 
 			auto* characterComponent = possessor->GetComponent<CharacterComponent>();

--- a/dGame/dBehaviors/ChangeOrientationBehavior.cpp
+++ b/dGame/dBehaviors/ChangeOrientationBehavior.cpp
@@ -5,14 +5,14 @@
 
 void ChangeOrientationBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
 	Entity* sourceEntity;
-	if (this->m_orientCaster) sourceEntity = EntityManager::Instance()->GetEntity(context->originator);
-	else sourceEntity = EntityManager::Instance()->GetEntity(branch.target);
+	if (this->m_orientCaster) sourceEntity = Game::entityManager->GetEntity(context->originator);
+	else sourceEntity = Game::entityManager->GetEntity(branch.target);
 	if (!sourceEntity) return;
 
 	if (this->m_toTarget) {
 		Entity* destinationEntity;
-		if (this->m_orientCaster) destinationEntity = EntityManager::Instance()->GetEntity(branch.target);
-		else destinationEntity = EntityManager::Instance()->GetEntity(context->originator);
+		if (this->m_orientCaster) destinationEntity = Game::entityManager->GetEntity(branch.target);
+		else destinationEntity = Game::entityManager->GetEntity(context->originator);
 		if (!destinationEntity) return;
 
 		sourceEntity->SetRotation(
@@ -23,7 +23,7 @@ void ChangeOrientationBehavior::Calculate(BehaviorContext* context, RakNet::BitS
 		if (this->m_relative) baseAngle += sourceEntity->GetRotation().GetForwardVector();
 		sourceEntity->SetRotation(NiQuaternion::FromEulerAngles(baseAngle));
 	} else return;
-	EntityManager::Instance()->SerializeEntity(sourceEntity);
+	Game::entityManager->SerializeEntity(sourceEntity);
 	return;
 }
 

--- a/dGame/dBehaviors/DamageAbsorptionBehavior.cpp
+++ b/dGame/dBehaviors/DamageAbsorptionBehavior.cpp
@@ -8,7 +8,7 @@
 #include "DestroyableComponent.h"
 
 void DamageAbsorptionBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, const BehaviorBranchContext branch) {
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 
 	if (target == nullptr) {
 		Game::logger->Log("DamageAbsorptionBehavior", "Failed to find target (%llu)!", branch.target);
@@ -34,7 +34,7 @@ void DamageAbsorptionBehavior::Calculate(BehaviorContext* context, RakNet::BitSt
 }
 
 void DamageAbsorptionBehavior::Timer(BehaviorContext* context, BehaviorBranchContext branch, const LWOOBJID second) {
-	auto* target = EntityManager::Instance()->GetEntity(second);
+	auto* target = Game::entityManager->GetEntity(second);
 
 	if (target == nullptr) {
 		Game::logger->Log("DamageAbsorptionBehavior", "Failed to find target (%llu)!", second);

--- a/dGame/dBehaviors/DamageReductionBehavior.cpp
+++ b/dGame/dBehaviors/DamageReductionBehavior.cpp
@@ -8,7 +8,7 @@
 #include "DestroyableComponent.h"
 
 void DamageReductionBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, const BehaviorBranchContext branch) {
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 
 	if (target == nullptr) {
 		Game::logger->Log("DamageReductionBehavior", "Failed to find target (%llu)!", branch.target);
@@ -32,7 +32,7 @@ void DamageReductionBehavior::Calculate(BehaviorContext* context, RakNet::BitStr
 }
 
 void DamageReductionBehavior::Timer(BehaviorContext* context, BehaviorBranchContext branch, const LWOOBJID second) {
-	auto* target = EntityManager::Instance()->GetEntity(second);
+	auto* target = Game::entityManager->GetEntity(second);
 
 	if (target == nullptr) {
 		Game::logger->Log("DamageReductionBehavior", "Failed to find target (%llu)!", second);

--- a/dGame/dBehaviors/DarkInspirationBehavior.cpp
+++ b/dGame/dBehaviors/DarkInspirationBehavior.cpp
@@ -7,7 +7,7 @@
 #include "BehaviorContext.h"
 
 void DarkInspirationBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, const BehaviorBranchContext branch) {
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 
 	if (target == nullptr) {
 		Game::logger->LogDebug("DarkInspirationBehavior", "Failed to find target (%llu)!", branch.target);
@@ -26,7 +26,7 @@ void DarkInspirationBehavior::Handle(BehaviorContext* context, RakNet::BitStream
 }
 
 void DarkInspirationBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 
 	if (target == nullptr) {
 		Game::logger->LogDebug("DarkInspirationBehavior", "Failed to find target (%llu)!", branch.target);

--- a/dGame/dBehaviors/FallSpeedBehavior.cpp
+++ b/dGame/dBehaviors/FallSpeedBehavior.cpp
@@ -8,13 +8,13 @@
 void FallSpeedBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
 	// make sure required parameter has non-default value
 	if (m_PercentSlowed == 0.0f) return;
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 	if (!target) return;
 
 	auto* controllablePhysicsComponent = target->GetComponent<ControllablePhysicsComponent>();
 	if (!controllablePhysicsComponent) return;
 	controllablePhysicsComponent->SetGravityScale(m_PercentSlowed);
-	EntityManager::Instance()->SerializeEntity(target);
+	Game::entityManager->SerializeEntity(target);
 
 	if (branch.duration > 0.0f) {
 		context->RegisterTimerBehavior(this, branch);
@@ -36,13 +36,13 @@ void FallSpeedBehavior::UnCast(BehaviorContext* context, BehaviorBranchContext b
 }
 
 void FallSpeedBehavior::End(BehaviorContext* context, BehaviorBranchContext branch, LWOOBJID second) {
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 	if (!target) return;
 
 	auto* controllablePhysicsComponent = target->GetComponent<ControllablePhysicsComponent>();
 	if (!controllablePhysicsComponent) return;
 	controllablePhysicsComponent->SetGravityScale(1);
-	EntityManager::Instance()->SerializeEntity(target);
+	Game::entityManager->SerializeEntity(target);
 }
 
 void FallSpeedBehavior::Load(){

--- a/dGame/dBehaviors/ForceMovementBehavior.cpp
+++ b/dGame/dBehaviors/ForceMovementBehavior.cpp
@@ -42,7 +42,7 @@ void ForceMovementBehavior::Calculate(BehaviorContext* context, RakNet::BitStrea
 		return;
 	}
 
-	auto* casterEntity = EntityManager::Instance()->GetEntity(context->caster);
+	auto* casterEntity = Game::entityManager->GetEntity(context->caster);
 	if (casterEntity != nullptr) {
 		auto* controllablePhysicsComponent = casterEntity->GetComponent<ControllablePhysicsComponent>();
 		if (controllablePhysicsComponent != nullptr) {
@@ -51,7 +51,7 @@ void ForceMovementBehavior::Calculate(BehaviorContext* context, RakNet::BitStrea
 				controllablePhysicsComponent->SetVelocity(controllablePhysicsComponent->GetRotation().GetForwardVector() * 25);
 			}
 
-			EntityManager::Instance()->SerializeEntity(casterEntity);
+			Game::entityManager->SerializeEntity(casterEntity);
 		}
 	}
 
@@ -72,7 +72,7 @@ void ForceMovementBehavior::Load() {
 }
 
 void ForceMovementBehavior::SyncCalculation(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* casterEntity = EntityManager::Instance()->GetEntity(context->caster);
+	auto* casterEntity = Game::entityManager->GetEntity(context->caster);
 	if (casterEntity != nullptr) {
 		auto* controllablePhysicsComponent = casterEntity->GetComponent<ControllablePhysicsComponent>();
 		if (controllablePhysicsComponent != nullptr) {
@@ -80,7 +80,7 @@ void ForceMovementBehavior::SyncCalculation(BehaviorContext* context, RakNet::Bi
 			controllablePhysicsComponent->SetPosition(controllablePhysicsComponent->GetPosition() + controllablePhysicsComponent->GetVelocity() * m_Duration);
 			controllablePhysicsComponent->SetVelocity({});
 
-			EntityManager::Instance()->SerializeEntity(casterEntity);
+			Game::entityManager->SerializeEntity(casterEntity);
 		}
 	}
 

--- a/dGame/dBehaviors/HealBehavior.cpp
+++ b/dGame/dBehaviors/HealBehavior.cpp
@@ -8,7 +8,7 @@
 
 
 void HealBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bit_stream, const BehaviorBranchContext branch) {
-	auto* entity = EntityManager::Instance()->GetEntity(branch.target);
+	auto* entity = Game::entityManager->GetEntity(branch.target);
 
 	if (entity == nullptr) {
 		Game::logger->Log("HealBehavior", "Failed to find entity for (%llu)!", branch.target);

--- a/dGame/dBehaviors/ImaginationBehavior.cpp
+++ b/dGame/dBehaviors/ImaginationBehavior.cpp
@@ -7,7 +7,7 @@
 
 
 void ImaginationBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bit_stream, const BehaviorBranchContext branch) {
-	auto* entity = EntityManager::Instance()->GetEntity(branch.target);
+	auto* entity = Game::entityManager->GetEntity(branch.target);
 
 	if (entity == nullptr) {
 		return;

--- a/dGame/dBehaviors/ImmunityBehavior.cpp
+++ b/dGame/dBehaviors/ImmunityBehavior.cpp
@@ -10,7 +10,7 @@
 #include "eStateChangeType.h"
 
 void ImmunityBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, const BehaviorBranchContext branch) {
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 
 	if (!target) {
 		Game::logger->Log("DamageAbsorptionBehavior", "Failed to find target (%llu)!", branch.target);
@@ -56,7 +56,7 @@ void ImmunityBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bi
 }
 
 void ImmunityBehavior::Timer(BehaviorContext* context, BehaviorBranchContext branch, const LWOOBJID second) {
-	auto* target = EntityManager::Instance()->GetEntity(second);
+	auto* target = Game::entityManager->GetEntity(second);
 
 	if (!target) {
 		Game::logger->Log("DamageAbsorptionBehavior", "Failed to find target (%llu)!", second);

--- a/dGame/dBehaviors/InterruptBehavior.cpp
+++ b/dGame/dBehaviors/InterruptBehavior.cpp
@@ -42,7 +42,7 @@ void InterruptBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitS
 
 	if (branch.target == context->originator) return;
 
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 
 	if (target == nullptr) return;
 
@@ -67,7 +67,7 @@ void InterruptBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* b
 
 	if (branch.target == context->originator) return;
 
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 
 	if (target == nullptr) return;
 

--- a/dGame/dBehaviors/JetPackBehavior.cpp
+++ b/dGame/dBehaviors/JetPackBehavior.cpp
@@ -6,7 +6,7 @@
 #include "Character.h"
 
 void JetPackBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bit_stream, const BehaviorBranchContext branch) {
-	auto* entity = EntityManager::Instance()->GetEntity(branch.target);
+	auto* entity = Game::entityManager->GetEntity(branch.target);
 
 	GameMessages::SendSetJetPackMode(entity, true, this->m_BypassChecks, this->m_EnableHover, this->m_effectId, this->m_Airspeed, this->m_MaxAirspeed, this->m_VerticalVelocity, this->m_WarningEffectID);
 
@@ -20,7 +20,7 @@ void JetPackBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bit_st
 }
 
 void JetPackBehavior::UnCast(BehaviorContext* context, BehaviorBranchContext branch) {
-	auto* entity = EntityManager::Instance()->GetEntity(branch.target);
+	auto* entity = Game::entityManager->GetEntity(branch.target);
 
 	GameMessages::SendSetJetPackMode(entity, false);
 

--- a/dGame/dBehaviors/KnockbackBehavior.cpp
+++ b/dGame/dBehaviors/KnockbackBehavior.cpp
@@ -21,7 +21,7 @@ void KnockbackBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitS
 void KnockbackBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
 	bool blocked = false;
 
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 
 	if (target != nullptr) {
 		auto* destroyableComponent = target->GetComponent<DestroyableComponent>();

--- a/dGame/dBehaviors/LootBuffBehavior.cpp
+++ b/dGame/dBehaviors/LootBuffBehavior.cpp
@@ -1,14 +1,14 @@
 #include "LootBuffBehavior.h"
 
 void LootBuffBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto target = EntityManager::Instance()->GetEntity(context->caster);
+	auto target = Game::entityManager->GetEntity(context->caster);
 	if (!target) return;
 
 	auto controllablePhysicsComponent = target->GetComponent<ControllablePhysicsComponent>();
 	if (!controllablePhysicsComponent) return;
 
 	controllablePhysicsComponent->AddPickupRadiusScale(m_Scale);
-	EntityManager::Instance()->SerializeEntity(target);
+	Game::entityManager->SerializeEntity(target);
 
 	if (branch.duration > 0) context->RegisterTimerBehavior(this, branch);
 
@@ -19,14 +19,14 @@ void LootBuffBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bi
 }
 
 void LootBuffBehavior::UnCast(BehaviorContext* context, BehaviorBranchContext branch) {
-	auto target = EntityManager::Instance()->GetEntity(context->caster);
+	auto target = Game::entityManager->GetEntity(context->caster);
 	if (!target) return;
 
 	auto controllablePhysicsComponent = target->GetComponent<ControllablePhysicsComponent>();
 	if (!controllablePhysicsComponent) return;
 
 	controllablePhysicsComponent->RemovePickupRadiusScale(m_Scale);
-	EntityManager::Instance()->SerializeEntity(target);
+	Game::entityManager->SerializeEntity(target);
 }
 
 void LootBuffBehavior::Timer(BehaviorContext* context, BehaviorBranchContext branch, LWOOBJID second) {

--- a/dGame/dBehaviors/OverTimeBehavior.cpp
+++ b/dGame/dBehaviors/OverTimeBehavior.cpp
@@ -14,13 +14,13 @@
 void OverTimeBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
 	const auto originator = context->originator;
 
-	auto* entity = EntityManager::Instance()->GetEntity(originator);
+	auto* entity = Game::entityManager->GetEntity(originator);
 
 	if (entity == nullptr) return;
 
 	for (size_t i = 0; i < m_NumIntervals; i++) {
 		entity->AddCallbackTimer((i + 1) * m_Delay, [originator, branch, this]() {
-			auto* entity = EntityManager::Instance()->GetEntity(originator);
+			auto* entity = Game::entityManager->GetEntity(originator);
 
 			if (entity == nullptr) return;
 

--- a/dGame/dBehaviors/ProjectileAttackBehavior.cpp
+++ b/dGame/dBehaviors/ProjectileAttackBehavior.cpp
@@ -16,7 +16,7 @@ void ProjectileAttackBehavior::Handle(BehaviorContext* context, RakNet::BitStrea
 		return;
 	};
 
-	auto* entity = EntityManager::Instance()->GetEntity(context->originator);
+	auto* entity = Game::entityManager->GetEntity(context->originator);
 
 	if (entity == nullptr) {
 		Game::logger->Log("ProjectileAttackBehavior", "Failed to find originator (%llu)!", context->originator);
@@ -40,7 +40,7 @@ void ProjectileAttackBehavior::Handle(BehaviorContext* context, RakNet::BitStrea
 		};
 	}
 
-	auto* targetEntity = EntityManager::Instance()->GetEntity(target);
+	auto* targetEntity = Game::entityManager->GetEntity(target);
 
 	for (auto i = 0u; i < this->m_projectileCount; ++i) {
 		LWOOBJID projectileId{};
@@ -61,7 +61,7 @@ void ProjectileAttackBehavior::Handle(BehaviorContext* context, RakNet::BitStrea
 void ProjectileAttackBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
 	bitStream->Write(branch.target);
 
-	auto* entity = EntityManager::Instance()->GetEntity(context->originator);
+	auto* entity = Game::entityManager->GetEntity(context->originator);
 
 	if (entity == nullptr) {
 		Game::logger->Log("ProjectileAttackBehavior", "Failed to find originator (%llu)!", context->originator);
@@ -78,7 +78,7 @@ void ProjectileAttackBehavior::Calculate(BehaviorContext* context, RakNet::BitSt
 
 	}
 
-	auto* other = EntityManager::Instance()->GetEntity(branch.target);
+	auto* other = Game::entityManager->GetEntity(branch.target);
 
 	if (other == nullptr) {
 		Game::logger->Log("ProjectileAttackBehavior", "Invalid projectile target (%llu)!", branch.target);

--- a/dGame/dBehaviors/PropertyTeleportBehavior.cpp
+++ b/dGame/dBehaviors/PropertyTeleportBehavior.cpp
@@ -12,7 +12,7 @@
 #include "dZoneManager.h"
 
 void PropertyTeleportBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* caster = EntityManager::Instance()->GetEntity(context->caster);
+	auto* caster = Game::entityManager->GetEntity(context->caster);
 	if (!caster) return;
 
 	auto* character = caster->GetCharacter();
@@ -32,7 +32,7 @@ void PropertyTeleportBehavior::Handle(BehaviorContext* context, RakNet::BitStrea
 
 	ZoneInstanceManager::Instance()->RequestZoneTransfer(Game::server, targetMapId, targetCloneId, false, [objId](bool mythranShift, uint32_t zoneID, uint32_t zoneInstance, uint32_t zoneClone, std::string serverIP, uint16_t serverPort) {
 
-		auto* entity = EntityManager::Instance()->GetEntity(objId);
+		auto* entity = Game::entityManager->GetEntity(objId);
 		if (!entity) return;
 
 		const auto sysAddr = entity->GetSystemAddress();

--- a/dGame/dBehaviors/PullToPointBehavior.cpp
+++ b/dGame/dBehaviors/PullToPointBehavior.cpp
@@ -6,9 +6,9 @@
 #include "MovementAIComponent.h"
 
 void PullToPointBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* entity = EntityManager::Instance()->GetEntity(context->originator);
+	auto* entity = Game::entityManager->GetEntity(context->originator);
 
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 
 	if (entity == nullptr || target == nullptr) {
 		return;

--- a/dGame/dBehaviors/RemoveBuffBehavior.cpp
+++ b/dGame/dBehaviors/RemoveBuffBehavior.cpp
@@ -6,7 +6,7 @@
 #include "BuffComponent.h"
 
 void RemoveBuffBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* entity = EntityManager::Instance()->GetEntity(context->caster);
+	auto* entity = Game::entityManager->GetEntity(context->caster);
 	if (!entity) return;
 
 	auto* buffComponent = entity->GetComponent<BuffComponent>();

--- a/dGame/dBehaviors/RepairBehavior.cpp
+++ b/dGame/dBehaviors/RepairBehavior.cpp
@@ -8,7 +8,7 @@
 #include "eReplicaComponentType.h"
 
 void RepairBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bit_stream, const BehaviorBranchContext branch) {
-	auto* entity = EntityManager::Instance()->GetEntity(branch.target);
+	auto* entity = Game::entityManager->GetEntity(branch.target);
 
 	if (entity == nullptr) {
 		Game::logger->Log("RepairBehavior", "Failed to find entity for (%llu)!", branch.target);

--- a/dGame/dBehaviors/SkillEventBehavior.cpp
+++ b/dGame/dBehaviors/SkillEventBehavior.cpp
@@ -5,8 +5,8 @@
 #include "CppScripts.h"
 
 void SkillEventBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
-	auto* caster = EntityManager::Instance()->GetEntity(context->originator);
+	auto* target = Game::entityManager->GetEntity(branch.target);
+	auto* caster = Game::entityManager->GetEntity(context->originator);
 
 	if (caster != nullptr && target != nullptr && this->m_effectHandle != nullptr && !this->m_effectHandle->empty()) {
 		for (CppScripts::Script* script : CppScripts::GetEntityScripts(target)) {
@@ -17,8 +17,8 @@ void SkillEventBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bit
 
 void
 SkillEventBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
-	auto* caster = EntityManager::Instance()->GetEntity(context->originator);
+	auto* target = Game::entityManager->GetEntity(branch.target);
+	auto* caster = Game::entityManager->GetEntity(context->originator);
 
 	if (caster != nullptr && target != nullptr && this->m_effectHandle != nullptr && !this->m_effectHandle->empty()) {
 		for (CppScripts::Script* script : CppScripts::GetEntityScripts(target)) {

--- a/dGame/dBehaviors/SpawnBehavior.cpp
+++ b/dGame/dBehaviors/SpawnBehavior.cpp
@@ -12,7 +12,7 @@
 #include "eReplicaComponentType.h"
 
 void SpawnBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* origin = EntityManager::Instance()->GetEntity(context->originator);
+	auto* origin = Game::entityManager->GetEntity(context->originator);
 
 	if (origin == nullptr) {
 		Game::logger->Log("SpawnBehavior", "Failed to find self entity (%llu)!", context->originator);
@@ -21,7 +21,7 @@ void SpawnBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStrea
 	}
 
 	if (branch.isProjectile) {
-		auto* target = EntityManager::Instance()->GetEntity(branch.target);
+		auto* target = Game::entityManager->GetEntity(branch.target);
 
 		if (target != nullptr) {
 			origin = target;
@@ -38,10 +38,10 @@ void SpawnBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStrea
 	info.spawnerNodeID = 0;
 	info.pos = info.pos + (info.rot.GetForwardVector() * m_Distance);
 
-	auto* entity = EntityManager::Instance()->CreateEntity(
+	auto* entity = Game::entityManager->CreateEntity(
 		info,
 		nullptr,
-		EntityManager::Instance()->GetEntity(context->originator)
+		Game::entityManager->GetEntity(context->originator)
 	);
 
 	if (entity == nullptr) {
@@ -59,7 +59,7 @@ void SpawnBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStrea
 		rebuildComponent->SetRepositionPlayer(false);
 	}
 
-	EntityManager::Instance()->ConstructEntity(entity);
+	Game::entityManager->ConstructEntity(entity);
 
 	if (branch.duration > 0) {
 		context->RegisterTimerBehavior(this, branch, entity->GetObjectID());
@@ -79,7 +79,7 @@ void SpawnBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitSt
 }
 
 void SpawnBehavior::Timer(BehaviorContext* context, const BehaviorBranchContext branch, const LWOOBJID second) {
-	auto* entity = EntityManager::Instance()->GetEntity(second);
+	auto* entity = Game::entityManager->GetEntity(second);
 
 	if (entity == nullptr) {
 		Game::logger->Log("SpawnBehavior", "Failed to find spawned entity (%llu)!", second);

--- a/dGame/dBehaviors/SpeedBehavior.cpp
+++ b/dGame/dBehaviors/SpeedBehavior.cpp
@@ -9,14 +9,14 @@
 void SpeedBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
 	if (m_AffectsCaster) branch.target = context->caster;
 
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 	if (!target) return;
 
 	auto* controllablePhysicsComponent = target->GetComponent<ControllablePhysicsComponent>();
 	if (!controllablePhysicsComponent) return;
 
 	controllablePhysicsComponent->AddSpeedboost(m_RunSpeed);
-	EntityManager::Instance()->SerializeEntity(target);
+	Game::entityManager->SerializeEntity(target);
 
 	if (branch.duration > 0.0f) {
 		context->RegisterTimerBehavior(this, branch);
@@ -38,14 +38,14 @@ void SpeedBehavior::Timer(BehaviorContext* context, BehaviorBranchContext branch
 }
 
 void SpeedBehavior::End(BehaviorContext* context, BehaviorBranchContext branch, LWOOBJID second) {
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 	if (!target) return;
 
 	auto* controllablePhysicsComponent = target->GetComponent<ControllablePhysicsComponent>();
 	if (!controllablePhysicsComponent) return;
 
 	controllablePhysicsComponent->RemoveSpeedboost(m_RunSpeed);
-	EntityManager::Instance()->SerializeEntity(target);
+	Game::entityManager->SerializeEntity(target);
 }
 
 void SpeedBehavior::Load() {

--- a/dGame/dBehaviors/StunBehavior.cpp
+++ b/dGame/dBehaviors/StunBehavior.cpp
@@ -21,7 +21,7 @@ void StunBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream
 		return;
 	};
 
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 
 	if (target == nullptr) {
 		Game::logger->Log("StunBehavior", "Failed to find target (%llu)!", branch.target);
@@ -44,7 +44,7 @@ void StunBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream
 
 void StunBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, const BehaviorBranchContext branch) {
 	if (this->m_stunCaster || branch.target == context->originator) {
-		auto* self = EntityManager::Instance()->GetEntity(context->originator);
+		auto* self = Game::entityManager->GetEntity(context->originator);
 
 		if (self == nullptr) {
 			Game::logger->Log("StunBehavior", "Invalid self entity (%llu)!", context->originator);
@@ -69,7 +69,7 @@ void StunBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitStr
 
 	bool blocked = false;
 
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 
 	if (target != nullptr) {
 		auto* destroyableComponent = target->GetComponent<DestroyableComponent>();

--- a/dGame/dBehaviors/SwitchBehavior.cpp
+++ b/dGame/dBehaviors/SwitchBehavior.cpp
@@ -16,7 +16,7 @@ void SwitchBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStre
 		};
 	}
 
-	auto* entity = EntityManager::Instance()->GetEntity(context->originator);
+	auto* entity = Game::entityManager->GetEntity(context->originator);
 
 	if (entity == nullptr) {
 		return;
@@ -41,7 +41,7 @@ void SwitchBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitS
 	auto state = true;
 
 	if (this->m_imagination > 0 || !this->m_isEnemyFaction) {
-		auto* entity = EntityManager::Instance()->GetEntity(branch.target);
+		auto* entity = Game::entityManager->GetEntity(branch.target);
 
 		state = entity != nullptr;
 

--- a/dGame/dBehaviors/TacArcBehavior.cpp
+++ b/dGame/dBehaviors/TacArcBehavior.cpp
@@ -76,7 +76,7 @@ void TacArcBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStre
 }
 
 void TacArcBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* self = EntityManager::Instance()->GetEntity(context->originator);
+	auto* self = Game::entityManager->GetEntity(context->originator);
 	if (self == nullptr) {
 		Game::logger->Log("TacArcBehavior", "Invalid self for (%llu)!", context->originator);
 		return;
@@ -85,7 +85,7 @@ void TacArcBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitS
 	const auto* destroyableComponent = self->GetComponent<DestroyableComponent>();
 
 	if ((this->m_usePickedTarget || context->clientInitalized) && branch.target > 0) {
-		const auto* target = EntityManager::Instance()->GetEntity(branch.target);
+		const auto* target = Game::entityManager->GetEntity(branch.target);
 
 		if (target == nullptr) {
 			return;
@@ -120,7 +120,7 @@ void TacArcBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitS
 	// Find all valid targets, based on whether we target enemies or friends
 	for (const auto& contextTarget : context->GetValidTargets()) {
 		if (destroyableComponent != nullptr) {
-			const auto* targetEntity = EntityManager::Instance()->GetEntity(contextTarget);
+			const auto* targetEntity = Game::entityManager->GetEntity(contextTarget);
 
 			if (m_targetEnemy && destroyableComponent->IsEnemy(targetEntity)
 				|| m_targetFriend && destroyableComponent->IsFriend(targetEntity)) {
@@ -136,7 +136,7 @@ void TacArcBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitS
 			break;
 		}
 
-		auto* entity = EntityManager::Instance()->GetEntity(validTarget);
+		auto* entity = Game::entityManager->GetEntity(validTarget);
 
 		if (entity == nullptr) {
 			Game::logger->Log("TacArcBehavior", "Invalid target (%llu) for (%llu)!", validTarget, context->originator);

--- a/dGame/dBehaviors/TauntBehavior.cpp
+++ b/dGame/dBehaviors/TauntBehavior.cpp
@@ -7,7 +7,7 @@
 
 
 void TauntBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 
 	if (target == nullptr) {
 		Game::logger->Log("TauntBehavior", "Failed to find target (%llu)!", branch.target);
@@ -23,7 +23,7 @@ void TauntBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStrea
 }
 
 void TauntBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* target = EntityManager::Instance()->GetEntity(branch.target);
+	auto* target = Game::entityManager->GetEntity(branch.target);
 
 	if (target == nullptr) {
 		Game::logger->Log("TauntBehavior", "Failed to find target (%llu)!", branch.target);

--- a/dGame/dBehaviors/VentureVisionBehavior.cpp
+++ b/dGame/dBehaviors/VentureVisionBehavior.cpp
@@ -5,7 +5,7 @@
 
 void VentureVisionBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
 
-	const auto targetEntity = EntityManager::Instance()->GetEntity(branch.target);
+	const auto targetEntity = Game::entityManager->GetEntity(branch.target);
 
 	if (targetEntity) {
 		auto characterComponent = targetEntity->GetComponent<CharacterComponent>();
@@ -21,7 +21,7 @@ void VentureVisionBehavior::Handle(BehaviorContext* context, RakNet::BitStream* 
 }
 
 void VentureVisionBehavior::UnCast(BehaviorContext* context, BehaviorBranchContext branch) {
-	const auto targetEntity = EntityManager::Instance()->GetEntity(branch.target);
+	const auto targetEntity = Game::entityManager->GetEntity(branch.target);
 
 	if (targetEntity) {
 		auto characterComponent = targetEntity->GetComponent<CharacterComponent>();

--- a/dGame/dBehaviors/VerifyBehavior.cpp
+++ b/dGame/dBehaviors/VerifyBehavior.cpp
@@ -8,14 +8,14 @@
 
 
 void VerifyBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitStream, BehaviorBranchContext branch) {
-	auto* entity = EntityManager::Instance()->GetEntity(branch.target);
+	auto* entity = Game::entityManager->GetEntity(branch.target);
 
 	auto success = true;
 
 	if (entity == nullptr) {
 		success = false;
 	} else if (this->m_rangeCheck) {
-		auto* self = EntityManager::Instance()->GetEntity(context->originator);
+		auto* self = Game::entityManager->GetEntity(context->originator);
 
 		if (self == nullptr) {
 			Game::logger->Log("VerifyBehavior", "Invalid self for (%llu)", context->originator);

--- a/dGame/dComponents/BaseCombatAIComponent.cpp
+++ b/dGame/dComponents/BaseCombatAIComponent.cpp
@@ -173,7 +173,7 @@ void BaseCombatAIComponent::Update(const float deltaTime) {
 	}
 
 	if (m_SoftTimer <= 0.0f) {
-		EntityManager::Instance()->SerializeEntity(m_Parent);
+		Game::entityManager->SerializeEntity(m_Parent);
 
 		m_SoftTimer = 5.0f;
 	} else {
@@ -305,7 +305,7 @@ void BaseCombatAIComponent::CalculateCombat(const float deltaTime) {
 			}
 
 			if (serilizationRequired) {
-				EntityManager::Instance()->SerializeEntity(m_Parent);
+				Game::entityManager->SerializeEntity(m_Parent);
 			}
 
 			GameMessages::SendPlayFXEffect(m_Parent->GetObjectID(), 6270, u"tether", "tether");
@@ -412,7 +412,7 @@ LWOOBJID BaseCombatAIComponent::FindTarget() {
 	float biggestThreat = 0;
 
 	for (const auto& entry : possibleTargets) {
-		auto* entity = EntityManager::Instance()->GetEntity(entry);
+		auto* entity = Game::entityManager->GetEntity(entry);
 
 		if (entity == nullptr) {
 			continue;
@@ -458,7 +458,7 @@ LWOOBJID BaseCombatAIComponent::FindTarget() {
 	std::vector<LWOOBJID> deadThreats{};
 
 	for (const auto& threatTarget : m_ThreatEntries) {
-		auto* entity = EntityManager::Instance()->GetEntity(threatTarget.first);
+		auto* entity = Game::entityManager->GetEntity(threatTarget.first);
 
 		if (entity == nullptr) {
 			deadThreats.push_back(threatTarget.first);
@@ -497,7 +497,7 @@ std::vector<LWOOBJID> BaseCombatAIComponent::GetTargetWithinAggroRange() const {
 	std::vector<LWOOBJID> targets;
 
 	for (auto id : m_Parent->GetTargetsInPhantom()) {
-		auto* other = EntityManager::Instance()->GetEntity(id);
+		auto* other = Game::entityManager->GetEntity(id);
 
 		const auto distance = Vector3::DistanceSquared(m_Parent->GetPosition(), other->GetPosition());
 
@@ -535,11 +535,11 @@ void BaseCombatAIComponent::SetAiState(AiState newState) {
 	if (newState == this->m_State) return;
 	this->m_State = newState;
 	m_DirtyStateOrTarget = true;
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 bool BaseCombatAIComponent::IsEnemy(LWOOBJID target) const {
-	auto* entity = EntityManager::Instance()->GetEntity(target);
+	auto* entity = Game::entityManager->GetEntity(target);
 
 	if (entity == nullptr) {
 		Game::logger->Log("BaseCombatAIComponent", "Invalid entity for checking validity (%llu)!", target);
@@ -588,11 +588,11 @@ void BaseCombatAIComponent::SetTarget(const LWOOBJID target) {
 	if (this->m_Target == target) return;
 	m_Target = target;
 	m_DirtyStateOrTarget = true;
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 Entity* BaseCombatAIComponent::GetTargetEntity() const {
-	return EntityManager::Instance()->GetEntity(m_Target);
+	return Game::entityManager->GetEntity(m_Target);
 }
 
 void BaseCombatAIComponent::Taunt(LWOOBJID offender, float threat) {

--- a/dGame/dComponents/BouncerComponent.cpp
+++ b/dGame/dComponents/BouncerComponent.cpp
@@ -36,7 +36,7 @@ Entity* BouncerComponent::GetParentEntity() const {
 void BouncerComponent::SetPetEnabled(bool value) {
 	m_PetEnabled = value;
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void BouncerComponent::SetPetBouncerEnabled(bool value) {
@@ -44,7 +44,7 @@ void BouncerComponent::SetPetBouncerEnabled(bool value) {
 
 	GameMessages::SendBouncerActiveStatus(m_Parent->GetObjectID(), value, UNASSIGNED_SYSTEM_ADDRESS);
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	if (value) {
 		m_Parent->TriggerEvent(eTriggerEventType::PET_ON_SWITCH, m_Parent);
@@ -68,7 +68,7 @@ void BouncerComponent::LookupPetSwitch() {
 	const auto& groups = m_Parent->GetGroups();
 
 	for (const auto& group : groups) {
-		const auto& entities = EntityManager::Instance()->GetEntitiesInGroup(group);
+		const auto& entities = Game::entityManager->GetEntitiesInGroup(group);
 
 		for (auto* entity : entities) {
 			auto* switchComponent = entity->GetComponent<SwitchComponent>();
@@ -79,7 +79,7 @@ void BouncerComponent::LookupPetSwitch() {
 				m_PetSwitchLoaded = true;
 				m_PetEnabled = true;
 
-				EntityManager::Instance()->SerializeEntity(m_Parent);
+				Game::entityManager->SerializeEntity(m_Parent);
 
 				Game::logger->Log("BouncerComponent", "Loaded pet bouncer");
 			}

--- a/dGame/dComponents/BuildBorderComponent.cpp
+++ b/dGame/dComponents/BuildBorderComponent.cpp
@@ -17,7 +17,7 @@ BuildBorderComponent::~BuildBorderComponent() {
 
 void BuildBorderComponent::OnUse(Entity* originator) {
 	if (originator->GetCharacter()) {
-		const auto& entities = EntityManager::Instance()->GetEntitiesInGroup("PropertyPlaque");
+		const auto& entities = Game::entityManager->GetEntitiesInGroup("PropertyPlaque");
 
 		auto buildArea = m_Parent->GetObjectID();
 

--- a/dGame/dComponents/ControllablePhysicsComponent.cpp
+++ b/dGame/dComponents/ControllablePhysicsComponent.cpp
@@ -300,7 +300,7 @@ void ControllablePhysicsComponent::RemovePickupRadiusScale(float value) {
 		auto candidateRadius = m_ActivePickupRadiusScales[i];
 		if (m_PickupRadius < candidateRadius) m_PickupRadius = candidateRadius;
 	}
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void ControllablePhysicsComponent::AddSpeedboost(float value) {
@@ -327,7 +327,7 @@ void ControllablePhysicsComponent::RemoveSpeedboost(float value) {
 		m_SpeedBoost = m_ActiveSpeedBoosts.back();
 	}
 	SetSpeedMultiplier(m_SpeedBoost / 500.0f); // 500 being the base speed
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void ControllablePhysicsComponent::ActivateBubbleBuff(eBubbleType bubbleType, bool specialAnims){
@@ -339,13 +339,13 @@ void ControllablePhysicsComponent::ActivateBubbleBuff(eBubbleType bubbleType, bo
 	m_IsInBubble = true;
 	m_DirtyBubble = true;
 	m_SpecialAnims = specialAnims;
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void ControllablePhysicsComponent::DeactivateBubbleBuff(){
 	m_DirtyBubble = true;
 	m_IsInBubble = false;
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 };
 
 void ControllablePhysicsComponent::SetStunImmunity(

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -253,7 +253,7 @@ void DestroyableComponent::SetMaxHealth(float value, bool playAnim) {
 		GameMessages::SendUIMessageServerToSingleClient(m_Parent, m_Parent->GetParentUser()->GetSystemAddress(), "MaxPlayerBarUpdate", args);
 	}
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void DestroyableComponent::SetArmor(int32_t value) {
@@ -294,7 +294,7 @@ void DestroyableComponent::SetMaxArmor(float value, bool playAnim) {
 		GameMessages::SendUIMessageServerToSingleClient(m_Parent, m_Parent->GetParentUser()->GetSystemAddress(), "MaxPlayerBarUpdate", args);
 	}
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void DestroyableComponent::SetImagination(int32_t value) {
@@ -333,7 +333,7 @@ void DestroyableComponent::SetMaxImagination(float value, bool playAnim) {
 
 		GameMessages::SendUIMessageServerToSingleClient(m_Parent, m_Parent->GetParentUser()->GetSystemAddress(), "MaxPlayerBarUpdate", args);
 	}
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void DestroyableComponent::SetDamageToAbsorb(int32_t value) {
@@ -482,11 +482,11 @@ LWOOBJID DestroyableComponent::GetKillerID() const {
 }
 
 Entity* DestroyableComponent::GetKiller() const {
-	return EntityManager::Instance()->GetEntity(m_KillerID);
+	return Game::entityManager->GetEntity(m_KillerID);
 }
 
 bool DestroyableComponent::CheckValidity(const LWOOBJID target, const bool ignoreFactions, const bool targetEnemy, const bool targetFriend) const {
-	auto* targetEntity = EntityManager::Instance()->GetEntity(target);
+	auto* targetEntity = Game::entityManager->GetEntity(target);
 
 	if (targetEntity == nullptr) {
 		Game::logger->Log("DestroyableComponent", "Invalid entity for checking validity (%llu)!", target);
@@ -532,7 +532,7 @@ void DestroyableComponent::Heal(const uint32_t health) {
 
 	SetHealth(current);
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 
@@ -550,7 +550,7 @@ void DestroyableComponent::Imagine(const int32_t deltaImagination) {
 
 	SetImagination(current);
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 
@@ -564,7 +564,7 @@ void DestroyableComponent::Repair(const uint32_t armor) {
 
 	SetArmor(current);
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 
@@ -626,7 +626,7 @@ void DestroyableComponent::Damage(uint32_t damage, const LWOOBJID source, uint32
 	if (possessor) {
 		auto possessableId = possessor->GetPossessable();
 		if (possessableId != LWOOBJID_EMPTY) {
-			auto possessable = EntityManager::Instance()->GetEntity(possessableId);
+			auto possessable = Game::entityManager->GetEntity(possessableId);
 			if (possessable) {
 				possessor->Dismount(possessable);
 			}
@@ -638,10 +638,10 @@ void DestroyableComponent::Damage(uint32_t damage, const LWOOBJID source, uint32
 	}
 
 	if (echo) {
-		EntityManager::Instance()->SerializeEntity(m_Parent);
+		Game::entityManager->SerializeEntity(m_Parent);
 	}
 
-	auto* attacker = EntityManager::Instance()->GetEntity(source);
+	auto* attacker = Game::entityManager->GetEntity(source);
 	m_Parent->OnHit(attacker);
 	m_Parent->OnHitOrHealResult(attacker, sourceDamage);
 	NotifySubscribers(attacker, sourceDamage);
@@ -661,7 +661,7 @@ void DestroyableComponent::Damage(uint32_t damage, const LWOOBJID source, uint32
 	}
 
 	//check if hardcore mode is enabled
-    if (EntityManager::Instance()->GetHardcoreMode()) {
+    if (Game::entityManager->GetHardcoreMode()) {
 		DoHardcoreModeDrops(source);
     }
 
@@ -696,12 +696,12 @@ void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType
 		SetArmor(0);
 		SetHealth(0);
 
-		EntityManager::Instance()->SerializeEntity(m_Parent);
+		Game::entityManager->SerializeEntity(m_Parent);
 	}
 
 	m_KillerID = source;
 
-	auto* owner = EntityManager::Instance()->GetEntity(source);
+	auto* owner = Game::entityManager->GetEntity(source);
 
 	if (owner != nullptr) {
 		owner = owner->GetOwner(); // If the owner is overwritten, we collect that here
@@ -721,7 +721,7 @@ void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType
 		if (missions != nullptr) {
 			if (team != nullptr) {
 				for (const auto memberId : team->members) {
-					auto* member = EntityManager::Instance()->GetEntity(memberId);
+					auto* member = Game::entityManager->GetEntity(memberId);
 
 					if (member == nullptr) continue;
 
@@ -761,12 +761,12 @@ void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType
 				if (team->lootOption == 0) { // Round robin
 					specificOwner = TeamManager::Instance()->GetNextLootOwner(team);
 
-					auto* member = EntityManager::Instance()->GetEntity(specificOwner);
+					auto* member = Game::entityManager->GetEntity(specificOwner);
 
 					if (member) LootGenerator::Instance().DropLoot(member, m_Parent, lootMatrixId, GetMinCoins(), GetMaxCoins());
 				} else {
 					for (const auto memberId : team->members) { // Free for all
-						auto* member = EntityManager::Instance()->GetEntity(memberId);
+						auto* member = Game::entityManager->GetEntity(memberId);
 
 						if (member == nullptr) continue;
 
@@ -797,12 +797,12 @@ void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType
 			}
 		}
 
-		Entity* zoneControl = EntityManager::Instance()->GetZoneControlEntity();
+		Entity* zoneControl = Game::entityManager->GetZoneControlEntity();
 		for (CppScripts::Script* script : CppScripts::GetEntityScripts(zoneControl)) {
 			script->OnPlayerDied(zoneControl, m_Parent);
 		}
 
-		std::vector<Entity*> scriptedActs = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::SCRIPTED_ACTIVITY);
+		std::vector<Entity*> scriptedActs = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SCRIPTED_ACTIVITY);
 		for (Entity* scriptEntity : scriptedActs) {
 			if (scriptEntity->GetObjectID() != zoneControl->GetObjectID()) { // Don't want to trigger twice on instance worlds
 				for (CppScripts::Script* script : CppScripts::GetEntityScripts(scriptEntity)) {
@@ -965,7 +965,7 @@ void DestroyableComponent::FixStats() {
 	destroyableComponent->SetImagination(currentImagination);
 
 	// Serialize the entity
-	EntityManager::Instance()->SerializeEntity(entity);
+	Game::entityManager->SerializeEntity(entity);
 }
 
 void DestroyableComponent::AddOnHitCallback(const std::function<void(Entity*)>& callback) {
@@ -979,12 +979,12 @@ void DestroyableComponent::DoHardcoreModeDrops(const LWOOBJID source){
 		auto* character = m_Parent->GetComponent<CharacterComponent>();
 		auto uscore = character->GetUScore();
 
-		auto uscoreToLose = uscore * (EntityManager::Instance()->GetHardcoreLoseUscoreOnDeathPercent() / 100);
+		auto uscoreToLose = uscore * (Game::entityManager->GetHardcoreLoseUscoreOnDeathPercent() / 100);
 		character->SetUScore(uscore - uscoreToLose);
 
 		GameMessages::SendModifyLEGOScore(m_Parent, m_Parent->GetSystemAddress(), -uscoreToLose, eLootSourceType::MISSION);
 
-		if (EntityManager::Instance()->GetHardcoreDropinventoryOnDeath()) {
+		if (Game::entityManager->GetHardcoreDropinventoryOnDeath()) {
 			//drop all items from inventory:
 			auto* inventory = m_Parent->GetComponent<InventoryComponent>();
 			if (inventory) {
@@ -1001,7 +1001,7 @@ void DestroyableComponent::DoHardcoreModeDrops(const LWOOBJID source){
 							GameMessages::SendDropClientLoot(m_Parent, source, item.second->GetLot(), 0, m_Parent->GetPosition(), item.second->GetCount());
 							item.second->SetCount(0, false, false);
 						}
-						EntityManager::Instance()->SerializeEntity(m_Parent);
+						Game::entityManager->SerializeEntity(m_Parent);
 					}
 				}
 			}
@@ -1021,25 +1021,25 @@ void DestroyableComponent::DoHardcoreModeDrops(const LWOOBJID source){
 
 		// Reload the player since we can't normally reduce uscore from the server and we want the UI to update
 		// do this last so we don't get killed.... again
-		EntityManager::Instance()->DestructEntity(m_Parent);
-		EntityManager::Instance()->ConstructEntity(m_Parent);
+		Game::entityManager->DestructEntity(m_Parent);
+		Game::entityManager->ConstructEntity(m_Parent);
 		return;
 	}
 
 	//award the player some u-score:
-	auto* player = EntityManager::Instance()->GetEntity(source);
+	auto* player = Game::entityManager->GetEntity(source);
 	if (player && player->IsPlayer()) {
 		auto* playerStats = player->GetComponent<CharacterComponent>();
 		if (playerStats) {
 			//get the maximum health from this enemy:
 			auto maxHealth = GetMaxHealth();
 
-			int uscore = maxHealth * EntityManager::Instance()->GetHardcoreUscoreEnemiesMultiplier();
+			int uscore = maxHealth * Game::entityManager->GetHardcoreUscoreEnemiesMultiplier();
 
 			playerStats->SetUScore(playerStats->GetUScore() + uscore);
 			GameMessages::SendModifyLEGOScore(player, player->GetSystemAddress(), uscore, eLootSourceType::MISSION);
 
-			EntityManager::Instance()->SerializeEntity(m_Parent);
+			Game::entityManager->SerializeEntity(m_Parent);
 		}
 	}
 }

--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -826,7 +826,7 @@ void InventoryComponent::EquipItem(Item* item, const bool skipChecks) {
 	if (character != nullptr && !skipChecks) {
 		// Hacky proximity rocket
 		if (item->GetLot() == 6416) {
-			const auto rocketLauchPads = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::ROCKET_LAUNCH);
+			const auto rocketLauchPads = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::ROCKET_LAUNCH);
 
 			const auto position = m_Parent->GetPosition();
 
@@ -887,7 +887,7 @@ void InventoryComponent::EquipItem(Item* item, const bool skipChecks) {
 
 	EquipScripts(item);
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void InventoryComponent::UnEquipItem(Item* item) {
@@ -917,7 +917,7 @@ void InventoryComponent::UnEquipItem(Item* item) {
 
 	UnequipScripts(item);
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	// Trigger property event
 	if (PropertyManagementComponent::Instance() != nullptr && item->GetCount() > 0 && Inventory::FindInventoryTypeForLot(item->GetLot()) == MODELS) {
@@ -968,7 +968,7 @@ void InventoryComponent::HandlePossession(Item* item) {
 	if (possessorComponent->GetIsDismounting()) return;
 
 	// Check to see if we are already mounting something
-	auto* currentlyPossessedEntity = EntityManager::Instance()->GetEntity(possessorComponent->GetPossessable());
+	auto* currentlyPossessedEntity = Game::entityManager->GetEntity(possessorComponent->GetPossessable());
 	auto currentlyPossessedItem = possessorComponent->GetMountItemID();
 
 	if (currentlyPossessedItem) {
@@ -991,7 +991,7 @@ void InventoryComponent::HandlePossession(Item* item) {
 	info.rot = startRotation;
 	info.spawnerID = m_Parent->GetObjectID();
 
-	auto* mount = EntityManager::Instance()->CreateEntity(info, nullptr, m_Parent);
+	auto* mount = Game::entityManager->CreateEntity(info, nullptr, m_Parent);
 
 	// Check to see if the mount is a vehicle, if so, flip it
 	auto* vehicleComponent = mount->GetComponent<VehiclePhysicsComponent>();
@@ -1016,9 +1016,9 @@ void InventoryComponent::HandlePossession(Item* item) {
 	GameMessages::SendSetJetPackMode(m_Parent, false);
 
 	// Make it go to the client
-	EntityManager::Instance()->ConstructEntity(mount);
+	Game::entityManager->ConstructEntity(mount);
 	// Update the possessor
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	// have to unlock the input so it vehicle can be driven
 	if (vehicleComponent) GameMessages::SendVehicleUnlockInput(mount->GetObjectID(), false, m_Parent->GetSystemAddress());
@@ -1080,7 +1080,7 @@ void InventoryComponent::PopEquippedItems() {
 		destroyableComponent->SetHealth(static_cast<int32_t>(destroyableComponent->GetMaxHealth()));
 		destroyableComponent->SetArmor(static_cast<int32_t>(destroyableComponent->GetMaxArmor()));
 		destroyableComponent->SetImagination(static_cast<int32_t>(destroyableComponent->GetMaxImagination()));
-		EntityManager::Instance()->SerializeEntity(m_Parent);
+		Game::entityManager->SerializeEntity(m_Parent);
 	}
 
 	m_Dirty = true;
@@ -1256,7 +1256,7 @@ void InventoryComponent::SpawnPet(Item* item) {
 	info.rot = NiQuaternion::IDENTITY;
 	info.spawnerID = m_Parent->GetObjectID();
 
-	auto* pet = EntityManager::Instance()->CreateEntity(info);
+	auto* pet = Game::entityManager->CreateEntity(info);
 
 	auto* petComponent = pet->GetComponent<PetComponent>();
 
@@ -1264,7 +1264,7 @@ void InventoryComponent::SpawnPet(Item* item) {
 		petComponent->Activate(item);
 	}
 
-	EntityManager::Instance()->ConstructEntity(pet);
+	Game::entityManager->ConstructEntity(pet);
 }
 
 void InventoryComponent::SetDatabasePet(LWOOBJID id, const DatabasePet& data) {
@@ -1373,7 +1373,7 @@ void InventoryComponent::SetNPCItems(const std::vector<LOT>& items) {
 		UpdateSlot(info.equipLocation, { id, static_cast<LOT>(item), 1, slot++ }, true);
 	}
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 InventoryComponent::~InventoryComponent() {

--- a/dGame/dComponents/LUPExhibitComponent.cpp
+++ b/dGame/dComponents/LUPExhibitComponent.cpp
@@ -35,7 +35,7 @@ void LUPExhibitComponent::NextExhibit() {
 
 	m_Exhibit = m_Exhibits[m_ExhibitIndex];
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void LUPExhibitComponent::Serialize(RakNet::BitStream* outBitStream, bool bIsInitialUpdate, uint32_t& flags) {

--- a/dGame/dComponents/MovementAIComponent.cpp
+++ b/dGame/dComponents/MovementAIComponent.cpp
@@ -149,7 +149,7 @@ nextAction:
 
 	SetVelocity(velocity);
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 const MovementAIInfo& MovementAIComponent::GetInfo() const {
@@ -221,7 +221,7 @@ bool MovementAIComponent::Warp(const NiPoint3& point) {
 
 	SetPosition(destination);
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	return true;
 }
@@ -253,7 +253,7 @@ void MovementAIComponent::Stop() {
 
 	m_CurrentSpeed = 0;
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void MovementAIComponent::PullToPoint(const NiPoint3& point) {

--- a/dGame/dComponents/MovingPlatformComponent.cpp
+++ b/dGame/dComponents/MovingPlatformComponent.cpp
@@ -133,7 +133,7 @@ void MovingPlatformComponent::SetMovementState(eMovementPlatformState value) {
 
 	subComponent->mState = value;
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void MovingPlatformComponent::GotoWaypoint(uint32_t index, bool stopAtWaypoint) {
@@ -194,7 +194,7 @@ void MovingPlatformComponent::StartPathing() {
 
 	//GameMessages::SendPlatformResync(m_Parent, UNASSIGNED_SYSTEM_ADDRESS);
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void MovingPlatformComponent::ContinuePathing() {
@@ -242,7 +242,7 @@ void MovingPlatformComponent::ContinuePathing() {
 		subComponent->mCurrentWaypointIndex = pathSize;
 		switch (behavior) {
 		case PathBehavior::Once:
-			EntityManager::Instance()->SerializeEntity(m_Parent);
+			Game::entityManager->SerializeEntity(m_Parent);
 			return;
 
 		case PathBehavior::Bounce:
@@ -304,7 +304,7 @@ void MovingPlatformComponent::ContinuePathing() {
 		ContinuePathing();
 		});
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void MovingPlatformComponent::StopPathing() {
@@ -318,7 +318,7 @@ void MovingPlatformComponent::StopPathing() {
 	subComponent->mDesiredWaypointIndex = -1;
 	subComponent->mShouldStopAtDesiredWaypoint = false;
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	//GameMessages::SendPlatformResync(m_Parent, UNASSIGNED_SYSTEM_ADDRESS);
 }
@@ -341,7 +341,7 @@ void MovingPlatformComponent::WarpToWaypoint(size_t index) {
 	m_Parent->SetPosition(waypoint.position);
 	m_Parent->SetRotation(waypoint.rotation);
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 size_t MovingPlatformComponent::GetLastWaypointIndex() const {

--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -154,7 +154,7 @@ void PetComponent::OnUse(Entity* originator) {
 	}
 
 	if (m_Tamer != LWOOBJID_EMPTY) {
-		auto* tamer = EntityManager::Instance()->GetEntity(m_Tamer);
+		auto* tamer = Game::entityManager->GetEntity(m_Tamer);
 
 		if (tamer != nullptr) {
 			return;
@@ -344,7 +344,7 @@ void PetComponent::Update(float deltaTime) {
 
 				if (m_Timer <= 0) {
 					Wander();
-					EntityManager::Instance()->SerializeEntity(m_Parent);
+					Game::entityManager->SerializeEntity(m_Parent);
 				}
 			} else {
 				m_Timer = 5;
@@ -369,7 +369,7 @@ void PetComponent::Update(float deltaTime) {
 	}
 
 	if (m_TresureTime > 0) {
-		auto* tresure = EntityManager::Instance()->GetEntity(m_Interaction);
+		auto* tresure = Game::entityManager->GetEntity(m_Interaction);
 
 		if (tresure == nullptr) {
 			m_TresureTime = 0;
@@ -476,7 +476,7 @@ skipTresure:
 void PetComponent::TryBuild(uint32_t numBricks, bool clientFailed) {
 	if (m_Tamer == LWOOBJID_EMPTY) return;
 
-	auto* tamer = EntityManager::Instance()->GetEntity(m_Tamer);
+	auto* tamer = Game::entityManager->GetEntity(m_Tamer);
 
 	if (tamer == nullptr) {
 		m_Tamer = LWOOBJID_EMPTY;
@@ -498,7 +498,7 @@ void PetComponent::TryBuild(uint32_t numBricks, bool clientFailed) {
 
 	destroyableComponent->SetImagination(imagination);
 
-	EntityManager::Instance()->SerializeEntity(tamer);
+	Game::entityManager->SerializeEntity(tamer);
 
 	if (clientFailed) {
 		if (imagination < cached->second.imaginationCost) {
@@ -516,7 +516,7 @@ void PetComponent::TryBuild(uint32_t numBricks, bool clientFailed) {
 void PetComponent::NotifyTamingBuildSuccess(NiPoint3 position) {
 	if (m_Tamer == LWOOBJID_EMPTY) return;
 
-	auto* tamer = EntityManager::Instance()->GetEntity(m_Tamer);
+	auto* tamer = Game::entityManager->GetEntity(m_Tamer);
 
 	if (tamer == nullptr) {
 		m_Tamer = LWOOBJID_EMPTY;
@@ -539,11 +539,11 @@ void PetComponent::NotifyTamingBuildSuccess(NiPoint3 position) {
 	info.rot = NiQuaternion::IDENTITY;
 	info.spawnerID = tamer->GetObjectID();
 
-	auto* modelEntity = EntityManager::Instance()->CreateEntity(info);
+	auto* modelEntity = Game::entityManager->CreateEntity(info);
 
 	m_ModelId = modelEntity->GetObjectID();
 
-	EntityManager::Instance()->ConstructEntity(modelEntity);
+	Game::entityManager->ConstructEntity(modelEntity);
 
 	GameMessages::SendNotifyTamingModelLoadedOnServer(m_Tamer, tamer->GetSystemAddress());
 
@@ -639,7 +639,7 @@ void PetComponent::RequestSetPetName(std::u16string name) {
 		return;
 	}
 
-	auto* tamer = EntityManager::Instance()->GetEntity(m_Tamer);
+	auto* tamer = Game::entityManager->GetEntity(m_Tamer);
 
 	if (tamer == nullptr) {
 		m_Tamer = LWOOBJID_EMPTY;
@@ -661,7 +661,7 @@ void PetComponent::RequestSetPetName(std::u16string name) {
 	//Save our pet's new name to the db:
 	SetPetNameForModeration(GeneralUtils::UTF16ToWTF8(name));
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	std::u16string u16name = GeneralUtils::UTF8ToUTF16(m_Name);
 	std::u16string u16ownerName = GeneralUtils::UTF8ToUTF16(m_OwnerName);
@@ -684,7 +684,7 @@ void PetComponent::RequestSetPetName(std::u16string name) {
 
 	GameMessages::SendTerminateInteraction(m_Tamer, eTerminateType::FROM_INTERACTION, m_Parent->GetObjectID());
 
-	auto* modelEntity = EntityManager::Instance()->GetEntity(m_ModelId);
+	auto* modelEntity = Game::entityManager->GetEntity(m_ModelId);
 
 	if (modelEntity != nullptr) {
 		modelEntity->Smash(m_Tamer);
@@ -703,7 +703,7 @@ void PetComponent::RequestSetPetName(std::u16string name) {
 void PetComponent::ClientExitTamingMinigame(bool voluntaryExit) {
 	if (m_Tamer == LWOOBJID_EMPTY) return;
 
-	auto* tamer = EntityManager::Instance()->GetEntity(m_Tamer);
+	auto* tamer = Game::entityManager->GetEntity(m_Tamer);
 
 	if (tamer == nullptr) {
 		m_Tamer = LWOOBJID_EMPTY;
@@ -733,7 +733,7 @@ void PetComponent::ClientExitTamingMinigame(bool voluntaryExit) {
 	m_Tamer = LWOOBJID_EMPTY;
 	m_Timer = 0;
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	// Notify the end of a pet taming minigame
 	for (CppScripts::Script* script : CppScripts::GetEntityScripts(m_Parent)) {
@@ -754,7 +754,7 @@ void PetComponent::StartTimer() {
 void PetComponent::ClientFailTamingMinigame() {
 	if (m_Tamer == LWOOBJID_EMPTY) return;
 
-	auto* tamer = EntityManager::Instance()->GetEntity(m_Tamer);
+	auto* tamer = Game::entityManager->GetEntity(m_Tamer);
 
 	if (tamer == nullptr) {
 		m_Tamer = LWOOBJID_EMPTY;
@@ -784,7 +784,7 @@ void PetComponent::ClientFailTamingMinigame() {
 	m_Tamer = LWOOBJID_EMPTY;
 	m_Timer = 0;
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	// Notify the end of a pet taming minigame
 	for (CppScripts::Script* script : CppScripts::GetEntityScripts(m_Parent)) {
@@ -887,7 +887,7 @@ void PetComponent::Activate(Item* item, bool registerPet, bool fromTaming) {
 
 	m_Timer = 3;
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	owner->GetCharacter()->SetPlayerFlag(ePlayerFlag::FIRST_MANUAL_PET_HIBERNATE, true);
 
@@ -1004,7 +1004,7 @@ LWOOBJID PetComponent::GetOwnerId() const {
 }
 
 Entity* PetComponent::GetOwner() const {
-	return EntityManager::Instance()->GetEntity(m_Owner);
+	return Game::entityManager->GetEntity(m_Owner);
 }
 
 LWOOBJID PetComponent::GetDatabaseId() const {
@@ -1046,7 +1046,7 @@ PetComponent* PetComponent::GetTamingPet(LWOOBJID tamer) {
 		return nullptr;
 	}
 
-	auto* entity = EntityManager::Instance()->GetEntity(pair->second);
+	auto* entity = Game::entityManager->GetEntity(pair->second);
 
 	if (entity == nullptr) {
 		currentActivities.erase(tamer);
@@ -1064,7 +1064,7 @@ PetComponent* PetComponent::GetActivePet(LWOOBJID owner) {
 		return nullptr;
 	}
 
-	auto* entity = EntityManager::Instance()->GetEntity(pair->second);
+	auto* entity = Game::entityManager->GetEntity(pair->second);
 
 	if (entity == nullptr) {
 		activePets.erase(owner);

--- a/dGame/dComponents/PhantomPhysicsComponent.cpp
+++ b/dGame/dComponents/PhantomPhysicsComponent.cpp
@@ -362,7 +362,7 @@ void PhantomPhysicsComponent::Update(float deltaTime) {
 
 		//If we are a respawn volume, inform the client:
 		if (m_IsRespawnVolume) {
-			auto entity = EntityManager::Instance()->GetEntity(en->GetObjectID());
+			auto entity = Game::entityManager->GetEntity(en->GetObjectID());
 
 			if (entity) {
 				GameMessages::SendPlayerReachedRespawnCheckpoint(entity, m_RespawnPos, m_RespawnRot);
@@ -403,8 +403,8 @@ void PhantomPhysicsComponent::SpawnVertices() {
 		info.spawnerID = m_Parent->GetObjectID();
 		info.spawnerNodeID = 0;
 
-		Entity* newEntity = EntityManager::Instance()->CreateEntity(info, nullptr);
-		EntityManager::Instance()->ConstructEntity(newEntity);
+		Entity* newEntity = Game::entityManager->CreateEntity(info, nullptr);
+		Game::entityManager->ConstructEntity(newEntity);
 	}
 }
 

--- a/dGame/dComponents/PossessorComponent.cpp
+++ b/dGame/dComponents/PossessorComponent.cpp
@@ -13,7 +13,7 @@ PossessorComponent::PossessorComponent(Entity* parent) : Component(parent) {
 
 PossessorComponent::~PossessorComponent() {
 	if (m_Possessable != LWOOBJID_EMPTY) {
-		auto* mount = EntityManager::Instance()->GetEntity(m_Possessable);
+		auto* mount = Game::entityManager->GetEntity(m_Possessable);
 		if (mount) {
 			auto* possessable = mount->GetComponent<PossessableComponent>();
 			if (possessable) {
@@ -58,8 +58,8 @@ void PossessorComponent::Mount(Entity* mount) {
 	GameMessages::SendVehicleUnlockInput(mount->GetObjectID(), false, m_Parent->GetSystemAddress());
 	GameMessages::SendSetStunned(m_Parent->GetObjectID(), eStateChangeType::PUSH, m_Parent->GetSystemAddress(), LWOOBJID_EMPTY, true, false, true, false, false, false, false, true, true, true, true, true, true, true, true, true);
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
-	EntityManager::Instance()->SerializeEntity(mount);
+	Game::entityManager->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(mount);
 }
 
 void PossessorComponent::Dismount(Entity* mount, bool forceDismount) {
@@ -73,8 +73,8 @@ void PossessorComponent::Dismount(Entity* mount, bool forceDismount) {
 			possessableComponent->SetPossessor(LWOOBJID_EMPTY);
 			if (forceDismount) possessableComponent->ForceDepossess();
 		}
-		EntityManager::Instance()->SerializeEntity(m_Parent);
-		EntityManager::Instance()->SerializeEntity(mount);
+		Game::entityManager->SerializeEntity(m_Parent);
+		Game::entityManager->SerializeEntity(mount);
 
 		auto characterComponent = m_Parent->GetComponent<CharacterComponent>();
 		if (characterComponent) characterComponent->SetIsRacing(false);

--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -90,7 +90,7 @@ LWOOBJID PropertyManagementComponent::GetOwnerId() const {
 }
 
 Entity* PropertyManagementComponent::GetOwner() const {
-	return EntityManager::Instance()->GetEntity(owner);
+	return Game::entityManager->GetEntity(owner);
 }
 
 void PropertyManagementComponent::SetOwner(Entity* value) {
@@ -185,7 +185,7 @@ bool PropertyManagementComponent::Claim(const LWOOBJID playerId) {
 		return false;
 	}
 
-	auto* entity = EntityManager::Instance()->GetEntity(playerId);
+	auto* entity = Game::entityManager->GetEntity(playerId);
 
 	auto* user = entity->GetParentUser();
 
@@ -256,7 +256,7 @@ void PropertyManagementComponent::OnStartBuilding() {
 
 	LWOMAPID zoneId = 1100;
 
-	const auto entrance = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::PROPERTY_ENTRANCE);
+	const auto entrance = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::PROPERTY_ENTRANCE);
 
 	originalPrivacyOption = privacyOption;
 
@@ -339,9 +339,9 @@ void PropertyManagementComponent::UpdateModelPosition(const LWOOBJID id, const N
 			info.settings.push_back(setting->Copy());
 		}
 
-		Entity* newEntity = EntityManager::Instance()->CreateEntity(info);
+		Entity* newEntity = Game::entityManager->CreateEntity(info);
 		if (newEntity != nullptr) {
-			EntityManager::Instance()->ConstructEntity(newEntity);
+			Game::entityManager->ConstructEntity(newEntity);
 
 			// Make sure the propMgmt doesn't delete our model after the server dies
 			// Trying to do this after the entity is constructed. Shouldn't really change anything but
@@ -371,7 +371,7 @@ void PropertyManagementComponent::UpdateModelPosition(const LWOOBJID id, const N
 		info.respawnTime = 10;
 
 		info.emulated = true;
-		info.emulator = EntityManager::Instance()->GetZoneControlEntity()->GetObjectID();
+		info.emulator = Game::entityManager->GetZoneControlEntity()->GetObjectID();
 
 		info.spawnerID = persistentId;
 		GeneralUtils::SetBit(info.spawnerID, eObjectBits::CLIENT);
@@ -401,7 +401,7 @@ void PropertyManagementComponent::UpdateModelPosition(const LWOOBJID id, const N
 
 		GameMessages::SendGetModelsOnProperty(entity->GetObjectID(), GetModels(), UNASSIGNED_SYSTEM_ADDRESS);
 
-		EntityManager::Instance()->GetZoneControlEntity()->OnZonePropertyModelPlaced(entity);
+		Game::entityManager->GetZoneControlEntity()->OnZonePropertyModelPlaced(entity);
 		});
 	// Progress place model missions
 	auto missionComponent = entity->GetComponent<MissionComponent>();
@@ -441,7 +441,7 @@ void PropertyManagementComponent::DeleteModel(const LWOOBJID id, const int delet
 		Game::logger->Log("PropertyManagementComponent", "Failed to find spawner");
 	}
 
-	auto* model = EntityManager::Instance()->GetEntity(id);
+	auto* model = Game::entityManager->GetEntity(id);
 
 	if (model == nullptr) {
 		Game::logger->Log("PropertyManagementComponent", "Failed to find model entity");
@@ -449,7 +449,7 @@ void PropertyManagementComponent::DeleteModel(const LWOOBJID id, const int delet
 		return;
 	}
 
-	EntityManager::Instance()->DestructEntity(model);
+	Game::entityManager->DestructEntity(model);
 
 	Game::logger->Log("PropertyManagementComponent", "Deleting model LOT %i", model->GetLOT());
 
@@ -520,13 +520,13 @@ void PropertyManagementComponent::DeleteModel(const LWOOBJID id, const int delet
 		item->Equip();
 
 		GameMessages::SendUGCEquipPostDeleteBasedOnEditMode(entity->GetObjectID(), entity->GetSystemAddress(), item->GetId(), item->GetCount());
-		EntityManager::Instance()->GetZoneControlEntity()->OnZonePropertyModelPickedUp(entity);
+		Game::entityManager->GetZoneControlEntity()->OnZonePropertyModelPickedUp(entity);
 
 		break;
 	}
 	case 1: // Return to inv
 	{
-		EntityManager::Instance()->GetZoneControlEntity()->OnZonePropertyModelRemoved(entity);
+		Game::entityManager->GetZoneControlEntity()->OnZonePropertyModelRemoved(entity);
 
 		break;
 	}
@@ -613,7 +613,7 @@ void PropertyManagementComponent::Load() {
 		info.respawnTime = 10;
 
 		//info.emulated = true;
-		//info.emulator = EntityManager::Instance()->GetZoneControlEntity()->GetObjectID();
+		//info.emulator = Game::entityManager->GetZoneControlEntity()->GetObjectID();
 
 		info.spawnerID = id;
 
@@ -698,7 +698,7 @@ void PropertyManagementComponent::Save() {
 
 		modelIds.push_back(id);
 
-		auto* entity = EntityManager::Instance()->GetEntity(pair.first);
+		auto* entity = Game::entityManager->GetEntity(pair.first);
 
 		if (entity == nullptr) {
 			continue;

--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -108,7 +108,7 @@ void RacingControlComponent::LoadPlayerVehicle(Entity* player,
 	auto* path = dZoneManager::Instance()->GetZone()->GetPath(
 		GeneralUtils::UTF16ToWTF8(m_PathName));
 
-	auto spawnPointEntities = EntityManager::Instance()->GetEntitiesByLOT(4843);
+	auto spawnPointEntities = Game::entityManager->GetEntitiesByLOT(4843);
 	auto startPosition = NiPoint3::ZERO;
 	auto startRotation = NiQuaternion::IDENTITY;
 	const std::string placementAsString = std::to_string(positionNumber);
@@ -135,7 +135,7 @@ void RacingControlComponent::LoadPlayerVehicle(Entity* player,
 	info.spawnerID = m_Parent->GetObjectID();
 
 	auto* carEntity =
-		EntityManager::Instance()->CreateEntity(info, nullptr, m_Parent);
+		Game::entityManager->CreateEntity(info, nullptr, m_Parent);
 
 	// Make the vehicle a child of the racing controller.
 	m_Parent->AddChild(carEntity);
@@ -206,9 +206,9 @@ void RacingControlComponent::LoadPlayerVehicle(Entity* player,
 
 	// Construct and serialize everything when done.
 
-	EntityManager::Instance()->ConstructEntity(carEntity);
-	EntityManager::Instance()->SerializeEntity(player);
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->ConstructEntity(carEntity);
+	Game::entityManager->SerializeEntity(player);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	GameMessages::SendRacingSetPlayerResetInfo(
 		m_Parent->GetObjectID(), 0, 0, player->GetObjectID(), startPosition, 1,
@@ -219,7 +219,7 @@ void RacingControlComponent::LoadPlayerVehicle(Entity* player,
 	// Reset the player to the start position during downtime, in case something
 	// went wrong.
 	m_Parent->AddCallbackTimer(1, [this, playerID]() {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 
 		if (player == nullptr) {
 			return;
@@ -268,7 +268,7 @@ void RacingControlComponent::OnRacingClientReady(Entity* player) {
 			racingPlayer.vehicleID, UNASSIGNED_SYSTEM_ADDRESS);
 	}
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void RacingControlComponent::OnRequestDie(Entity* player) {
@@ -281,7 +281,7 @@ void RacingControlComponent::OnRequestDie(Entity* player) {
 		}
 
 		auto* vehicle =
-			EntityManager::Instance()->GetEntity(racingPlayer.vehicleID);
+			Game::entityManager->GetEntity(racingPlayer.vehicleID);
 
 		if (!vehicle) return;
 
@@ -318,7 +318,7 @@ void RacingControlComponent::OnRequestDie(Entity* player) {
 				auto* destroyableComponent = vehicle->GetComponent<DestroyableComponent>();
 				// Reset imagination to half its current value, rounded up to the nearest value divisible by 10, as it was done in live.
 				if (destroyableComponent) destroyableComponent->SetImagination(respawnImagination);
-				EntityManager::Instance()->SerializeEntity(vehicle);
+				Game::entityManager->SerializeEntity(vehicle);
 			});
 
 			auto* characterComponent = player->GetComponent<CharacterComponent>();
@@ -347,7 +347,7 @@ void RacingControlComponent::OnRacingPlayerInfoResetFinished(Entity* player) {
 		}
 
 		auto* vehicle =
-			EntityManager::Instance()->GetEntity(racingPlayer.vehicleID);
+			Game::entityManager->GetEntity(racingPlayer.vehicleID);
 
 		if (vehicle == nullptr) {
 			return;
@@ -402,7 +402,7 @@ void RacingControlComponent::HandleMessageBoxResponse(Entity* player, int32_t bu
 			}
 		}
 	} else if ((id == "ACT_RACE_EXIT_THE_RACE?" || id == "Exit") && button == m_ActivityExitConfirm) {
-		auto* vehicle = EntityManager::Instance()->GetEntity(data->vehicleID);
+		auto* vehicle = Game::entityManager->GetEntity(data->vehicleID);
 
 		if (vehicle == nullptr) {
 			return;
@@ -503,7 +503,7 @@ void RacingControlComponent::Update(float deltaTime) {
 		// Check if any players has disconnected before loading in
 		for (size_t i = 0; i < m_LobbyPlayers.size(); i++) {
 			auto* playerEntity =
-				EntityManager::Instance()->GetEntity(m_LobbyPlayers[i]);
+				Game::entityManager->GetEntity(m_LobbyPlayers[i]);
 
 			if (playerEntity == nullptr) {
 				--m_LoadedPlayers;
@@ -525,7 +525,7 @@ void RacingControlComponent::Update(float deltaTime) {
 		if (m_EmptyTimer >= 30) {
 			for (const auto player : m_LobbyPlayers) {
 				auto* playerEntity =
-					EntityManager::Instance()->GetEntity(player);
+					Game::entityManager->GetEntity(player);
 
 				if (playerEntity == nullptr) {
 					continue;
@@ -550,7 +550,7 @@ void RacingControlComponent::Update(float deltaTime) {
 					"Loading player now!");
 
 				auto* player =
-					EntityManager::Instance()->GetEntity(m_LobbyPlayers[positionNumber]);
+					Game::entityManager->GetEntity(m_LobbyPlayers[positionNumber]);
 
 				if (player == nullptr) {
 					return;
@@ -574,7 +574,7 @@ void RacingControlComponent::Update(float deltaTime) {
 	if (!m_Started) {
 		// Check if anyone has disconnected during this period
 		for (size_t i = 0; i < m_RacingPlayers.size(); i++) {
-			auto* playerEntity = EntityManager::Instance()->GetEntity(
+			auto* playerEntity = Game::entityManager->GetEntity(
 				m_RacingPlayers[i].playerID);
 
 			if (playerEntity == nullptr) {
@@ -590,7 +590,7 @@ void RacingControlComponent::Update(float deltaTime) {
 		if (m_LoadedPlayers < 2 && !(m_LoadedPlayers == 1 && m_SoloRacing)) {
 			for (const auto player : m_LobbyPlayers) {
 				auto* playerEntity =
-					EntityManager::Instance()->GetEntity(player);
+					Game::entityManager->GetEntity(player);
 
 				if (playerEntity == nullptr) {
 					continue;
@@ -623,9 +623,9 @@ void RacingControlComponent::Update(float deltaTime) {
 
 				for (const auto& player : m_RacingPlayers) {
 					auto* vehicle =
-						EntityManager::Instance()->GetEntity(player.vehicleID);
+						Game::entityManager->GetEntity(player.vehicleID);
 					auto* playerEntity =
-						EntityManager::Instance()->GetEntity(player.playerID);
+						Game::entityManager->GetEntity(player.playerID);
 
 					if (vehicle != nullptr && playerEntity != nullptr) {
 						GameMessages::SendTeleport(
@@ -643,8 +643,8 @@ void RacingControlComponent::Update(float deltaTime) {
 							destroyableComponent->SetImagination(0);
 						}
 
-						EntityManager::Instance()->SerializeEntity(vehicle);
-						EntityManager::Instance()->SerializeEntity(
+						Game::entityManager->SerializeEntity(vehicle);
+						Game::entityManager->SerializeEntity(
 							playerEntity);
 					}
 				}
@@ -670,9 +670,9 @@ void RacingControlComponent::Update(float deltaTime) {
 				// Reset players to their start location, without smashing them
 				for (auto& player : m_RacingPlayers) {
 					auto* vehicleEntity =
-						EntityManager::Instance()->GetEntity(player.vehicleID);
+						Game::entityManager->GetEntity(player.vehicleID);
 					auto* playerEntity =
-						EntityManager::Instance()->GetEntity(player.playerID);
+						Game::entityManager->GetEntity(player.playerID);
 
 					if (vehicleEntity == nullptr || playerEntity == nullptr) {
 						continue;
@@ -689,9 +689,9 @@ void RacingControlComponent::Update(float deltaTime) {
 				// Activate the players movement
 				for (auto& player : m_RacingPlayers) {
 					auto* vehicleEntity =
-						EntityManager::Instance()->GetEntity(player.vehicleID);
+						Game::entityManager->GetEntity(player.vehicleID);
 					auto* playerEntity =
-						EntityManager::Instance()->GetEntity(player.playerID);
+						Game::entityManager->GetEntity(player.playerID);
 
 					if (vehicleEntity == nullptr || playerEntity == nullptr) {
 						continue;
@@ -709,7 +709,7 @@ void RacingControlComponent::Update(float deltaTime) {
 
 				Game::logger->Log("RacingControlComponent", "Starting race");
 
-				EntityManager::Instance()->SerializeEntity(m_Parent);
+				Game::entityManager->SerializeEntity(m_Parent);
 
 				m_StartTime = std::time(nullptr);
 			}
@@ -727,9 +727,9 @@ void RacingControlComponent::Update(float deltaTime) {
 		GeneralUtils::UTF16ToWTF8(m_PathName));
 
 	for (auto& player : m_RacingPlayers) {
-		auto* vehicle = EntityManager::Instance()->GetEntity(player.vehicleID);
+		auto* vehicle = Game::entityManager->GetEntity(player.vehicleID);
 		auto* playerEntity =
-			EntityManager::Instance()->GetEntity(player.playerID);
+			Game::entityManager->GetEntity(player.playerID);
 
 		if (vehicle == nullptr || playerEntity == nullptr) {
 			continue;

--- a/dGame/dComponents/RailActivatorComponent.cpp
+++ b/dGame/dComponents/RailActivatorComponent.cpp
@@ -68,7 +68,7 @@ void RailActivatorComponent::OnUse(Entity* originator) {
 	const auto originatorID = originator->GetObjectID();
 
 	m_Parent->AddCallbackTimer(animationLength, [originatorID, this]() {
-		auto* originator = EntityManager::Instance()->GetEntity(originatorID);
+		auto* originator = Game::entityManager->GetEntity(originatorID);
 
 		if (originator == nullptr) {
 			return;

--- a/dGame/dComponents/RebuildComponent.cpp
+++ b/dGame/dComponents/RebuildComponent.cpp
@@ -120,7 +120,7 @@ void RebuildComponent::Update(float deltaTime) {
 	else {
 		m_SoftTimer = 5.0f;
 
-		EntityManager::Instance()->SerializeEntity(m_Parent);
+		Game::entityManager->SerializeEntity(m_Parent);
 	}*/
 
 	switch (m_State) {
@@ -139,7 +139,7 @@ void RebuildComponent::Update(float deltaTime) {
 				if (m_TimerIncomplete >= m_TimeBeforeSmash - 4.0f) {
 					m_ShowResetEffect = true;
 
-					EntityManager::Instance()->SerializeEntity(m_Parent);
+					Game::entityManager->SerializeEntity(m_Parent);
 				}
 
 				if (m_TimerIncomplete >= m_TimeBeforeSmash) {
@@ -163,7 +163,7 @@ void RebuildComponent::Update(float deltaTime) {
 				if (!m_ShowResetEffect) {
 					m_ShowResetEffect = true;
 
-					EntityManager::Instance()->SerializeEntity(m_Parent);
+					Game::entityManager->SerializeEntity(m_Parent);
 				}
 			}
 
@@ -206,7 +206,7 @@ void RebuildComponent::Update(float deltaTime) {
 			++m_DrainedImagination;
 			--newImagination;
 			destComp->SetImagination(newImagination);
-			EntityManager::Instance()->SerializeEntity(builder);
+			Game::entityManager->SerializeEntity(builder);
 
 
 		}
@@ -225,7 +225,7 @@ void RebuildComponent::Update(float deltaTime) {
 			if (m_TimerIncomplete >= m_TimeBeforeSmash - 4.0f) {
 				m_ShowResetEffect = true;
 
-				EntityManager::Instance()->SerializeEntity(m_Parent);
+				Game::entityManager->SerializeEntity(m_Parent);
 			}
 
 			if (m_TimerIncomplete >= m_TimeBeforeSmash) {
@@ -263,20 +263,20 @@ void RebuildComponent::SpawnActivator() {
 			info.spawnerID = m_Parent->GetObjectID();
 			info.pos = m_ActivatorPosition == NiPoint3::ZERO ? m_Parent->GetPosition() : m_ActivatorPosition;
 
-			m_Activator = EntityManager::Instance()->CreateEntity(info, nullptr, m_Parent);
+			m_Activator = Game::entityManager->CreateEntity(info, nullptr, m_Parent);
 			if (m_Activator) {
 				m_ActivatorId = m_Activator->GetObjectID();
-				EntityManager::Instance()->ConstructEntity(m_Activator);
+				Game::entityManager->ConstructEntity(m_Activator);
 			}
 
-			EntityManager::Instance()->SerializeEntity(m_Parent);
+			Game::entityManager->SerializeEntity(m_Parent);
 		}
 	}
 }
 
 void RebuildComponent::DespawnActivator() {
 	if (m_Activator) {
-		EntityManager::Instance()->DestructEntity(m_Activator);
+		Game::entityManager->DestructEntity(m_Activator);
 
 		m_Activator->ScheduleKillAfterUpdate();
 
@@ -287,7 +287,7 @@ void RebuildComponent::DespawnActivator() {
 }
 
 Entity* RebuildComponent::GetActivator() {
-	return EntityManager::Instance()->GetEntity(m_ActivatorId);
+	return Game::entityManager->GetEntity(m_ActivatorId);
 }
 
 NiPoint3 RebuildComponent::GetActivatorPosition() {
@@ -335,7 +335,7 @@ eRebuildState RebuildComponent::GetState() {
 }
 
 Entity* RebuildComponent::GetBuilder() const {
-	auto* builder = EntityManager::Instance()->GetEntity(m_Builder);
+	auto* builder = Game::entityManager->GetEntity(m_Builder);
 
 	return builder;
 }
@@ -403,14 +403,14 @@ void RebuildComponent::StartRebuild(Entity* user) {
 		auto* character = user->GetComponent<CharacterComponent>();
 		character->SetCurrentActivity(eGameActivity::QUICKBUILDING);
 
-		EntityManager::Instance()->SerializeEntity(user);
+		Game::entityManager->SerializeEntity(user);
 
 		GameMessages::SendRebuildNotifyState(m_Parent, m_State, eRebuildState::BUILDING, user->GetObjectID());
 		GameMessages::SendEnableRebuild(m_Parent, true, false, false, eQuickBuildFailReason::NOT_GIVEN, 0.0f, user->GetObjectID());
 
 		m_State = eRebuildState::BUILDING;
 		m_StateDirty = true;
-		EntityManager::Instance()->SerializeEntity(m_Parent);
+		Game::entityManager->SerializeEntity(m_Parent);
 
 		auto* movingPlatform = m_Parent->GetComponent<MovingPlatformComponent>();
 		if (movingPlatform != nullptr) {
@@ -443,7 +443,7 @@ void RebuildComponent::CompleteRebuild(Entity* user) {
 		return;
 	}
 
-	EntityManager::Instance()->SerializeEntity(user);
+	Game::entityManager->SerializeEntity(user);
 
 	GameMessages::SendRebuildNotifyState(m_Parent, m_State, eRebuildState::COMPLETED, user->GetObjectID());
 	GameMessages::SendPlayFXEffect(m_Parent, 507, u"create", "BrickFadeUpVisCompleteEffect", LWOOBJID_EMPTY, 0.4f, 1.0f, true);
@@ -456,7 +456,7 @@ void RebuildComponent::CompleteRebuild(Entity* user) {
 	m_Timer = 0.0f;
 	m_DrainedImagination = 0;
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	// Removes extra item requirements, isn't live accurate.
 	// In live, all items were removed at the start of the quickbuild, then returned if it was cancelled.
@@ -476,7 +476,7 @@ void RebuildComponent::CompleteRebuild(Entity* user) {
 		auto* team = TeamManager::Instance()->GetTeam(builder->GetObjectID());
 		if (team) {
 			for (const auto memberId : team->members) { // progress missions for all team members
-				auto* member = EntityManager::Instance()->GetEntity(memberId);
+				auto* member = Game::entityManager->GetEntity(memberId);
 				if (member) {
 					auto* missionComponent = member->GetComponent<MissionComponent>();
 					if (missionComponent) missionComponent->Progress(eMissionTaskType::ACTIVITY, m_ActivityId);
@@ -541,7 +541,7 @@ void RebuildComponent::ResetRebuild(bool failed) {
 	m_ShowResetEffect = false;
 	m_DrainedImagination = 0;
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	// Notify scripts and possible subscribers
 	for (auto* script : CppScripts::GetEntityScripts(m_Parent))
@@ -581,7 +581,7 @@ void RebuildComponent::CancelRebuild(Entity* entity, eQuickBuildFailReason failR
 		for (const auto& cb : m_RebuildStateCallbacks)
 			cb(m_State);
 
-		EntityManager::Instance()->SerializeEntity(m_Parent);
+		Game::entityManager->SerializeEntity(m_Parent);
 	}
 
 	if (entity == nullptr) {
@@ -591,7 +591,7 @@ void RebuildComponent::CancelRebuild(Entity* entity, eQuickBuildFailReason failR
 	CharacterComponent* characterComponent = entity->GetComponent<CharacterComponent>();
 	if (characterComponent) {
 		characterComponent->SetCurrentActivity(eGameActivity::NONE);
-		EntityManager::Instance()->SerializeEntity(entity);
+		Game::entityManager->SerializeEntity(entity);
 	}
 }
 

--- a/dGame/dComponents/RocketLaunchpadControlComponent.cpp
+++ b/dGame/dComponents/RocketLaunchpadControlComponent.cpp
@@ -81,7 +81,7 @@ void RocketLaunchpadControlComponent::Launch(Entity* originator, LWOMAPID mapId,
 
 	GameMessages::SendChangeObjectWorldState(rocket->GetId(), eObjectWorldState::ATTACHED, UNASSIGNED_SYSTEM_ADDRESS);
 
-	EntityManager::Instance()->SerializeEntity(originator);
+	Game::entityManager->SerializeEntity(originator);
 }
 
 void RocketLaunchpadControlComponent::OnUse(Entity* originator) {

--- a/dGame/dComponents/ScriptedActivityComponent.cpp
+++ b/dGame/dComponents/ScriptedActivityComponent.cpp
@@ -137,7 +137,7 @@ void ScriptedActivityComponent::PlayerJoin(Entity* player) {
 		instance->AddParticipant(player);
 	}
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void ScriptedActivityComponent::PlayerJoinLobby(Entity* player) {
@@ -445,7 +445,7 @@ void ScriptedActivityComponent::RemoveActivityPlayerData(LWOOBJID playerID) {
 			m_ActivityPlayers[i] = nullptr;
 
 			m_ActivityPlayers.erase(m_ActivityPlayers.begin() + i);
-			EntityManager::Instance()->SerializeEntity(m_Parent);
+			Game::entityManager->SerializeEntity(m_Parent);
 
 			return;
 		}
@@ -458,7 +458,7 @@ ActivityPlayer* ScriptedActivityComponent::AddActivityPlayerData(LWOOBJID player
 		return data;
 
 	m_ActivityPlayers.push_back(new ActivityPlayer{ playerID, {} });
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	return GetActivityPlayerData(playerID);
 }
@@ -480,7 +480,7 @@ void ScriptedActivityComponent::SetActivityValue(LWOOBJID playerID, uint32_t ind
 		data->values[std::min(index, (uint32_t)9)] = value;
 	}
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void ScriptedActivityComponent::PlayerRemove(LWOOBJID playerID) {
@@ -535,7 +535,7 @@ void ActivityInstance::StartZone() {
 		const auto objid = player->GetObjectID();
 		ZoneInstanceManager::Instance()->RequestZoneTransfer(Game::server, m_ActivityInfo.instanceMapID, cloneId, false, [objid](bool mythranShift, uint32_t zoneID, uint32_t zoneInstance, uint32_t zoneClone, std::string serverIP, uint16_t serverPort) {
 
-			auto* player = EntityManager::Instance()->GetEntity(objid);
+			auto* player = Game::entityManager->GetEntity(objid);
 			if (player == nullptr)
 				return;
 
@@ -585,7 +585,7 @@ std::vector<Entity*> ActivityInstance::GetParticipants() const {
 	entities.reserve(m_Participants.size());
 
 	for (const auto& id : m_Participants) {
-		auto* entity = EntityManager::Instance()->GetEntity(id);
+		auto* entity = Game::entityManager->GetEntity(id);
 		if (entity != nullptr)
 			entities.push_back(entity);
 	}
@@ -617,5 +617,5 @@ void ActivityInstance::SetScore(uint32_t score) {
 }
 
 Entity* LobbyPlayer::GetEntity() const {
-	return EntityManager::Instance()->GetEntity(entityID);
+	return Game::entityManager->GetEntity(entityID);
 }

--- a/dGame/dComponents/ShootingGalleryComponent.cpp
+++ b/dGame/dComponents/ShootingGalleryComponent.cpp
@@ -14,7 +14,7 @@ void ShootingGalleryComponent::SetStaticParams(const StaticShootingGalleryParams
 void ShootingGalleryComponent::SetDynamicParams(const DynamicShootingGalleryParams& params) {
 	m_DynamicParams = params;
 	m_Dirty = true;
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void ShootingGalleryComponent::Serialize(RakNet::BitStream* outBitStream, bool isInitialUpdate, uint32_t& flags) const {

--- a/dGame/dComponents/SkillComponent.cpp
+++ b/dGame/dComponents/SkillComponent.cpp
@@ -292,7 +292,7 @@ SkillExecutionResult SkillComponent::CalculateBehavior(const uint32_t skillId, c
 		start.optionalOriginatorID = context->originator;
 		start.optionalTargetID = target;
 
-		auto* originator = EntityManager::Instance()->GetEntity(context->originator);
+		auto* originator = Game::entityManager->GetEntity(context->originator);
 
 		if (originator != nullptr) {
 			start.originatorRot = originator->GetRotation();
@@ -338,7 +338,7 @@ void SkillComponent::CalculateUpdate(const float deltaTime) {
 
 		entry.time += deltaTime;
 
-		auto* origin = EntityManager::Instance()->GetEntity(entry.context->originator);
+		auto* origin = Game::entityManager->GetEntity(entry.context->originator);
 
 		if (origin == nullptr) {
 			continue;
@@ -349,7 +349,7 @@ void SkillComponent::CalculateUpdate(const float deltaTime) {
 		const auto position = entry.startPosition + (entry.velocity * entry.time);
 
 		for (const auto& targetId : targets) {
-			auto* target = EntityManager::Instance()->GetEntity(targetId);
+			auto* target = Game::entityManager->GetEntity(targetId);
 
 			const auto targetPosition = target->GetPosition();
 
@@ -397,7 +397,7 @@ void SkillComponent::CalculateUpdate(const float deltaTime) {
 
 
 void SkillComponent::SyncProjectileCalculation(const ProjectileSyncEntry& entry) const {
-	auto* other = EntityManager::Instance()->GetEntity(entry.branchContext.target);
+	auto* other = Game::entityManager->GetEntity(entry.branchContext.target);
 
 	if (other == nullptr) {
 		if (entry.branchContext.target != LWOOBJID_EMPTY) {

--- a/dGame/dComponents/SoundTriggerComponent.cpp
+++ b/dGame/dComponents/SoundTriggerComponent.cpp
@@ -76,7 +76,7 @@ void SoundTriggerComponent::ActivateMusicCue(const std::string& name) {
 			-1.0f
 			});
 		dirty = true;
-		EntityManager::Instance()->SerializeEntity(m_Parent);
+		Game::entityManager->SerializeEntity(m_Parent);
 	}
 }
 
@@ -88,6 +88,6 @@ void SoundTriggerComponent::DeactivateMusicCue(const std::string& name) {
 	if (musicCue != this->musicCues.end()) {
 		this->musicCues.erase(musicCue);
 		dirty = true;
-		EntityManager::Instance()->SerializeEntity(m_Parent);
+		Game::entityManager->SerializeEntity(m_Parent);
 	}
 }

--- a/dGame/dComponents/SwitchComponent.cpp
+++ b/dGame/dComponents/SwitchComponent.cpp
@@ -49,7 +49,7 @@ void SwitchComponent::EntityEnter(Entity* entity) {
 		const auto grpName = m_Parent->GetVarAsString(u"grp_name");
 
 		if (!grpName.empty()) {
-			const auto entities = EntityManager::Instance()->GetEntitiesInGroup(grpName);
+			const auto entities = Game::entityManager->GetEntitiesInGroup(grpName);
 
 			for (auto* entity : entities) {
 				entity->OnFireEventServerSide(entity, "OnActivated");
@@ -63,7 +63,7 @@ void SwitchComponent::EntityEnter(Entity* entity) {
 			RenderComponent::PlayAnimation(m_Parent, u"engaged");
 			m_PetBouncer->SetPetBouncerEnabled(true);
 		} else {
-			EntityManager::Instance()->SerializeEntity(m_Parent);
+			Game::entityManager->SerializeEntity(m_Parent);
 		}
 
 	}
@@ -85,7 +85,7 @@ void SwitchComponent::Update(float deltaTime) {
 			const auto grpName = m_Parent->GetVarAsString(u"grp_name");
 
 			if (!grpName.empty()) {
-				const auto entities = EntityManager::Instance()->GetEntitiesInGroup(grpName);
+				const auto entities = Game::entityManager->GetEntitiesInGroup(grpName);
 
 				for (auto* entity : entities) {
 					entity->OnFireEventServerSide(entity, "OnDectivated");
@@ -95,7 +95,7 @@ void SwitchComponent::Update(float deltaTime) {
 			if (m_PetBouncer != nullptr) {
 				m_PetBouncer->SetPetBouncerEnabled(false);
 			} else {
-				EntityManager::Instance()->SerializeEntity(m_Parent);
+				Game::entityManager->SerializeEntity(m_Parent);
 			}
 		}
 	}

--- a/dGame/dComponents/TriggerComponent.cpp
+++ b/dGame/dComponents/TriggerComponent.cpp
@@ -170,10 +170,10 @@ std::vector<Entity*> TriggerComponent::GatherTargets(LUTriggers::Command* comman
 	else if (command->target == "targetTeam" && optionalTarget) {
 		auto* team = TeamManager::Instance()->GetTeam(optionalTarget->GetObjectID());
 		for (const auto memberId : team->members) {
-			auto* member = EntityManager::Instance()->GetEntity(memberId);
+			auto* member = Game::entityManager->GetEntity(memberId);
 			if (member) entities.push_back(member);
 		}
-	} else if (command->target == "objGroup") entities = EntityManager::Instance()->GetEntitiesInGroup(command->targetName);
+	} else if (command->target == "objGroup") entities = Game::entityManager->GetEntitiesInGroup(command->targetName);
 	else if (command->target == "allPlayers") {
 		for (auto* player : Player::GetAllPlayers()) {
 			entities.push_back(player);
@@ -249,7 +249,7 @@ void TriggerComponent::HandlePushObject(Entity* targetEntity, std::vector<std::s
 	GeneralUtils::TryParse(argArray.at(0), argArray.at(1), argArray.at(2), direction);
 	phantomPhysicsComponent->SetDirection(direction);
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 
@@ -274,7 +274,7 @@ void TriggerComponent::HandleRepelObject(Entity* targetEntity, std::string args)
 	NiPoint3 direction = delta / length;
 	phantomPhysicsComponent->SetDirection(direction);
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 }
 
 void TriggerComponent::HandleSetTimer(Entity* targetEntity, std::vector<std::string> argArray){
@@ -395,7 +395,7 @@ void TriggerComponent::HandleSetPhysicsVolumeEffect(Entity* targetEntity, std::v
 		phantomPhysicsComponent->SetMax(max);
 	}
 
-	EntityManager::Instance()->SerializeEntity(targetEntity);
+	Game::entityManager->SerializeEntity(targetEntity);
 }
 
 void TriggerComponent::HandleSetPhysicsVolumeStatus(Entity* targetEntity, std::string args) {
@@ -405,7 +405,7 @@ void TriggerComponent::HandleSetPhysicsVolumeStatus(Entity* targetEntity, std::s
 		return;
 	}
 	phantomPhysicsComponent->SetPhysicsEffectActive(args == "On");
-	EntityManager::Instance()->SerializeEntity(targetEntity);
+	Game::entityManager->SerializeEntity(targetEntity);
 }
 
 void TriggerComponent::HandleActivateSpawnerNetwork(std::string args){

--- a/dGame/dComponents/VehiclePhysicsComponent.cpp
+++ b/dGame/dComponents/VehiclePhysicsComponent.cpp
@@ -135,7 +135,7 @@ void VehiclePhysicsComponent::Serialize(RakNet::BitStream* outBitStream, bool bI
 
 void VehiclePhysicsComponent::Update(float deltaTime) {
 	if (m_SoftUpdate > 5) {
-		EntityManager::Instance()->SerializeEntity(m_Parent);
+		Game::entityManager->SerializeEntity(m_Parent);
 		m_SoftUpdate = 0;
 	} else {
 		m_SoftUpdate += deltaTime;

--- a/dGame/dGameMessages/GameMessageHandler.cpp
+++ b/dGame/dGameMessages/GameMessageHandler.cpp
@@ -42,7 +42,7 @@ void GameMessageHandler::HandleMessage(RakNet::BitStream* inStream, const System
 	CBITSTREAM;
 
 	// Get the entity
-	Entity* entity = EntityManager::Instance()->GetEntity(objectID);
+	Entity* entity = Game::entityManager->GetEntity(objectID);
 
 	User* usr = UserManager::Instance()->GetUser(sysAddr);
 
@@ -122,9 +122,9 @@ void GameMessageHandler::HandleMessage(RakNet::BitStream* inStream, const System
 
 		auto* destroyable = entity->GetComponent<DestroyableComponent>();
 		destroyable->SetImagination(destroyable->GetImagination());
-		EntityManager::Instance()->SerializeEntity(entity);
+		Game::entityManager->SerializeEntity(entity);
 
-		std::vector<Entity*> racingControllers = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::RACING_CONTROL);
+		std::vector<Entity*> racingControllers = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::RACING_CONTROL);
 		for (Entity* racingController : racingControllers) {
 			auto* racingComponent = racingController->GetComponent<RacingControlComponent>();
 			if (racingComponent != nullptr) {
@@ -132,12 +132,12 @@ void GameMessageHandler::HandleMessage(RakNet::BitStream* inStream, const System
 			}
 		}
 
-		Entity* zoneControl = EntityManager::Instance()->GetZoneControlEntity();
+		Entity* zoneControl = Game::entityManager->GetZoneControlEntity();
 		for (CppScripts::Script* script : CppScripts::GetEntityScripts(zoneControl)) {
 			script->OnPlayerLoaded(zoneControl, player);
 		}
 
-		std::vector<Entity*> scriptedActs = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::SCRIPT);
+		std::vector<Entity*> scriptedActs = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SCRIPT);
 		for (Entity* scriptEntity : scriptedActs) {
 			if (scriptEntity->GetObjectID() != zoneControl->GetObjectID()) { // Don't want to trigger twice on instance worlds
 				for (CppScripts::Script* script : CppScripts::GetEntityScripts(scriptEntity)) {
@@ -248,7 +248,7 @@ void GameMessageHandler::HandleMessage(RakNet::BitStream* inStream, const System
 			dest->SetHealth(4);
 			dest->SetArmor(0);
 			dest->SetImagination(6);
-			EntityManager::Instance()->SerializeEntity(entity);
+			Game::entityManager->SerializeEntity(entity);
 		}*/
 		break;
 	}
@@ -560,7 +560,7 @@ void GameMessageHandler::HandleMessage(RakNet::BitStream* inStream, const System
 		break;
 
 	case eGameMessageType::ZONE_PROPERTY_MODEL_ROTATED:
-		EntityManager::Instance()->GetZoneControlEntity()->OnZonePropertyModelRotated(usr->GetLastUsedChar()->GetEntity());
+		Game::entityManager->GetZoneControlEntity()->OnZonePropertyModelRotated(usr->GetLastUsedChar()->GetEntity());
 		break;
 
 	case eGameMessageType::UPDATE_PROPERTY_OR_MODEL_FOR_FILTER_CHECK:

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -1101,7 +1101,7 @@ void GameMessages::SendDropClientLoot(Entity* entity, const LWOOBJID& sourceID, 
 
 		if (object.type != "Powerup") {
 			for (const auto memberId : team->members) {
-				auto* member = EntityManager::Instance()->GetEntity(memberId);
+				auto* member = Game::entityManager->GetEntity(memberId);
 
 				if (member == nullptr) continue;
 
@@ -1705,11 +1705,11 @@ void GameMessages::HandleActivityStateChangeRequest(RakNet::BitStream* inStream,
 		stringValue.push_back(character);
 	}
 
-	auto* assosiate = EntityManager::Instance()->GetEntity(objectID);
+	auto* assosiate = Game::entityManager->GetEntity(objectID);
 
 	Game::logger->Log("Activity State Change", "%s [%i, %i] from %i to %i", GeneralUtils::UTF16ToWTF8(stringValue).c_str(), value1, value2, entity->GetLOT(), assosiate != nullptr ? assosiate->GetLOT() : 0);
 
-	std::vector<Entity*> scriptedActs = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::SHOOTING_GALLERY);
+	std::vector<Entity*> scriptedActs = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SHOOTING_GALLERY);
 	for (Entity* scriptEntity : scriptedActs) {
 		scriptEntity->OnActivityStateChangeRequest(objectID, value1, value2, stringValue);
 	}
@@ -2238,7 +2238,7 @@ void GameMessages::HandleQueryPropertyData(RakNet::BitStream* inStream, Entity* 
 	Game::logger->Log("HandleQueryPropertyData", "Entity (%i) requesting data", entity->GetLOT());
 
 	/*
-	auto entites = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::PROPERTY_VENDOR);
+	auto entites = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::PROPERTY_VENDOR);
 
 	entity = entites[0];
 	*/
@@ -2250,7 +2250,7 @@ void GameMessages::HandleQueryPropertyData(RakNet::BitStream* inStream, Entity* 
 	}
 
 	/*
-	entites = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::PROPERTY_MANAGEMENT);
+	entites = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::PROPERTY_MANAGEMENT);
 
 	entity = entites[0];
 	*/
@@ -2285,7 +2285,7 @@ void GameMessages::HandleSetBuildMode(RakNet::BitStream* inStream, Entity* entit
 	if (inStream->ReadBit())
 		inStream->Read(startPosition);
 
-	auto* player = EntityManager::Instance()->GetEntity(playerId);
+	auto* player = Game::entityManager->GetEntity(playerId);
 
 	if (startPosition == NiPoint3::ZERO) {
 		startPosition = player->GetPosition();
@@ -2333,7 +2333,7 @@ void GameMessages::HandleStartBuildingWithItem(RakNet::BitStream* inStream, Enti
 
 	auto* user = UserManager::Instance()->GetUser(sysAddr);
 
-	auto* player = EntityManager::Instance()->GetEntity(user->GetLoggedInChar());
+	auto* player = Game::entityManager->GetEntity(user->GetLoggedInChar());
 
 	SendStartArrangingWithItem(
 		player,
@@ -2367,7 +2367,7 @@ void GameMessages::HandlePropertyEditorEnd(RakNet::BitStream* inStream, Entity* 
 void GameMessages::HandlePropertyContentsFromClient(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 
-	Entity* player = EntityManager::Instance()->GetEntity(user->GetLoggedInChar());
+	Entity* player = Game::entityManager->GetEntity(user->GetLoggedInChar());
 
 	SendGetModelsOnProperty(player->GetObjectID(), PropertyManagementComponent::Instance()->GetModels(), UNASSIGNED_SYSTEM_ADDRESS);
 }
@@ -2730,9 +2730,9 @@ void GameMessages::HandleBBBSaveRequest(RakNet::BitStream* inStream, Entity* ent
 				info.settings.push_back(propertyObjectID);
 				info.settings.push_back(userModelID);
 
-				Entity* newEntity = EntityManager::Instance()->CreateEntity(info, nullptr);
+				Entity* newEntity = Game::entityManager->CreateEntity(info, nullptr);
 				if (newEntity) {
-					EntityManager::Instance()->ConstructEntity(newEntity);
+					Game::entityManager->ConstructEntity(newEntity);
 
 					//Make sure the propMgmt doesn't delete our model after the server dies
 					//Trying to do this after the entity is constructed. Shouldn't really change anything but
@@ -2928,7 +2928,7 @@ void GameMessages::HandleCinematicUpdate(RakNet::BitStream* inStream, Entity* en
 		inStream->Read<int32_t>(waypoint);
 	}
 
-	std::vector<Entity*> scriptedActs = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::SCRIPT);
+	std::vector<Entity*> scriptedActs = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SCRIPT);
 	for (Entity* scriptEntity : scriptedActs) {
 		scriptEntity->OnCinematicUpdate(scriptEntity, entity, event, pathName, pathTime, overallTime, waypoint);
 	}
@@ -3308,7 +3308,7 @@ void GameMessages::HandleClientTradeRequest(RakNet::BitStream* inStream, Entity*
 
 	inStream->Read(i64Invitee);
 
-	auto* invitee = EntityManager::Instance()->GetEntity(i64Invitee);
+	auto* invitee = Game::entityManager->GetEntity(i64Invitee);
 
 	if (invitee != nullptr && invitee->IsPlayer()) {
 		character = invitee->GetCharacter();
@@ -3895,7 +3895,7 @@ void GameMessages::HandleMessageBoxResponse(RakNet::BitStream* inStream, Entity*
 		racingControlComponent->HandleMessageBoxResponse(userEntity, iButton, GeneralUtils::UTF16ToWTF8(identifier));
 	}
 
-	for (auto* shootingGallery : EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::SHOOTING_GALLERY)) {
+	for (auto* shootingGallery : Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SHOOTING_GALLERY)) {
 		shootingGallery->OnMessageBoxResponse(userEntity, iButton, identifier, userData);
 	}
 }
@@ -4056,7 +4056,7 @@ void GameMessages::HandleDismountComplete(RakNet::BitStream* inStream, Entity* e
 	// If we aren't possessing somethings, the don't do anything
 	if (objectId != LWOOBJID_EMPTY) {
 		auto* possessorComponent = entity->GetComponent<PossessorComponent>();
-		auto* mount = EntityManager::Instance()->GetEntity(objectId);
+		auto* mount = Game::entityManager->GetEntity(objectId);
 		// make sure we have the things we need and they aren't null
 		if (possessorComponent && mount) {
 			if (!possessorComponent->GetIsDismounting()) return;
@@ -4081,7 +4081,7 @@ void GameMessages::HandleDismountComplete(RakNet::BitStream* inStream, Entity* e
 			if (possessableComponent) possessableComponent->Dismount();
 
 			// Update the entity that was possessing
-			EntityManager::Instance()->SerializeEntity(entity);
+			Game::entityManager->SerializeEntity(entity);
 
 			// We aren't mounted so remove the stun
 			GameMessages::SendSetStunned(entity->GetObjectID(), eStateChangeType::POP, UNASSIGNED_SYSTEM_ADDRESS, LWOOBJID_EMPTY, true, false, true, false, false, false, false, true, true, true, true, true, true, true, true, true);
@@ -4091,11 +4091,11 @@ void GameMessages::HandleDismountComplete(RakNet::BitStream* inStream, Entity* e
 
 
 void GameMessages::HandleAcknowledgePossession(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
-	EntityManager::Instance()->SerializeEntity(entity);
+	Game::entityManager->SerializeEntity(entity);
 	LWOOBJID objectId{};
 	inStream->Read(objectId);
-	auto* mount = EntityManager::Instance()->GetEntity(objectId);
-	if (mount) EntityManager::Instance()->SerializeEntity(mount);
+	auto* mount = Game::entityManager->GetEntity(objectId);
+	if (mount) Game::entityManager->SerializeEntity(mount);
 }
 
 //Racing
@@ -4131,7 +4131,7 @@ void GameMessages::HandleRacingClientReady(RakNet::BitStream* inStream, Entity* 
 
 	inStream->Read(playerID);
 
-	auto* player = EntityManager::Instance()->GetEntity(playerID);
+	auto* player = Game::entityManager->GetEntity(playerID);
 
 	if (player == nullptr) {
 		return;
@@ -4195,7 +4195,7 @@ void GameMessages::HandleRequestDie(RakNet::BitStream* inStream, Entity* entity,
 		auto* possessableComponent = entity->GetComponent<PossessableComponent>();
 
 		if (possessableComponent != nullptr) {
-			entity = EntityManager::Instance()->GetEntity(possessableComponent->GetPossessor());
+			entity = Game::entityManager->GetEntity(possessableComponent->GetPossessor());
 
 			if (entity == nullptr) {
 				return;
@@ -4222,7 +4222,7 @@ void GameMessages::HandleRacingPlayerInfoResetFinished(RakNet::BitStream* inStre
 
 	inStream->Read(playerID);
 
-	auto* player = EntityManager::Instance()->GetEntity(playerID);
+	auto* player = Game::entityManager->GetEntity(playerID);
 
 	if (player == nullptr) {
 		return;
@@ -4286,7 +4286,7 @@ void GameMessages::HandleVehicleNotifyHitImaginationServer(RakNet::BitStream* in
 	if (inStream->ReadBit()) inStream->Read(pickupSpawnerIndex);
 	if (inStream->ReadBit()) inStream->Read(vehiclePosition);
 
-	auto* pickup = EntityManager::Instance()->GetEntity(pickupObjID);
+	auto* pickup = Game::entityManager->GetEntity(pickupObjID);
 
 	if (pickup == nullptr) {
 		return;
@@ -4295,7 +4295,7 @@ void GameMessages::HandleVehicleNotifyHitImaginationServer(RakNet::BitStream* in
 	auto* possessableComponent = entity->GetComponent<PossessableComponent>();
 
 	if (possessableComponent != nullptr) {
-		entity = EntityManager::Instance()->GetEntity(possessableComponent->GetPossessor());
+		entity = Game::entityManager->GetEntity(possessableComponent->GetPossessor());
 
 		if (entity == nullptr) {
 			return;
@@ -4686,7 +4686,7 @@ void GameMessages::HandleToggleGhostReferenceOverride(RakNet::BitStream* inStrea
 	if (player != nullptr) {
 		player->SetGhostOverride(bOverride);
 
-		EntityManager::Instance()->UpdateGhosting(player);
+		Game::entityManager->UpdateGhosting(player);
 	}
 }
 
@@ -4701,7 +4701,7 @@ void GameMessages::HandleSetGhostReferencePosition(RakNet::BitStream* inStream, 
 	if (player != nullptr) {
 		player->SetGhostOverridePoint(position);
 
-		EntityManager::Instance()->UpdateGhosting(player);
+		Game::entityManager->UpdateGhosting(player);
 	}
 }
 
@@ -4719,7 +4719,7 @@ void GameMessages::HandleBuyFromVendor(RakNet::BitStream* inStream, Entity* enti
 
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 	if (!user) return;
-	Entity* player = EntityManager::Instance()->GetEntity(user->GetLoggedInChar());
+	Entity* player = Game::entityManager->GetEntity(user->GetLoggedInChar());
 	if (!player) return;
 
 	auto* propertyVendorComponent = static_cast<PropertyVendorComponent*>(entity->GetComponent(eReplicaComponentType::PROPERTY_VENDOR));
@@ -4822,7 +4822,7 @@ void GameMessages::HandleSellToVendor(RakNet::BitStream* inStream, Entity* entit
 
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 	if (!user) return;
-	Entity* player = EntityManager::Instance()->GetEntity(user->GetLoggedInChar());
+	Entity* player = Game::entityManager->GetEntity(user->GetLoggedInChar());
 	if (!player) return;
 	Character* character = player->GetCharacter();
 	if (!character) return;
@@ -4853,7 +4853,7 @@ void GameMessages::HandleSellToVendor(RakNet::BitStream* inStream, Entity* entit
 	//inv->RemoveItem(count, -1, iObjID);
 	inv->MoveItemToInventory(item, eInventoryType::VENDOR_BUYBACK, count, true, false, true);
 	character->SetCoins(std::floor(character->GetCoins() + (static_cast<uint32_t>(itemComp.baseValue * sellScalar) * count)), eLootSourceType::VENDOR);
-	//EntityManager::Instance()->SerializeEntity(player); // so inventory updates
+	//Game::entityManager->SerializeEntity(player); // so inventory updates
 	GameMessages::SendVendorTransactionResult(entity, sysAddr);
 }
 
@@ -4872,7 +4872,7 @@ void GameMessages::HandleBuybackFromVendor(RakNet::BitStream* inStream, Entity* 
 
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 	if (!user) return;
-	Entity* player = EntityManager::Instance()->GetEntity(user->GetLoggedInChar());
+	Entity* player = Game::entityManager->GetEntity(user->GetLoggedInChar());
 	if (!player) return;
 	Character* character = player->GetCharacter();
 	if (!character) return;
@@ -4912,7 +4912,7 @@ void GameMessages::HandleBuybackFromVendor(RakNet::BitStream* inStream, Entity* 
 	//inv->RemoveItem(count, -1, iObjID);
 	inv->MoveItemToInventory(item, Inventory::FindInventoryTypeForLot(item->GetLot()), count, true, false);
 	character->SetCoins(character->GetCoins() - cost, eLootSourceType::VENDOR);
-	//EntityManager::Instance()->SerializeEntity(player); // so inventory updates
+	//Game::entityManager->SerializeEntity(player); // so inventory updates
 	GameMessages::SendVendorTransactionResult(entity, sysAddr);
 }
 
@@ -4959,7 +4959,7 @@ void GameMessages::HandleFireEventServerSide(RakNet::BitStream* inStream, Entity
 	if (param3IsDefault) inStream->Read(param3);
 	inStream->Read(senderID);
 
-	auto* sender = EntityManager::Instance()->GetEntity(senderID);
+	auto* sender = Game::entityManager->GetEntity(senderID);
 	auto* player = Player::GetPlayer(sysAddr);
 
 	if (!player) {
@@ -5033,7 +5033,7 @@ void GameMessages::HandleRebuildCancel(RakNet::BitStream* inStream, Entity* enti
 	RebuildComponent* rebComp = static_cast<RebuildComponent*>(entity->GetComponent(eReplicaComponentType::QUICK_BUILD));
 	if (!rebComp) return;
 
-	rebComp->CancelRebuild(EntityManager::Instance()->GetEntity(userID), eQuickBuildFailReason::CANCELED_EARLY);
+	rebComp->CancelRebuild(Game::entityManager->GetEntity(userID), eQuickBuildFailReason::CANCELED_EARLY);
 }
 
 void GameMessages::HandleRequestUse(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
@@ -5049,7 +5049,7 @@ void GameMessages::HandleRequestUse(RakNet::BitStream* inStream, Entity* entity,
 	inStream->Read(objectID);
 	inStream->Read(secondary);
 
-	Entity* interactedObject = EntityManager::Instance()->GetEntity(objectID);
+	Entity* interactedObject = Game::entityManager->GetEntity(objectID);
 
 	if (interactedObject == nullptr) {
 		Game::logger->Log("GameMessages", "Object %llu tried to interact, but doesn't exist!", objectID);
@@ -5102,7 +5102,7 @@ void GameMessages::HandlePlayEmote(RakNet::BitStream* inStream, Entity* entity) 
 	if (!missionComponent) return;
 
 	if (targetID != LWOOBJID_EMPTY) {
-		auto* targetEntity = EntityManager::Instance()->GetEntity(targetID);
+		auto* targetEntity = Game::entityManager->GetEntity(targetID);
 
 		Game::logger->LogDebug("GameMessages", "Emote target found (%d)", targetEntity != nullptr);
 
@@ -5112,7 +5112,7 @@ void GameMessages::HandlePlayEmote(RakNet::BitStream* inStream, Entity* entity) 
 		}
 	} else {
 		Game::logger->LogDebug("GameMessages", "Target ID is empty, using backup");
-		const auto scriptedEntities = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::SCRIPT);
+		const auto scriptedEntities = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SCRIPT);
 
 		const auto& referencePoint = entity->GetPosition();
 
@@ -5140,7 +5140,7 @@ void GameMessages::HandleModularBuildConvertModel(RakNet::BitStream* inStream, E
 
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 	if (!user) return;
-	Entity* character = EntityManager::Instance()->GetEntity(user->GetLoggedInChar());
+	Entity* character = Game::entityManager->GetEntity(user->GetLoggedInChar());
 	if (!character) return;
 	InventoryComponent* inv = static_cast<InventoryComponent*>(character->GetComponent(eReplicaComponentType::INVENTORY));
 	if (!inv) return;
@@ -5198,7 +5198,7 @@ void GameMessages::HandleRespondToMission(RakNet::BitStream* inStream, Entity* e
 		Game::logger->Log("GameMessages", "Unable to get mission %i for entity %llu to update reward in RespondToMission", missionID, playerID);
 	}
 
-	Entity* offerer = EntityManager::Instance()->GetEntity(receiverID);
+	Entity* offerer = Game::entityManager->GetEntity(receiverID);
 
 	if (offerer == nullptr) {
 		Game::logger->Log("GameMessages", "Unable to get receiver entity %llu for RespondToMission", receiverID);
@@ -5206,7 +5206,7 @@ void GameMessages::HandleRespondToMission(RakNet::BitStream* inStream, Entity* e
 	}
 
 	for (CppScripts::Script* script : CppScripts::GetEntityScripts(offerer)) {
-		script->OnRespondToMission(offerer, missionID, EntityManager::Instance()->GetEntity(playerID), reward);
+		script->OnRespondToMission(offerer, missionID, Game::entityManager->GetEntity(playerID), reward);
 	}
 }
 
@@ -5221,7 +5221,7 @@ void GameMessages::HandleMissionDialogOK(RakNet::BitStream* inStream, Entity* en
 	inStream->Read(iMissionState);
 	inStream->Read(missionID);
 	inStream->Read(responder);
-	player = EntityManager::Instance()->GetEntity(responder);
+	player = Game::entityManager->GetEntity(responder);
 
 	for (CppScripts::Script* script : CppScripts::GetEntityScripts(entity)) {
 		script->OnMissionDialogueOK(entity, player, missionID, iMissionState);
@@ -5250,7 +5250,7 @@ void GameMessages::HandleRequestLinkedMission(RakNet::BitStream* inStream, Entit
 	inStream->Read(missionId);
 	inStream->Read(bMissionOffered);
 
-	auto* player = EntityManager::Instance()->GetEntity(playerId);
+	auto* player = Game::entityManager->GetEntity(playerId);
 
 	auto* missionOfferComponent = static_cast<MissionOfferComponent*>(entity->GetComponent(eReplicaComponentType::MISSION_OFFER));
 
@@ -5263,7 +5263,7 @@ void GameMessages::HandleHasBeenCollected(RakNet::BitStream* inStream, Entity* e
 	LWOOBJID playerID;
 	inStream->Read(playerID);
 
-	Entity* player = EntityManager::Instance()->GetEntity(playerID);
+	Entity* player = Game::entityManager->GetEntity(playerID);
 	if (!player || !entity || entity->GetCollectibleID() == 0) return;
 
 	MissionComponent* missionComponent = static_cast<MissionComponent*>(player->GetComponent(eReplicaComponentType::MISSION));
@@ -5377,7 +5377,7 @@ void GameMessages::HandleEquipItem(RakNet::BitStream* inStream, Entity* entity) 
 
 	item->Equip();
 
-	EntityManager::Instance()->SerializeEntity(entity);
+	Game::entityManager->SerializeEntity(entity);
 }
 
 void GameMessages::HandleUnequipItem(RakNet::BitStream* inStream, Entity* entity) {
@@ -5397,7 +5397,7 @@ void GameMessages::HandleUnequipItem(RakNet::BitStream* inStream, Entity* entity
 
 	item->UnEquip();
 
-	EntityManager::Instance()->SerializeEntity(entity);
+	Game::entityManager->SerializeEntity(entity);
 }
 
 void GameMessages::HandleRemoveItemFromInventory(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
@@ -5482,7 +5482,7 @@ void GameMessages::HandleRemoveItemFromInventory(RakNet::BitStream* inStream, En
 		}
 
 		item->SetCount(item->GetCount() - iStackCount, true);
-		EntityManager::Instance()->SerializeEntity(entity);
+		Game::entityManager->SerializeEntity(entity);
 
 		auto* missionComponent = entity->GetComponent<MissionComponent>();
 
@@ -5516,7 +5516,7 @@ void GameMessages::HandleMoveItemInInventory(RakNet::BitStream* inStream, Entity
 	}
 
 	inv->MoveStack(item, static_cast<eInventoryType>(destInvType), slot);
-	EntityManager::Instance()->SerializeEntity(entity);
+	Game::entityManager->SerializeEntity(entity);
 }
 
 void GameMessages::HandleMoveItemBetweenInventoryTypes(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
@@ -5562,7 +5562,7 @@ void GameMessages::HandleMoveItemBetweenInventoryTypes(RakNet::BitStream* inStre
 	}
 
 	inv->MoveItemToInventory(item, inventoryTypeB, stackCount, showFlyingLoot);
-	EntityManager::Instance()->SerializeEntity(entity);
+	Game::entityManager->SerializeEntity(entity);
 }
 
 void GameMessages::HandleBuildModeSet(RakNet::BitStream* inStream, Entity* entity) {
@@ -5581,7 +5581,7 @@ void GameMessages::HandleBuildModeSet(RakNet::BitStream* inStream, Entity* entit
 void GameMessages::HandleModularBuildFinish(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 	if (!user) return;
-	Entity* character = EntityManager::Instance()->GetEntity(user->GetLoggedInChar());
+	Entity* character = Game::entityManager->GetEntity(user->GetLoggedInChar());
 	if (!character) return;
 	InventoryComponent* inv = static_cast<InventoryComponent*>(character->GetComponent(eReplicaComponentType::INVENTORY));
 	if (!inv) return;
@@ -5592,7 +5592,7 @@ void GameMessages::HandleModularBuildFinish(RakNet::BitStream* inStream, Entity*
 	GameMessages::SendModularBuildEnd(character); // i dont know if this does anything but DLUv2 did it
 
 	//inv->UnequipItem(inv->GetItemStackByLOT(6086, eInventoryType::ITEMS)); // take off the thinking cap
-	//EntityManager::Instance()->SerializeEntity(entity);
+	//Game::entityManager->SerializeEntity(entity);
 
 	uint8_t count; // 3 for rockets, 7 for cars
 
@@ -5669,7 +5669,7 @@ void GameMessages::HandleModularBuildFinish(RakNet::BitStream* inStream, Entity*
 void GameMessages::HandleDoneArrangingWithItem(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 	if (!user) return;
-	Entity* character = EntityManager::Instance()->GetEntity(user->GetLoggedInChar());
+	Entity* character = Game::entityManager->GetEntity(user->GetLoggedInChar());
 	if (!character) return;
 	InventoryComponent* inv = static_cast<InventoryComponent*>(character->GetComponent(eReplicaComponentType::INVENTORY));
 	if (!inv) return;
@@ -5722,9 +5722,9 @@ void GameMessages::HandleDoneArrangingWithItem(RakNet::BitStream* inStream, Enti
 	*/
 
 	if (PropertyManagementComponent::Instance() != nullptr) {
-		const auto& buildAreas = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::BUILD_BORDER);
+		const auto& buildAreas = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::BUILD_BORDER);
 
-		const auto& entities = EntityManager::Instance()->GetEntitiesInGroup("PropertyPlaque");
+		const auto& entities = Game::entityManager->GetEntitiesInGroup("PropertyPlaque");
 
 		Entity* buildArea;
 
@@ -5780,7 +5780,7 @@ void GameMessages::HandleDoneArrangingWithItem(RakNet::BitStream* inStream, Enti
 void GameMessages::HandleModularBuildMoveAndEquip(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 	if (!user) return;
-	Entity* character = EntityManager::Instance()->GetEntity(user->GetLoggedInChar());
+	Entity* character = Game::entityManager->GetEntity(user->GetLoggedInChar());
 	if (!character) return;
 
 	Game::logger->Log("GameMessages", "Build and move");
@@ -5813,7 +5813,7 @@ void GameMessages::HandlePickupItem(RakNet::BitStream* inStream, Entity* entity)
 
 	if (team != nullptr) {
 		for (const auto memberId : team->members) {
-			auto* member = EntityManager::Instance()->GetEntity(memberId);
+			auto* member = Game::entityManager->GetEntity(memberId);
 
 			if (member == nullptr || memberId == playerID) continue;
 
@@ -5825,12 +5825,12 @@ void GameMessages::HandlePickupItem(RakNet::BitStream* inStream, Entity* entity)
 void GameMessages::HandleResurrect(RakNet::BitStream* inStream, Entity* entity) {
 	bool immediate = inStream->ReadBit();
 
-	Entity* zoneControl = EntityManager::Instance()->GetZoneControlEntity();
+	Entity* zoneControl = Game::entityManager->GetZoneControlEntity();
 	for (CppScripts::Script* script : CppScripts::GetEntityScripts(zoneControl)) {
 		script->OnPlayerResurrected(zoneControl, entity);
 	}
 
-	std::vector<Entity*> scriptedActs = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::SCRIPTED_ACTIVITY);
+	std::vector<Entity*> scriptedActs = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SCRIPTED_ACTIVITY);
 	for (Entity* scriptEntity : scriptedActs) {
 		if (scriptEntity->GetObjectID() != zoneControl->GetObjectID()) { // Don't want to trigger twice on instance worlds
 			for (CppScripts::Script* script : CppScripts::GetEntityScripts(scriptEntity)) {
@@ -5850,7 +5850,7 @@ void GameMessages::HandlePopEquippedItemsState(RakNet::BitStream* inStream, Enti
 	InventoryComponent* inv = static_cast<InventoryComponent*>(entity->GetComponent(eReplicaComponentType::INVENTORY));
 	if (!inv) return;
 	inv->PopEquippedItems();
-	EntityManager::Instance()->SerializeEntity(entity); // so it updates on client side
+	Game::entityManager->SerializeEntity(entity); // so it updates on client side
 }
 
 
@@ -5916,7 +5916,7 @@ void GameMessages::HandleMatchRequest(RakNet::BitStream* inStream, Entity* entit
 	inStream->Read(type);
 	inStream->Read(value);
 
-	std::vector<Entity*> scriptedActs = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::SCRIPTED_ACTIVITY);
+	std::vector<Entity*> scriptedActs = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SCRIPTED_ACTIVITY);
 	if (type == 0) { // join
 		if (value != 0) {
 			for (Entity* scriptedAct : scriptedActs) {
@@ -6049,7 +6049,7 @@ void GameMessages::HandleReportBug(RakNet::BitStream* inStream, Entity* entity) 
 
 void
 GameMessages::HandleClientRailMovementReady(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
-	const auto possibleRails = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::RAIL_ACTIVATOR);
+	const auto possibleRails = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::RAIL_ACTIVATOR);
 	for (const auto* possibleRail : possibleRails) {
 		const auto* rail = possibleRail->GetComponent<RailActivatorComponent>();
 		if (rail != nullptr) {
@@ -6061,7 +6061,7 @@ GameMessages::HandleClientRailMovementReady(RakNet::BitStream* inStream, Entity*
 void GameMessages::HandleCancelRailMovement(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
 	const auto immediate = inStream->ReadBit();
 
-	const auto possibleRails = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::RAIL_ACTIVATOR);
+	const auto possibleRails = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::RAIL_ACTIVATOR);
 	for (const auto* possibleRail : possibleRails) {
 		auto* rail = possibleRail->GetComponent<RailActivatorComponent>();
 		if (rail != nullptr) {
@@ -6085,7 +6085,7 @@ void GameMessages::HandlePlayerRailArrivedNotification(RakNet::BitStream* inStre
 	int32_t waypointNumber;
 	inStream->Read(waypointNumber);
 
-	const auto possibleRails = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::RAIL_ACTIVATOR);
+	const auto possibleRails = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::RAIL_ACTIVATOR);
 	for (auto* possibleRail : possibleRails) {
 		for (CppScripts::Script* script : CppScripts::GetEntityScripts(possibleRail)) {
 			script->OnPlayerRailArrived(possibleRail, entity, pathName, waypointNumber);
@@ -6178,7 +6178,7 @@ void GameMessages::SendDeactivateBubbleBuffFromServer(LWOOBJID objectId, const S
 void GameMessages::HandleZoneSummaryDismissed(RakNet::BitStream* inStream, Entity* entity) {
 	LWOOBJID player_id;
 	inStream->Read<LWOOBJID>(player_id);
-	auto target = EntityManager::Instance()->GetEntity(player_id);
+	auto target = Game::entityManager->GetEntity(player_id);
 	entity->TriggerEvent(eTriggerEventType::ZONE_SUMMARY_DISMISSED, target);
 };
 
@@ -6218,7 +6218,7 @@ void GameMessages::HandleRequestActivityExit(RakNet::BitStream* inStream, Entity
 
 	LWOOBJID player_id = LWOOBJID_EMPTY;
 	inStream->Read(player_id);
-	auto player = EntityManager::Instance()->GetEntity(player_id);
+	auto player = Game::entityManager->GetEntity(player_id);
 	if (!entity || !player) return;
 	entity->RequestActivityExit(entity, player_id, canceled);
 }

--- a/dGame/dInventory/Item.cpp
+++ b/dGame/dInventory/Item.cpp
@@ -100,7 +100,7 @@ Item::Item(
 
 		Game::logger->Log("Item", "Move and equipped (%i) from (%i)", this->lot, this->inventory->GetType());
 
-		EntityManager::Instance()->SerializeEntity(inventory->GetComponent()->GetParent());
+		Game::entityManager->SerializeEntity(inventory->GetComponent()->GetParent());
 	}
 }
 

--- a/dGame/dInventory/ItemSetPassiveAbility.cpp
+++ b/dGame/dInventory/ItemSetPassiveAbility.cpp
@@ -44,7 +44,7 @@ void ItemSetPassiveAbility::Activate(Entity* target) {
 		return;
 	}
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	const auto id = static_cast<eItemSetPassiveAbilityID>(m_ItemSet->GetID());
 	const auto parentID = m_Parent->GetObjectID();
@@ -203,7 +203,7 @@ void ItemSetPassiveAbility::OnEnemySmshed(Entity* target) {
 		return;
 	}
 
-	EntityManager::Instance()->SerializeEntity(m_Parent);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	const auto id = static_cast<eItemSetPassiveAbilityID>(m_ItemSet->GetID());
 	const auto parentID = m_Parent->GetObjectID();

--- a/dGame/dMission/Mission.cpp
+++ b/dGame/dMission/Mission.cpp
@@ -547,7 +547,7 @@ void Mission::YieldRewards() {
 		destroyableComponent->SetMaxImagination(destroyableComponent->GetMaxImagination() + static_cast<float>(info->reward_maximagination), true);
 	}
 
-	EntityManager::Instance()->SerializeEntity(entity);
+	Game::entityManager->SerializeEntity(entity);
 
 	if (info->reward_emote > 0) {
 		character->UnlockEmote(info->reward_emote);

--- a/dGame/dMission/MissionTask.cpp
+++ b/dGame/dMission/MissionTask.cpp
@@ -230,7 +230,7 @@ void MissionTask::Progress(int32_t value, LWOOBJID associate, const std::string&
 			break;
 		}
 
-		entity = EntityManager::Instance()->GetEntity(associate);
+		entity = Game::entityManager->GetEntity(associate);
 		if (entity == nullptr) {
 			if (associate != LWOOBJID_EMPTY) {
 				Game::logger->Log("MissionTask", "Failed to find associated entity (%llu)!", associate);
@@ -272,7 +272,7 @@ void MissionTask::Progress(int32_t value, LWOOBJID associate, const std::string&
 	{
 		if (!InParameters(value)) break;
 
-		entity = EntityManager::Instance()->GetEntity(associate);
+		entity = Game::entityManager->GetEntity(associate);
 
 		if (entity == nullptr) {
 			Game::logger->Log("MissionTask", "Failed to find associated entity (%llu)!", associate);
@@ -302,7 +302,7 @@ void MissionTask::Progress(int32_t value, LWOOBJID associate, const std::string&
 
 	case eMissionTaskType::PERFORM_ACTIVITY:
 	{
-		auto* minigameManager = EntityManager::Instance()->GetEntity(associate);
+		auto* minigameManager = Game::entityManager->GetEntity(associate);
 		if (minigameManager == nullptr)
 			break;
 
@@ -346,7 +346,7 @@ void MissionTask::Progress(int32_t value, LWOOBJID associate, const std::string&
 	{
 		if (!InAllTargets(value)) break;
 
-		entity = EntityManager::Instance()->GetEntity(associate);
+		entity = Game::entityManager->GetEntity(associate);
 
 		if (entity == nullptr) {
 			Game::logger->Log("MissionTask", "Failed to find associated entity (%llu)!", associate);

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -184,7 +184,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		}
 
 		character->SetPvpEnabled(!character->GetPvpEnabled());
-		EntityManager::Instance()->SerializeEntity(entity);
+		Game::entityManager->SerializeEntity(entity);
 
 		std::stringstream message;
 		message << character->GetName() << " changed their PVP flag to " << std::to_string(character->GetPvpEnabled()) << "!";
@@ -289,7 +289,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		const auto objid = entity->GetObjectID();
 
 		ZoneInstanceManager::Instance()->RequestZoneTransfer(Game::server, newZone, 0, false, [objid](bool mythranShift, uint32_t zoneID, uint32_t zoneInstance, uint32_t zoneClone, std::string serverIP, uint16_t serverPort) {
-			auto* entity = EntityManager::Instance()->GetEntity(objid);
+			auto* entity = Game::entityManager->GetEntity(objid);
 
 			if (entity == nullptr) {
 				return;
@@ -372,7 +372,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			ChatPackets::SendSystemMessage(sysAddr, u"Invalid Minifig Item Id ID.");
 			return;
 		}
-		EntityManager::Instance()->DestructEntity(entity, sysAddr);
+		Game::entityManager->DestructEntity(entity, sysAddr);
 		auto* charComp = entity->GetComponent<CharacterComponent>();
 		std::string lowerName = args[0];
 		if (lowerName.empty()) return;
@@ -399,12 +399,12 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			charComp->m_Character->SetLeftHand(minifigItemId);
 			charComp->m_Character->SetRightHand(minifigItemId);
 		} else {
-			EntityManager::Instance()->ConstructEntity(entity);
+			Game::entityManager->ConstructEntity(entity);
 			ChatPackets::SendSystemMessage(sysAddr, u"Invalid Minifig item to change, try one of the following: Eyebrows, Eyes, HairColor, HairStyle, Pants, LeftHand, Mouth, RightHand, Shirt, Hands");
 			return;
 		}
 
-		EntityManager::Instance()->ConstructEntity(entity);
+		Game::entityManager->ConstructEntity(entity);
 		ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16(lowerName) + u" set to " + (GeneralUtils::to_u16string(minifigItemId)));
 
 		GameMessages::SendToggleGMInvis(entity->GetObjectID(), false, UNASSIGNED_SYSTEM_ADDRESS); // need to retoggle because it gets reenabled on creation of new character
@@ -415,13 +415,13 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		RenderComponent::PlayAnimation(entity, anim);
 		auto* possessorComponent = entity->GetComponent<PossessorComponent>();
 		if (possessorComponent) {
-			auto* possessedComponent = EntityManager::Instance()->GetEntity(possessorComponent->GetPossessable());
+			auto* possessedComponent = Game::entityManager->GetEntity(possessorComponent->GetPossessable());
 			if (possessedComponent) RenderComponent::PlayAnimation(possessedComponent, anim);
 		}
 	}
 
 	if (chatCommand == "list-spawns" && entity->GetGMLevel() >= eGameMasterLevel::DEVELOPER) {
-		for (const auto& pair : EntityManager::Instance()->GetSpawnPointEntities()) {
+		for (const auto& pair : Game::entityManager->GetSpawnPointEntities()) {
 			ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16(pair.first));
 		}
 
@@ -450,7 +450,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 		auto* user = UserManager::Instance()->GetUser(args[0]);
 		if (user) {
-			auto* player = EntityManager::Instance()->GetEntity(user->GetLoggedInChar());
+			auto* player = Game::entityManager->GetEntity(user->GetLoggedInChar());
 			player->Smash(entity->GetObjectID());
 			ChatPackets::SendSystemMessage(sysAddr, u"It has been done, do you feel good about yourself now?");
 			return;
@@ -478,7 +478,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		if (possessor) {
 			auto possessedID = possessor->GetPossessable();
 			if (possessedID != LWOOBJID_EMPTY) {
-				auto possessable = EntityManager::Instance()->GetEntity(possessedID);
+				auto possessable = Game::entityManager->GetEntity(possessedID);
 				if (possessable) {
 					auto* possessControllablePhysicsComponent = possessable->GetComponent<ControllablePhysicsComponent>();
 					if (possessControllablePhysicsComponent) {
@@ -488,7 +488,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			}
 		}
 
-		EntityManager::Instance()->SerializeEntity(entity);
+		Game::entityManager->SerializeEntity(entity);
 	}
 
 	if (chatCommand == "freecam" && entity->GetGMLevel() >= eGameMasterLevel::DEVELOPER) {
@@ -937,13 +937,13 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 		auto* possessorComponent = entity->GetComponent<PossessorComponent>();
 		if (possessorComponent) {
-			auto* possassableEntity = EntityManager::Instance()->GetEntity(possessorComponent->GetPossessable());
+			auto* possassableEntity = Game::entityManager->GetEntity(possessorComponent->GetPossessable());
 
 			if (possassableEntity != nullptr) {
 				auto* vehiclePhysicsComponent = possassableEntity->GetComponent<VehiclePhysicsComponent>();
 				if (vehiclePhysicsComponent) {
 					vehiclePhysicsComponent->SetPosition(pos);
-					EntityManager::Instance()->SerializeEntity(possassableEntity);
+					Game::entityManager->SerializeEntity(possassableEntity);
 				} else GameMessages::SendTeleport(possassableEntity->GetObjectID(), pos, NiQuaternion(), sysAddr);
 			}
 		}
@@ -952,7 +952,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 	if (chatCommand == "tpall" && entity->GetGMLevel() >= eGameMasterLevel::DEVELOPER) {
 		const auto pos = entity->GetPosition();
 
-		const auto characters = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::CHARACTER);
+		const auto characters = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::CHARACTER);
 
 		for (auto* character : characters) {
 			GameMessages::SendTeleport(character->GetObjectID(), pos, NiQuaternion(), character->GetSystemAddress());
@@ -966,7 +966,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		if (possessorComponent) {
 			auto possessableId = possessorComponent->GetPossessable();
 			if (possessableId != LWOOBJID_EMPTY) {
-				auto* possessableEntity = EntityManager::Instance()->GetEntity(possessableId);
+				auto* possessableEntity = Game::entityManager->GetEntity(possessableId);
 				if (possessableEntity) possessorComponent->Dismount(possessableEntity, true);
 			}
 		}
@@ -1180,7 +1180,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			dest->SetImagination(999);
 			dest->SetMaxImagination(999.0f);
 		}
-		EntityManager::Instance()->SerializeEntity(entity);
+		Game::entityManager->SerializeEntity(entity);
 	}
 
 	if (chatCommand == "startcelebration" && entity->GetGMLevel() >= eGameMasterLevel::DEVELOPER && args.size() == 1) {
@@ -1204,7 +1204,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			dest->SetImagination(9);
 			dest->SetMaxImagination(9.0f);
 		}
-		EntityManager::Instance()->SerializeEntity(entity);
+		Game::entityManager->SerializeEntity(entity);
 	}
 
 	if (chatCommand == "refillstats" && entity->GetGMLevel() >= eGameMasterLevel::DEVELOPER) {
@@ -1216,7 +1216,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			dest->SetImagination((int)dest->GetMaxImagination());
 		}
 
-		EntityManager::Instance()->SerializeEntity(entity);
+		Game::entityManager->SerializeEntity(entity);
 	}
 
 	if (chatCommand == "lookup" && entity->GetGMLevel() >= eGameMasterLevel::DEVELOPER && args.size() >= 1) {
@@ -1260,14 +1260,14 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		info.spawnerID = entity->GetObjectID();
 		info.spawnerNodeID = 0;
 
-		Entity* newEntity = EntityManager::Instance()->CreateEntity(info, nullptr);
+		Entity* newEntity = Game::entityManager->CreateEntity(info, nullptr);
 
 		if (newEntity == nullptr) {
 			ChatPackets::SendSystemMessage(sysAddr, u"Failed to spawn entity.");
 			return;
 		}
 
-		EntityManager::Instance()->ConstructEntity(newEntity);
+		Game::entityManager->ConstructEntity(newEntity);
 	}
 
 	if (chatCommand == "spawngroup" && entity->GetGMLevel() >= eGameMasterLevel::DEVELOPER && args.size() >= 3) {
@@ -1310,13 +1310,13 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			info.pos = playerPosition + NiPoint3(cos(randomAngle) * randomRadius, 0.0f, sin(randomAngle) * randomRadius);
 			info.rot = NiQuaternion();
 
-			auto newEntity = EntityManager::Instance()->CreateEntity(info);
+			auto newEntity = Game::entityManager->CreateEntity(info);
 			if (newEntity == nullptr) {
 				ChatPackets::SendSystemMessage(sysAddr, u"Failed to spawn entity.");
 				return;
 			}
 
-			EntityManager::Instance()->ConstructEntity(newEntity);
+			Game::entityManager->ConstructEntity(newEntity);
 			numberToSpawn--;
 		}
 	}
@@ -1545,7 +1545,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 			ZoneInstanceManager::Instance()->RequestZoneTransfer(Game::server, reqZone, cloneId, false, [objid](bool mythranShift, uint32_t zoneID, uint32_t zoneInstance, uint32_t zoneClone, std::string serverIP, uint16_t serverPort) {
 
-				auto* entity = EntityManager::Instance()->GetEntity(objid);
+				auto* entity = Game::entityManager->GetEntity(objid);
 				if (!entity) return;
 
 				const auto sysAddr = entity->GetSystemAddress();
@@ -1609,7 +1609,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			return;
 		}
 
-		auto* vehicle = EntityManager::Instance()->GetEntity(possessorComponent->GetPossessable());
+		auto* vehicle = Game::entityManager->GetEntity(possessorComponent->GetPossessable());
 
 		if (vehicle == nullptr) {
 			return;
@@ -1638,7 +1638,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		auto* possessorComponent = entity->GetComponent<PossessorComponent>();
 
 		if (possessorComponent == nullptr) return;
-		auto* vehicle = EntityManager::Instance()->GetEntity(possessorComponent->GetPossessable());
+		auto* vehicle = Game::entityManager->GetEntity(possessorComponent->GetPossessable());
 
 		if (vehicle == nullptr) return;
 		GameMessages::SendVehicleRemovePassiveBoostAction(vehicle->GetObjectID(), UNASSIGNED_SYSTEM_ADDRESS);
@@ -1660,7 +1660,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 	if (chatCommand == "spawnphysicsverts" && entity->GetGMLevel() >= eGameMasterLevel::JUNIOR_DEVELOPER) {
 		//Go tell physics to spawn all the vertices:
-		auto entities = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::PHANTOM_PHYSICS);
+		auto entities = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::PHANTOM_PHYSICS);
 		for (auto en : entities) {
 			auto phys = static_cast<PhantomPhysicsComponent*>(en->GetComponent(eReplicaComponentType::PHANTOM_PHYSICS));
 			if (phys)
@@ -1669,7 +1669,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 	}
 
 	if (chatCommand == "reportproxphys" && entity->GetGMLevel() >= eGameMasterLevel::JUNIOR_DEVELOPER) {
-		auto entities = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::PROXIMITY_MONITOR);
+		auto entities = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::PROXIMITY_MONITOR);
 		for (auto en : entities) {
 			auto phys = static_cast<ProximityMonitorComponent*>(en->GetComponent(eReplicaComponentType::PROXIMITY_MONITOR));
 			if (phys) {
@@ -1765,7 +1765,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		Game::config->ReloadConfig();
 		VanityUtilities::SpawnVanity();
 		dpWorld::Instance().Reload();
-		auto entities = EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::SCRIPTED_ACTIVITY);
+		auto entities = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SCRIPTED_ACTIVITY);
 		for (auto entity : entities) {
 			auto* scriptedActivityComponent = entity->GetComponent<ScriptedActivityComponent>();
 			if (!scriptedActivityComponent) continue;
@@ -1862,7 +1862,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 		auto closestDistance = 0.0f;
 
-		const auto candidates = EntityManager::Instance()->GetEntitiesByComponent(component);
+		const auto candidates = Game::entityManager->GetEntitiesByComponent(component);
 
 		for (auto* candidate : candidates) {
 			if (candidate->GetLOT() == 1 || candidate->GetLOT() == 8092) {
@@ -1894,7 +1894,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 			return;
 		}
 
-		EntityManager::Instance()->SerializeEntity(closest);
+		Game::entityManager->SerializeEntity(closest);
 
 		auto* table = CDClientManager::Instance().GetTable<CDObjectsTable>();
 
@@ -1934,7 +1934,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 					movingPlatformComponent->GotoWaypoint(value);
 				}
 
-				EntityManager::Instance()->SerializeEntity(closest);
+				Game::entityManager->SerializeEntity(closest);
 			} else if (args[1] == "-a" && args.size() >= 3) {
 				RenderComponent::PlayAnimation(closest, args.at(2));
 			} else if (args[1] == "-s") {

--- a/dGame/dUtilities/VanityUtilities.cpp
+++ b/dGame/dUtilities/VanityUtilities.cpp
@@ -137,14 +137,14 @@ void VanityUtilities::SpawnVanity() {
 			info.lot = 8139;
 			info.pos = { 259.5f, 246.4f, -705.2f };
 			info.rot = { 0.0f, 0.0f, 1.0f, 0.0f };
-			info.spawnerID = EntityManager::Instance()->GetZoneControlEntity()->GetObjectID();
+			info.spawnerID = Game::entityManager->GetZoneControlEntity()->GetObjectID();
 
 			info.settings = { new LDFData<bool>(u"hasCustomText", true),
 				new LDFData<std::string>(u"customText", ParseMarkdown((BinaryPathFinder::GetBinaryDir() / "vanity/TESTAMENT.md").string())) };
 
-			auto* entity = EntityManager::Instance()->CreateEntity(info);
+			auto* entity = Game::entityManager->CreateEntity(info);
 
-			EntityManager::Instance()->ConstructEntity(entity);
+			Game::entityManager->ConstructEntity(entity);
 		}
 	}
 }
@@ -155,10 +155,10 @@ Entity* VanityUtilities::SpawnNPC(LOT lot, const std::string& name, const NiPoin
 	info.lot = lot;
 	info.pos = position;
 	info.rot = rotation;
-	info.spawnerID = EntityManager::Instance()->GetZoneControlEntity()->GetObjectID();
+	info.spawnerID = Game::entityManager->GetZoneControlEntity()->GetObjectID();
 	info.settings = ldf;
 
-	auto* entity = EntityManager::Instance()->CreateEntity(info);
+	auto* entity = Game::entityManager->CreateEntity(info);
 	entity->SetVar(u"npcName", name);
 
 	auto* inventoryComponent = entity->GetComponent<InventoryComponent>();
@@ -175,7 +175,7 @@ Entity* VanityUtilities::SpawnNPC(LOT lot, const std::string& name, const NiPoin
 		destroyableComponent->SetHealth(0);
 	}
 
-	EntityManager::Instance()->ConstructEntity(entity);
+	Game::entityManager->ConstructEntity(entity);
 
 	return entity;
 }
@@ -535,7 +535,7 @@ void VanityUtilities::NPCTalk(Entity* npc) {
 			npc->GetObjectID(), u"sendToclient_bubble", 0, 0, npc->GetObjectID(), selected, UNASSIGNED_SYSTEM_ADDRESS);
 	}
 
-	EntityManager::Instance()->SerializeEntity(npc);
+	Game::entityManager->SerializeEntity(npc);
 
 	const float nextTime = GeneralUtils::GenerateRandomNumber<float>(15, 60);
 

--- a/dNet/ClientPackets.cpp
+++ b/dNet/ClientPackets.cpp
@@ -82,7 +82,7 @@ void ClientPackets::HandleClientPositionUpdate(const SystemAddress& sysAddr, Pac
 
 	CINSTREAM_SKIP_HEADER;
 
-	Entity* entity = EntityManager::Instance()->GetEntity(user->GetLastUsedChar()->GetObjectID());
+	Entity* entity = Game::entityManager->GetEntity(user->GetLastUsedChar()->GetObjectID());
 	if (!entity) return;
 
 	ControllablePhysicsComponent* comp = static_cast<ControllablePhysicsComponent*>(entity->GetComponent(eReplicaComponentType::CONTROLLABLE_PHYSICS));
@@ -95,7 +95,7 @@ void ClientPackets::HandleClientPositionUpdate(const SystemAddress& sysAddr, Pac
 		comp->SetVelocity(zeroVel);
 		comp->SetAngularVelocity(zeroVel);
 		comp->SetIsOnGround(true); //probably8
-		EntityManager::Instance()->SerializeEntity(entity);
+		Game::entityManager->SerializeEntity(entity);
 		return;
 	}
 	*/
@@ -166,7 +166,7 @@ void ClientPackets::HandleClientPositionUpdate(const SystemAddress& sysAddr, Pac
 	bool updateChar = true;
 
 	if (possessorComponent != nullptr) {
-		auto* possassableEntity = EntityManager::Instance()->GetEntity(possessorComponent->GetPossessable());
+		auto* possassableEntity = Game::entityManager->GetEntity(possessorComponent->GetPossessable());
 
 		if (possassableEntity != nullptr) {
 			auto* possessableComponent = possassableEntity->GetComponent<PossessableComponent>();
@@ -199,7 +199,7 @@ void ClientPackets::HandleClientPositionUpdate(const SystemAddress& sysAddr, Pac
 				controllablePhysicsComponent->SetAngularVelocity(angVelocity);
 				controllablePhysicsComponent->SetDirtyAngularVelocity(angVelocityFlag);
 			}
-			EntityManager::Instance()->SerializeEntity(possassableEntity);
+			Game::entityManager->SerializeEntity(possassableEntity);
 		}
 	}
 
@@ -227,9 +227,9 @@ void ClientPackets::HandleClientPositionUpdate(const SystemAddress& sysAddr, Pac
 
 	auto* player = static_cast<Player*>(entity);
 	player->SetGhostReferencePoint(position);
-	EntityManager::Instance()->QueueGhostUpdate(player->GetObjectID());
+	Game::entityManager->QueueGhostUpdate(player->GetObjectID());
 
-	if (updateChar) EntityManager::Instance()->SerializeEntity(entity);
+	if (updateChar) Game::entityManager->SerializeEntity(entity);
 
 	//TODO: add moving platform stuffs
 	/*bool movingPlatformFlag;
@@ -267,7 +267,7 @@ void ClientPackets::HandleClientPositionUpdate(const SystemAddress& sysAddr, Pac
 			continue;
 		}
 
-		EntityManager::Instance()->SerializeEntity(entity, player);
+		Game::entityManager->SerializeEntity(entity, player);
 	}
 	*/
 }

--- a/dScripts/02_server/Enemy/AG/BossSpiderQueenEnemyServer.cpp
+++ b/dScripts/02_server/Enemy/AG/BossSpiderQueenEnemyServer.cpp
@@ -61,13 +61,13 @@ void BossSpiderQueenEnemyServer::OnDie(Entity* self, Entity* killer) {
 	}
 
 	// There is suppose to be a 0.1 second delay here but that may be admitted?
-	auto* controller = EntityManager::Instance()->GetZoneControlEntity();
+	auto* controller = Game::entityManager->GetZoneControlEntity();
 
 	GameMessages::SendNotifyClientObject(self->GetObjectID(), u"SetColGroup", 10, 0, 0, "", UNASSIGNED_SYSTEM_ADDRESS);
 
 	self->SetPosition({ 10000, 0, 10000 });
 
-	EntityManager::Instance()->SerializeEntity(self);
+	Game::entityManager->SerializeEntity(self);
 
 	controller->OnFireEventServerSide(self, "ClearProperty");
 }
@@ -97,7 +97,7 @@ void BossSpiderQueenEnemyServer::WithdrawSpider(Entity* self, const bool withdra
 
 		rot = controllable->GetRotation();
 
-		EntityManager::Instance()->SerializeEntity(self);
+		Game::entityManager->SerializeEntity(self);
 
 		auto* baseCombatAi = self->GetComponent<BaseCombatAIComponent>();
 
@@ -113,7 +113,7 @@ void BossSpiderQueenEnemyServer::WithdrawSpider(Entity* self, const bool withdra
 		//TODO: Set faction to -1 and set immunity
 		destroyable->SetFaction(-1);
 		destroyable->SetIsImmune(true);
-		EntityManager::Instance()->SerializeEntity(self);
+		Game::entityManager->SerializeEntity(self);
 
 		self->AddTimer("WithdrawComplete", withdrawTime + 1.0f);
 		waitForIdle = true;
@@ -146,7 +146,7 @@ void BossSpiderQueenEnemyServer::WithdrawSpider(Entity* self, const bool withdra
 		//Reset the current wave death counter
 		m_DeathCounter = 0;
 
-		EntityManager::Instance()->SerializeEntity(self);
+		Game::entityManager->SerializeEntity(self);
 
 		// Prepare a timer for post leap attack
 		self->AddTimer("AdvanceAttack", attackPause);
@@ -179,7 +179,7 @@ void BossSpiderQueenEnemyServer::SpiderWaveManager(Entity* self) {
 
 	std::vector<LWOOBJID> spiderEggs{};
 
-	auto spooders = EntityManager::Instance()->GetEntitiesInGroup("EGG");
+	auto spooders = Game::entityManager->GetEntitiesInGroup("EGG");
 	for (auto spodder : spooders) {
 		spiderEggs.push_back(spodder->GetObjectID());
 	}
@@ -201,7 +201,7 @@ void BossSpiderQueenEnemyServer::SpiderWaveManager(Entity* self) {
 			}
 
 			if (randomEgg) {
-				auto* eggEntity = EntityManager::Instance()->GetEntity(randomEgg);
+				auto* eggEntity = Game::entityManager->GetEntity(randomEgg);
 
 				if (eggEntity == nullptr) {
 					continue;
@@ -234,7 +234,7 @@ void BossSpiderQueenEnemyServer::SpiderWaveManager(Entity* self) {
 		// We have successfully readied a full wave
 		// initiate hatching!
 		for (auto egg : hatchList) {
-			auto* eggEntity = EntityManager::Instance()->GetEntity(egg);
+			auto* eggEntity = Game::entityManager->GetEntity(egg);
 
 			if (eggEntity == nullptr) {
 				continue;
@@ -304,7 +304,7 @@ void BossSpiderQueenEnemyServer::RunRainOfFire(Entity* self) {
 
 void BossSpiderQueenEnemyServer::RainOfFireManager(Entity* self) {
 	if (!impactList.empty()) {
-		auto* entity = EntityManager::Instance()->GetEntity(impactList[0]);
+		auto* entity = Game::entityManager->GetEntity(impactList[0]);
 
 		impactList.erase(impactList.begin());
 
@@ -408,7 +408,7 @@ void BossSpiderQueenEnemyServer::OnTimerDone(Entity* self, const std::string tim
 		controllable->SetStatic(false);
 		controllable->SetRotation(rot);
 		controllable->SetStatic(true);
-		EntityManager::Instance()->SerializeEntity(self);
+		Game::entityManager->SerializeEntity(self);
 
 		//Play the Spider Boss' mountain idle anim
 		auto time = PlayAnimAndReturnTime(self, spiderWithdrawIdle);
@@ -419,7 +419,7 @@ void BossSpiderQueenEnemyServer::OnTimerDone(Entity* self, const std::string tim
 		rot = controllable->GetRotation();
 
 		//If there are still baby spiders, don't do anyhting either
-		const auto spiders = EntityManager::Instance()->GetEntitiesInGroup("BabySpider");
+		const auto spiders = Game::entityManager->GetEntitiesInGroup("BabySpider");
 		if (spiders.size() > 0)
 			self->AddTimer("checkForSpiders", time);
 		else
@@ -491,7 +491,7 @@ void BossSpiderQueenEnemyServer::OnTimerDone(Entity* self, const std::string tim
 		}*/
 
 		auto landingTarget = self->GetI64(u"LandingTarget");
-		auto landingEntity = EntityManager::Instance()->GetEntity(landingTarget);
+		auto landingEntity = Game::entityManager->GetEntity(landingTarget);
 
 		auto* skillComponent = self->GetComponent<SkillComponent>();
 
@@ -547,10 +547,10 @@ void BossSpiderQueenEnemyServer::OnTimerDone(Entity* self, const std::string tim
 		destroyable->SetIsImmune(false);
 		destroyable->SetFaction(4);
 
-		EntityManager::Instance()->SerializeEntity(self);
+		Game::entityManager->SerializeEntity(self);
 
 	} else if (timerName == "Clear") {
-		EntityManager::Instance()->FireEventServerSide(self, "ClearProperty");
+		Game::entityManager->FireEventServerSide(self, "ClearProperty");
 		self->CancelAllTimers();
 	} else if (timerName == "UnlockSpecials") {
 		//We no longer need to lock specials
@@ -605,7 +605,7 @@ void BossSpiderQueenEnemyServer::OnUpdate(Entity* self) {
 	controllable->SetRotation(NiQuaternion::IDENTITY);
 	controllable->SetStatic(true);
 
-	EntityManager::Instance()->SerializeEntity(self);
+	Game::entityManager->SerializeEntity(self);
 }
 
 //----------------------------------------------

--- a/dScripts/02_server/Enemy/AM/AmDarklingDragon.cpp
+++ b/dScripts/02_server/Enemy/AM/AmDarklingDragon.cpp
@@ -28,7 +28,7 @@ void AmDarklingDragon::OnDie(Entity* self, Entity* killer) {
 
 	auto golemId = self->GetVar<LWOOBJID>(u"Golem");
 
-	auto* golem = EntityManager::Instance()->GetEntity(golemId);
+	auto* golem = Game::entityManager->GetEntity(golemId);
 
 	if (golem != nullptr) {
 		golem->Smash(self->GetObjectID());
@@ -109,9 +109,9 @@ void AmDarklingDragon::OnHitOrHealResult(Entity* self, Entity* attacker, int32_t
 					new LDFData<LWOOBJID>(u"Dragon", self->GetObjectID())
 			};
 
-			auto* golemObject = EntityManager::Instance()->CreateEntity(info);
+			auto* golemObject = Game::entityManager->CreateEntity(info);
 
-			EntityManager::Instance()->ConstructEntity(golemObject);
+			Game::entityManager->ConstructEntity(golemObject);
 		}
 	}
 }

--- a/dScripts/02_server/Enemy/FV/FvMaelstromCavalry.cpp
+++ b/dScripts/02_server/Enemy/FV/FvMaelstromCavalry.cpp
@@ -3,7 +3,7 @@
 
 void FvMaelstromCavalry::OnStartup(Entity* self) {
 	for (const auto& group : self->GetGroups()) {
-		const auto& objects = EntityManager::Instance()->GetEntitiesInGroup(group);
+		const auto& objects = Game::entityManager->GetEntitiesInGroup(group);
 
 		for (auto* obj : objects) {
 			if (obj->GetLOT() != 8551) continue;
@@ -22,7 +22,7 @@ void FvMaelstromCavalry::OnDie(Entity* self, Entity* killer) {
 		return;
 	}
 
-	const auto& triggers = EntityManager::Instance()->GetEntitiesInGroup("HorsemenTrigger");
+	const auto& triggers = Game::entityManager->GetEntitiesInGroup("HorsemenTrigger");
 
 	for (auto* trigger : triggers) {
 		trigger->OnFireEventServerSide(self, "HorsemenDeath");

--- a/dScripts/02_server/Enemy/FV/FvMaelstromDragon.cpp
+++ b/dScripts/02_server/Enemy/FV/FvMaelstromDragon.cpp
@@ -35,13 +35,13 @@ void FvMaelstromDragon::OnDie(Entity* self, Entity* killer) {
 	info.rot = rotation;
 	info.spawnerID = self->GetObjectID();
 
-	auto* chest = EntityManager::Instance()->CreateEntity(info);
+	auto* chest = Game::entityManager->CreateEntity(info);
 
-	EntityManager::Instance()->ConstructEntity(chest);
+	Game::entityManager->ConstructEntity(chest);
 
 	auto golemId = self->GetVar<LWOOBJID>(u"Golem");
 
-	auto* golem = EntityManager::Instance()->GetEntity(golemId);
+	auto* golem = Game::entityManager->GetEntity(golemId);
 
 	if (golem != nullptr) {
 		golem->Smash(self->GetObjectID());
@@ -125,9 +125,9 @@ void FvMaelstromDragon::OnHitOrHealResult(Entity* self, Entity* attacker, int32_
 					new LDFData<LWOOBJID>(u"Dragon", self->GetObjectID())
 			};
 
-			auto* golemObject = EntityManager::Instance()->CreateEntity(info);
+			auto* golemObject = Game::entityManager->CreateEntity(info);
 
-			EntityManager::Instance()->ConstructEntity(golemObject);
+			Game::entityManager->ConstructEntity(golemObject);
 		}
 	}
 }

--- a/dScripts/02_server/Enemy/General/BaseEnemyApe.cpp
+++ b/dScripts/02_server/Enemy/General/BaseEnemyApe.cpp
@@ -15,7 +15,7 @@ void BaseEnemyApe::OnStartup(Entity* self) {
 }
 
 void BaseEnemyApe::OnDie(Entity* self, Entity* killer) {
-	auto* anchor = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"QB"));
+	auto* anchor = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"QB"));
 	if (anchor != nullptr && !anchor->GetIsDead()) {
 		anchor->Smash(self->GetObjectID(), eKillType::SILENT);
 	}
@@ -56,7 +56,7 @@ void BaseEnemyApe::OnTimerDone(Entity* self, std::string timerName) {
 		if (destroyableComponent != nullptr) {
 			destroyableComponent->SetArmor(destroyableComponent->GetMaxArmor() / timesStunned);
 		}
-		EntityManager::Instance()->SerializeEntity(self);
+		Game::entityManager->SerializeEntity(self);
 		GameMessages::SendChangeIdleFlags(self->GetObjectID(), eAnimationFlags::IDLE_COMBAT, eAnimationFlags::IDLE_NONE, UNASSIGNED_SYSTEM_ADDRESS);
 		self->SetVar<uint32_t>(u"timesStunned", timesStunned + 1);
 		StunApe(self, false);
@@ -92,14 +92,14 @@ void BaseEnemyApe::OnTimerDone(Entity* self, std::string timerName) {
 			new LDFData<LWOOBJID>(u"ape", self->GetObjectID())
 		};
 
-		auto* anchor = EntityManager::Instance()->CreateEntity(entityInfo);
-		EntityManager::Instance()->ConstructEntity(anchor);
+		auto* anchor = Game::entityManager->CreateEntity(entityInfo);
+		Game::entityManager->ConstructEntity(anchor);
 		self->SetVar<LWOOBJID>(u"QB", anchor->GetObjectID());
 
 	} else if (timerName == "anchorDamageTimer") {
 
 		// Attacks the ape with some god skill
-		const auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"smasher"));
+		const auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"smasher"));
 		if (player == nullptr) {
 			return;
 		}

--- a/dScripts/02_server/Enemy/General/BaseEnemyMech.cpp
+++ b/dScripts/02_server/Enemy/General/BaseEnemyMech.cpp
@@ -38,8 +38,8 @@ void BaseEnemyMech::OnDie(Entity* self, Entity* killer) {
 	info.spawnerID = self->GetObjectID();
 	info.settings = cfg;
 
-	Entity* turret = EntityManager::Instance()->CreateEntity(info, nullptr);
+	Entity* turret = Game::entityManager->CreateEntity(info, nullptr);
 	if (turret) {
-		EntityManager::Instance()->ConstructEntity(turret);
+		Game::entityManager->ConstructEntity(turret);
 	}
 }

--- a/dScripts/02_server/Enemy/General/GfApeSmashingQB.cpp
+++ b/dScripts/02_server/Enemy/General/GfApeSmashingQB.cpp
@@ -15,7 +15,7 @@ void GfApeSmashingQB::OnTimerDone(Entity* self, std::string timerName) {
 }
 
 void GfApeSmashingQB::OnRebuildComplete(Entity* self, Entity* target) {
-	auto* ape = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"ape"));
+	auto* ape = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"ape"));
 	if (ape != nullptr) {
 		ape->OnFireEventServerSide(target, "rebuildDone");
 		RenderComponent::PlayAnimation(self, u"smash", 1.7f);

--- a/dScripts/02_server/Enemy/General/TreasureChestDragonServer.cpp
+++ b/dScripts/02_server/Enemy/General/TreasureChestDragonServer.cpp
@@ -29,7 +29,7 @@ void TreasureChestDragonServer::OnUse(Entity* self, Entity* user) {
 		rating = team->members.size();
 
 		for (const auto member : team->members) {
-			auto* memberObject = EntityManager::Instance()->GetEntity(member);
+			auto* memberObject = Game::entityManager->GetEntity(member);
 
 			if (memberObject == nullptr) continue;
 

--- a/dScripts/02_server/Equipment/BootyDigServer.cpp
+++ b/dScripts/02_server/Equipment/BootyDigServer.cpp
@@ -7,14 +7,14 @@
 #include "Loot.h"
 
 void BootyDigServer::OnStartup(Entity* self) {
-	auto* zoneControlObject = EntityManager::Instance()->GetZoneControlEntity();
+	auto* zoneControlObject = Game::entityManager->GetZoneControlEntity();
 	if (zoneControlObject != nullptr) {
 		zoneControlObject->OnFireEventServerSide(self, "CheckForPropertyOwner");
 	}
 }
 
 void BootyDigServer::OnPlayerLoaded(Entity* self, Entity* player) {
-	auto* zoneControlObject = EntityManager::Instance()->GetZoneControlEntity();
+	auto* zoneControlObject = Game::entityManager->GetZoneControlEntity();
 	if (zoneControlObject != nullptr) {
 		zoneControlObject->OnFireEventServerSide(self, "CheckForPropertyOwner");
 	}

--- a/dScripts/02_server/Equipment/MaestromExtracticatorServer.cpp
+++ b/dScripts/02_server/Equipment/MaestromExtracticatorServer.cpp
@@ -18,7 +18,7 @@ void MaestromExtracticatorServer::OnFireEventServerSide(Entity* self, Entity* se
 	if (sender == nullptr) return;
 
 	if (args == "attemptCollection") {
-		Entity* player = EntityManager::Instance()->GetEntity(self->GetSpawnerID());
+		Entity* player = Game::entityManager->GetEntity(self->GetSpawnerID());
 		if (!player) return;
 
 		auto missionComponent = player->GetComponent<MissionComponent>();

--- a/dScripts/02_server/Map/AG/AgCagedBricksServer.cpp
+++ b/dScripts/02_server/Map/AG/AgCagedBricksServer.cpp
@@ -8,7 +8,7 @@
 
 void AgCagedBricksServer::OnUse(Entity* self, Entity* user) {
 	//Tell the client to spawn the baby spiderling:
-	auto spooders = EntityManager::Instance()->GetEntitiesInGroup("cagedSpider");
+	auto spooders = Game::entityManager->GetEntitiesInGroup("cagedSpider");
 	for (auto spodder : spooders) {
 		GameMessages::SendFireEventClientSide(spodder->GetObjectID(), user->GetSystemAddress(), u"toggle", LWOOBJID_EMPTY, 0, 0, user->GetObjectID());
 	}

--- a/dScripts/02_server/Map/AG/AgMonumentBirds.cpp
+++ b/dScripts/02_server/Map/AG/AgMonumentBirds.cpp
@@ -28,7 +28,7 @@ void AgMonumentBirds::OnProximityUpdate(Entity* self, Entity* entering, std::str
 void AgMonumentBirds::OnTimerDone(Entity* self, std::string timerName) {
 	if (timerName != "killBird") return;
 
-	auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"PlayerID"));
+	auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"PlayerID"));
 
 	if (player == nullptr) return;
 

--- a/dScripts/02_server/Map/AG/AgMonumentLaserServer.cpp
+++ b/dScripts/02_server/Map/AG/AgMonumentLaserServer.cpp
@@ -2,14 +2,14 @@
 #include "EntityManager.h"
 
 void AgMonumentLaserServer::OnStartup(Entity* self) {
-	auto lasers = EntityManager::Instance()->GetEntitiesInGroup(self->GetVarAsString(u"volGroup"));
+	auto lasers = Game::entityManager->GetEntitiesInGroup(self->GetVarAsString(u"volGroup"));
 	for (auto laser : lasers) {
 		if (laser) laser->SetBoolean(u"active", true);
 	}
 }
 
 void AgMonumentLaserServer::OnDie(Entity* self, Entity* killer) {
-	auto lasers = EntityManager::Instance()->GetEntitiesInGroup(self->GetVarAsString(u"volGroup"));
+	auto lasers = Game::entityManager->GetEntitiesInGroup(self->GetVarAsString(u"volGroup"));
 	for (auto laser : lasers) {
 		if (laser) laser->SetBoolean(u"active", false);
 	}

--- a/dScripts/02_server/Map/AG/AgMonumentRaceCancel.cpp
+++ b/dScripts/02_server/Map/AG/AgMonumentRaceCancel.cpp
@@ -2,7 +2,7 @@
 #include "EntityManager.h"
 
 void AgMonumentRaceCancel::OnCollisionPhantom(Entity* self, Entity* target) {
-	auto managers = EntityManager::Instance()->GetEntitiesInGroup("race_manager");
+	auto managers = Game::entityManager->GetEntitiesInGroup("race_manager");
 	if (!managers.empty()) {
 		managers[0]->OnFireEventServerSide(target, "course_cancel");
 	}

--- a/dScripts/02_server/Map/AG/AgMonumentRaceGoal.cpp
+++ b/dScripts/02_server/Map/AG/AgMonumentRaceGoal.cpp
@@ -8,7 +8,7 @@ void AgMonumentRaceGoal::OnStartup(Entity* self) {
 
 void AgMonumentRaceGoal::OnProximityUpdate(Entity* self, Entity* entering, std::string name, std::string status) {
 	if (name == "RaceGoal" && entering && entering->IsPlayer() && status == "ENTER") {
-		auto managers = EntityManager::Instance()->GetEntitiesInGroup("race_manager");
+		auto managers = Game::entityManager->GetEntitiesInGroup("race_manager");
 		if (managers.empty() || !managers.at(0)) return;
 		managers.at(0)->OnFireEventServerSide(entering, "course_finish");
 	}

--- a/dScripts/02_server/Map/AG/NpcAgCourseStarter.cpp
+++ b/dScripts/02_server/Map/AG/NpcAgCourseStarter.cpp
@@ -40,7 +40,7 @@ void NpcAgCourseStarter::OnMessageBoxResponse(Entity* self, Entity* sender, int3
 
 		scriptedActivityComponent->RemoveActivityPlayerData(sender->GetObjectID());
 
-		EntityManager::Instance()->SerializeEntity(self);
+		Game::entityManager->SerializeEntity(self);
 	} else if (identifier == u"player_dialog_start_course" && button == 1) {
 		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"start_timer", 0, 0, LWOOBJID_EMPTY, "", sender->GetSystemAddress());
 
@@ -54,7 +54,7 @@ void NpcAgCourseStarter::OnMessageBoxResponse(Entity* self, Entity* sender, int3
 
 		data->values[1] = *(float*)&startTime;
 
-		EntityManager::Instance()->SerializeEntity(self);
+		Game::entityManager->SerializeEntity(self);
 	} else if (identifier == u"FootRaceCancel") {
 		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"stop_timer", 0, 0, LWOOBJID_EMPTY, "", sender->GetSystemAddress());
 
@@ -95,7 +95,7 @@ void NpcAgCourseStarter::OnFireEventServerSide(Entity* self, Entity* sender, std
 				"performact_time");
 		}
 
-		EntityManager::Instance()->SerializeEntity(self);
+		Game::entityManager->SerializeEntity(self);
 		LeaderboardManager::SaveScore(sender->GetObjectID(), scriptedActivityComponent->GetActivityID(),
 			0, (uint32_t)finish);
 

--- a/dScripts/02_server/Map/AG/NpcWispServer.cpp
+++ b/dScripts/02_server/Map/AG/NpcWispServer.cpp
@@ -35,7 +35,7 @@ void NpcWispServer::OnMissionDialogueOK(Entity* self, Entity* target, int missio
 	: std::vector<std::string>{ "MaelstromSamples", "MaelstromSamples2ndary1", "MaelstromSamples2ndary2" };
 
 	for (const auto& group : groups) {
-		auto samples = EntityManager::Instance()->GetEntitiesInGroup(group);
+		auto samples = Game::entityManager->GetEntitiesInGroup(group);
 		for (auto* sample : samples) {
 			GameMessages::SendNotifyClientObject(sample->GetObjectID(), u"SetVisibility", visible, 0,
 				target->GetObjectID(), "", target->GetSystemAddress());

--- a/dScripts/02_server/Map/AG_Spider_Queen/ZoneAgSpiderQueen.cpp
+++ b/dScripts/02_server/Map/AG_Spider_Queen/ZoneAgSpiderQueen.cpp
@@ -63,7 +63,7 @@ void ZoneAgSpiderQueen::OnTimerDone(Entity* self, std::string timerName) {
 		return;
 
 	if (timerName == "killSpider") {
-		auto spawnTargets = EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(LandTargetGroup));
+		auto spawnTargets = Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(LandTargetGroup));
 		for (auto* spawnTarget : spawnTargets) {
 			EntityInfo info{};
 
@@ -75,8 +75,8 @@ void ZoneAgSpiderQueen::OnTimerDone(Entity* self, std::string timerName) {
 					new LDFData<LWOOBJID>(u"parent_tag", self->GetObjectID())
 			};
 
-			auto* chest = EntityManager::Instance()->CreateEntity(info);
-			EntityManager::Instance()->ConstructEntity(chest);
+			auto* chest = Game::entityManager->CreateEntity(info);
+			Game::entityManager->ConstructEntity(chest);
 		}
 	}
 

--- a/dScripts/02_server/Map/AM/AmBlueX.cpp
+++ b/dScripts/02_server/Map/AM/AmBlueX.cpp
@@ -27,16 +27,16 @@ void AmBlueX::OnSkillEventFired(Entity* self, Entity* caster, const std::string&
 		info.rot = self->GetRotation();
 		info.spawnerID = self->GetObjectID();
 
-		auto* fxObject = EntityManager::Instance()->CreateEntity(info, nullptr, self);
-		EntityManager::Instance()->ConstructEntity(fxObject);
+		auto* fxObject = Game::entityManager->CreateEntity(info, nullptr, self);
+		Game::entityManager->ConstructEntity(fxObject);
 
 		auto fxObjectID = fxObject->GetObjectID();
 		auto playerID = caster->GetObjectID();
 
 		// Add a callback for the bomb to explode
 		self->AddCallbackTimer(m_BombTime, [this, self, fxObjectID, playerID]() {
-			auto* fxObject = EntityManager::Instance()->GetEntity(fxObjectID);
-			auto* player = EntityManager::Instance()->GetEntity(playerID);
+			auto* fxObject = Game::entityManager->GetEntity(fxObjectID);
+			auto* player = Game::entityManager->GetEntity(playerID);
 			auto* skillComponent = self->GetComponent<SkillComponent>();
 
 			if (skillComponent == nullptr)

--- a/dScripts/02_server/Map/AM/AmBridge.cpp
+++ b/dScripts/02_server/Map/AM/AmBridge.cpp
@@ -6,7 +6,7 @@ void AmBridge::OnStartup(Entity* self) {
 }
 
 void AmBridge::OnRebuildComplete(Entity* self, Entity* target) {
-	const auto consoles = EntityManager::Instance()->GetEntitiesInGroup("Console" + GeneralUtils::UTF16ToWTF8(self->GetVar<std::u16string>(u"bridge")));
+	const auto consoles = Game::entityManager->GetEntitiesInGroup("Console" + GeneralUtils::UTF16ToWTF8(self->GetVar<std::u16string>(u"bridge")));
 
 	if (consoles.empty()) {
 		return;

--- a/dScripts/02_server/Map/AM/AmDrawBridge.cpp
+++ b/dScripts/02_server/Map/AM/AmDrawBridge.cpp
@@ -68,7 +68,7 @@ void AmDrawBridge::OnTimerDone(Entity* self, std::string timerName) {
 
 		simplePhysicsComponent->SetAngularVelocity(NiPoint3::ZERO);
 
-		EntityManager::Instance()->SerializeEntity(bridge);
+		Game::entityManager->SerializeEntity(bridge);
 	}
 }
 
@@ -103,7 +103,7 @@ void AmDrawBridge::MoveBridgeDown(Entity* self, Entity* bridge, bool down) {
 
 	simplePhysicsComponent->SetAngularVelocity(forwardVect);
 
-	EntityManager::Instance()->SerializeEntity(bridge);
+	Game::entityManager->SerializeEntity(bridge);
 
 	self->AddTimer("rotateBridgeDown", travelTime);
 }
@@ -118,5 +118,5 @@ void AmDrawBridge::NotifyDie(Entity* self, Entity* other) {
 Entity* AmDrawBridge::GetBridge(Entity* self) {
 	const auto bridgeID = self->GetVar<LWOOBJID>(u"BridgeID");
 
-	return EntityManager::Instance()->GetEntity(bridgeID);
+	return Game::entityManager->GetEntity(bridgeID);
 }

--- a/dScripts/02_server/Map/AM/AmShieldGenerator.cpp
+++ b/dScripts/02_server/Map/AM/AmShieldGenerator.cpp
@@ -49,7 +49,7 @@ void AmShieldGenerator::OnProximityUpdate(Entity* self, Entity* entering, std::s
 void AmShieldGenerator::OnDie(Entity* self, Entity* killer) {
 	self->CancelAllTimers();
 
-	auto* child = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"Child"));
+	auto* child = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"Child"));
 
 	if (child != nullptr) {
 		child->Kill();
@@ -69,7 +69,7 @@ void AmShieldGenerator::OnTimerDone(Entity* self, std::string timerName) {
 		auto enemiesInProximity = self->GetVar<std::vector<LWOOBJID>>(u"Enemies");
 
 		for (const auto enemyID : enemiesInProximity) {
-			auto* enemy = EntityManager::Instance()->GetEntity(enemyID);
+			auto* enemy = Game::entityManager->GetEntity(enemyID);
 
 			if (enemy != nullptr) {
 				EnemyEnteredShield(self, enemy);
@@ -94,7 +94,7 @@ void AmShieldGenerator::StartShield(Entity* self) {
 	info.rot = myRot;
 	info.spawnerID = self->GetObjectID();
 
-	auto* child = EntityManager::Instance()->CreateEntity(info);
+	auto* child = Game::entityManager->CreateEntity(info);
 
 	self->SetVar(u"Child", child->GetObjectID());
 
@@ -111,7 +111,7 @@ void AmShieldGenerator::BuffPlayers(Entity* self) {
 	auto entitiesInProximity = self->GetVar<std::vector<LWOOBJID>>(u"Players");
 
 	for (const auto playerID : entitiesInProximity) {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 
 		if (player == nullptr) {
 			return;

--- a/dScripts/02_server/Map/AM/AmShieldGeneratorQuickbuild.cpp
+++ b/dScripts/02_server/Map/AM/AmShieldGeneratorQuickbuild.cpp
@@ -69,7 +69,7 @@ void AmShieldGeneratorQuickbuild::OnProximityUpdate(Entity* self, Entity* enteri
 void AmShieldGeneratorQuickbuild::OnDie(Entity* self, Entity* killer) {
 	self->CancelAllTimers();
 
-	auto* child = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"Child"));
+	auto* child = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"Child"));
 
 	if (child != nullptr) {
 		child->Kill();
@@ -89,7 +89,7 @@ void AmShieldGeneratorQuickbuild::OnTimerDone(Entity* self, std::string timerNam
 		auto enemiesInProximity = self->GetVar<std::vector<LWOOBJID>>(u"Enemies");
 
 		for (const auto enemyID : enemiesInProximity) {
-			auto* enemy = EntityManager::Instance()->GetEntity(enemyID);
+			auto* enemy = Game::entityManager->GetEntity(enemyID);
 
 			if (enemy != nullptr) {
 				EnemyEnteredShield(self, enemy);
@@ -106,7 +106,7 @@ void AmShieldGeneratorQuickbuild::OnRebuildComplete(Entity* self, Entity* target
 	auto enemiesInProximity = self->GetVar<std::vector<LWOOBJID>>(u"Enemies");
 
 	for (const auto enemyID : enemiesInProximity) {
-		auto* enemy = EntityManager::Instance()->GetEntity(enemyID);
+		auto* enemy = Game::entityManager->GetEntity(enemyID);
 
 		if (enemy != nullptr) {
 			enemy->Smash();
@@ -116,7 +116,7 @@ void AmShieldGeneratorQuickbuild::OnRebuildComplete(Entity* self, Entity* target
 	auto entitiesInProximity = self->GetVar<std::vector<LWOOBJID>>(u"Players");
 
 	for (const auto playerID : entitiesInProximity) {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 
 		if (player == nullptr) {
 			continue;
@@ -146,7 +146,7 @@ void AmShieldGeneratorQuickbuild::StartShield(Entity* self) {
 	info.rot = myRot;
 	info.spawnerID = self->GetObjectID();
 
-	auto* child = EntityManager::Instance()->CreateEntity(info);
+	auto* child = Game::entityManager->CreateEntity(info);
 
 	self->SetVar(u"Child", child->GetObjectID());
 
@@ -163,7 +163,7 @@ void AmShieldGeneratorQuickbuild::BuffPlayers(Entity* self) {
 	auto entitiesInProximity = self->GetVar<std::vector<LWOOBJID>>(u"Players");
 
 	for (const auto playerID : entitiesInProximity) {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 
 		if (player == nullptr) {
 			return;

--- a/dScripts/02_server/Map/AM/AmSkullkinDrill.cpp
+++ b/dScripts/02_server/Map/AM/AmSkullkinDrill.cpp
@@ -44,7 +44,7 @@ Entity* AmSkullkinDrill::GetStandObj(Entity* self) {
 
 	groupName.push_back(myGroup[0][myGroup[0].size() - 1]);
 
-	const auto standObjs = EntityManager::Instance()->GetEntitiesInGroup(groupName);
+	const auto standObjs = Game::entityManager->GetEntitiesInGroup(groupName);
 
 	if (standObjs.empty()) {
 		return nullptr;
@@ -105,16 +105,16 @@ void AmSkullkinDrill::OnWaypointReached(Entity* self, uint32_t waypointIndex) {
 		info.scale = 3; // Needs the scale, otherwise attacks fail
 		info.spawnerID = self->GetObjectID();
 
-		auto* child = EntityManager::Instance()->CreateEntity(info);
+		auto* child = Game::entityManager->CreateEntity(info);
 
-		EntityManager::Instance()->ConstructEntity(child);
+		Game::entityManager->ConstructEntity(child);
 
 		self->SetVar(u"ChildSmash", child->GetObjectID());
 
 		child->AddDieCallback([this, self]() {
 			const auto& userID = self->GetVar<LWOOBJID>(u"activaterID");
 
-			auto* player = EntityManager::Instance()->GetEntity(userID);
+			auto* player = Game::entityManager->GetEntity(userID);
 
 			if (player == nullptr) {
 				return;
@@ -180,7 +180,7 @@ void AmSkullkinDrill::OnArrived(Entity* self, uint32_t waypointIndex) {
 
 		const auto playerID = self->GetVar<LWOOBJID>(u"userID");
 
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 
 		if (player != nullptr) {
 			PlayAnim(self, player, "spinjitzu-staff-end");
@@ -199,7 +199,7 @@ void AmSkullkinDrill::OnArrived(Entity* self, uint32_t waypointIndex) {
 }
 
 void AmSkullkinDrill::PlayCinematic(Entity* self) {
-	auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"userID"));
+	auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"userID"));
 
 	if (player == nullptr) {
 		return;
@@ -235,7 +235,7 @@ void AmSkullkinDrill::OnHitOrHealResult(Entity* self, Entity* attacker, int32_t 
 
 	const auto activaterID = self->GetVar<LWOOBJID>(u"activaterID");
 
-	auto* activator = EntityManager::Instance()->GetEntity(activaterID);
+	auto* activator = Game::entityManager->GetEntity(activaterID);
 
 	// TODO: Missions
 	if (activator != nullptr) {
@@ -263,7 +263,7 @@ void AmSkullkinDrill::OnTimerDone(Entity* self, std::string timerName) {
 	if (timerName == "killDrill") {
 		const auto childID = self->GetVar<LWOOBJID>(u"ChildSmash");
 
-		auto* child = EntityManager::Instance()->GetEntity(childID);
+		auto* child = Game::entityManager->GetEntity(childID);
 
 		if (child != nullptr) {
 			child->Smash(self->GetObjectID(), eKillType::SILENT);
@@ -301,7 +301,7 @@ void AmSkullkinDrill::OnTimerDone(Entity* self, std::string timerName) {
 
 		const auto playerID = self->GetVar<LWOOBJID>(u"userID");
 
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 
 		if (player == nullptr) {
 			return;

--- a/dScripts/02_server/Map/AM/AmSkullkinTower.cpp
+++ b/dScripts/02_server/Map/AM/AmSkullkinTower.cpp
@@ -64,9 +64,9 @@ void AmSkullkinTower::SpawnLegs(Entity* self, const std::string& loc) {
 
 	info.rot = NiQuaternion::LookAt(info.pos, self->GetPosition());
 
-	auto* entity = EntityManager::Instance()->CreateEntity(info);
+	auto* entity = Game::entityManager->CreateEntity(info);
 
-	EntityManager::Instance()->ConstructEntity(entity);
+	Game::entityManager->ConstructEntity(entity);
 
 	OnChildLoaded(self, entity);
 }
@@ -81,7 +81,7 @@ void AmSkullkinTower::OnChildLoaded(Entity* self, Entity* child) {
 	const auto selfID = self->GetObjectID();
 
 	child->AddDieCallback([this, selfID, child]() {
-		auto* self = EntityManager::Instance()->GetEntity(selfID);
+		auto* self = Game::entityManager->GetEntity(selfID);
 		auto* destroyableComponent = child->GetComponent<DestroyableComponent>();
 
 		if (destroyableComponent == nullptr || self == nullptr) {
@@ -157,7 +157,7 @@ void AmSkullkinTower::OnChildRemoved(Entity* self, Entity* child) {
 		const auto& players = self->GetVar<std::vector<LWOOBJID>>(u"Players");
 
 		for (const auto& playerID : players) {
-			auto* player = EntityManager::Instance()->GetEntity(playerID);
+			auto* player = Game::entityManager->GetEntity(playerID);
 
 			if (player == nullptr) {
 				continue;
@@ -233,9 +233,9 @@ void AmSkullkinTower::OnTimerDone(Entity* self, std::string timerName) {
 		for (size_t i = 0; i < 2; i++) {
 			info.pos.x += i * 2; // Just to set the apart a bit
 
-			auto* entity = EntityManager::Instance()->CreateEntity(info);
+			auto* entity = Game::entityManager->CreateEntity(info);
 
-			EntityManager::Instance()->ConstructEntity(entity);
+			Game::entityManager->ConstructEntity(entity);
 		}
 
 		self->AddTimer("killTower", 0.7f);

--- a/dScripts/02_server/Map/FV/EnemyRoninSpawner.cpp
+++ b/dScripts/02_server/Map/FV/EnemyRoninSpawner.cpp
@@ -22,13 +22,13 @@ void EnemyRoninSpawner::OnTimerDone(Entity* self, std::string timerName) {
 		info.rot = self->GetRotation();
 		info.spawnerID = self->GetObjectID();
 
-		auto* spawnedEntity = EntityManager::Instance()->CreateEntity(info);
+		auto* spawnedEntity = Game::entityManager->CreateEntity(info);
 
 		if (spawnedEntity == nullptr) {
 			return;
 		}
 
-		EntityManager::Instance()->ConstructEntity(spawnedEntity);
+		Game::entityManager->ConstructEntity(spawnedEntity);
 
 		spawnedEntity->AddCallbackTimer(60, [spawnedEntity]() {
 			spawnedEntity->Smash(spawnedEntity->GetObjectID());

--- a/dScripts/02_server/Map/FV/FvHorsemenTrigger.cpp
+++ b/dScripts/02_server/Map/FV/FvHorsemenTrigger.cpp
@@ -33,7 +33,7 @@ FvHorsemenTrigger::OnFireEventServerSide(Entity* self, Entity* sender, std::stri
 
 	if (args == "HorsemenDeath") {
 		for (const auto& playerId : self->GetVar<std::vector<LWOOBJID>>(u"players")) {
-			auto* player = EntityManager::Instance()->GetEntity(playerId);
+			auto* player = Game::entityManager->GetEntity(playerId);
 
 			if (player == nullptr) {
 				continue;

--- a/dScripts/02_server/Map/FV/ImgBrickConsoleQB.cpp
+++ b/dScripts/02_server/Map/FV/ImgBrickConsoleQB.cpp
@@ -23,7 +23,7 @@ void ImgBrickConsoleQB::OnUse(Entity* self, Entity* user) {
 
 	if (rebuildComponent->GetState() == eRebuildState::COMPLETED) {
 		if (!self->GetNetworkVar<bool>(u"used")) {
-			const auto consoles = EntityManager::Instance()->GetEntitiesInGroup("Console");
+			const auto consoles = Game::entityManager->GetEntitiesInGroup("Console");
 
 			auto bothBuilt = false;
 
@@ -59,7 +59,7 @@ void ImgBrickConsoleQB::OnUse(Entity* self, Entity* user) {
 				onFX = 2779;
 			}
 
-			const auto& facility = EntityManager::Instance()->GetEntitiesInGroup("FacilityPipes");
+			const auto& facility = Game::entityManager->GetEntitiesInGroup("FacilityPipes");
 
 			if (!facility.empty()) {
 				GameMessages::SendStopFXEffect(facility[0], true, location + "PipeEnergy");
@@ -106,13 +106,13 @@ void ImgBrickConsoleQB::SpawnBrick(Entity* self) {
 }
 
 void ImgBrickConsoleQB::SmashCanister(Entity* self) {
-	const auto brick = EntityManager::Instance()->GetEntitiesInGroup("Imagination");
+	const auto brick = Game::entityManager->GetEntitiesInGroup("Imagination");
 	if (!brick.empty()) {
 		GameMessages::SendPlayFXEffect(brick[0]->GetObjectID(), 122, u"create", "bluebrick");
 		GameMessages::SendPlayFXEffect(brick[0]->GetObjectID(), 1034, u"cast", "imaginationexplosion");
 	}
 
-	const auto canisters = EntityManager::Instance()->GetEntitiesInGroup("Canister");
+	const auto canisters = Game::entityManager->GetEntitiesInGroup("Canister");
 	for (auto* canister : canisters) {
 		canister->Smash(canister->GetObjectID(), eKillType::VIOLENT);
 	}
@@ -135,14 +135,14 @@ void ImgBrickConsoleQB::OnRebuildComplete(Entity* self, Entity* target) {
 		energyFX = 2778;
 	}
 
-	const auto& facility = EntityManager::Instance()->GetEntitiesInGroup("FacilityPipes");
+	const auto& facility = Game::entityManager->GetEntitiesInGroup("FacilityPipes");
 
 	if (!facility.empty()) {
 		GameMessages::SendStopFXEffect(facility[0], true, location + "PipeOff");
 		GameMessages::SendPlayFXEffect(facility[0]->GetObjectID(), energyFX, u"create", location + "PipeEnergy");
 	}
 
-	const auto consoles = EntityManager::Instance()->GetEntitiesInGroup("Console");
+	const auto consoles = Game::entityManager->GetEntitiesInGroup("Console");
 
 	for (auto* console : consoles) {
 		auto* consoleRebuildComponent = console->GetComponent<RebuildComponent>();
@@ -179,7 +179,7 @@ void ImgBrickConsoleQB::OnDie(Entity* self, Entity* killer) {
 			offFX = 2777;
 		}
 
-		const auto& facility = EntityManager::Instance()->GetEntitiesInGroup("FacilityPipes");
+		const auto& facility = Game::entityManager->GetEntitiesInGroup("FacilityPipes");
 
 		if (!facility.empty()) {
 			GameMessages::SendStopFXEffect(facility[0], true, location + "PipeEnergy");
@@ -233,7 +233,7 @@ void ImgBrickConsoleQB::OnTimerDone(Entity* self, std::string timerName) {
 			self->Smash(self->GetObjectID(), eKillType::SILENT);
 		}
 	} else if (timerName == "Die") {
-		const auto consoles = EntityManager::Instance()->GetEntitiesInGroup("Console");
+		const auto consoles = Game::entityManager->GetEntitiesInGroup("Console");
 
 		for (auto* console : consoles) {
 			console->Smash(console->GetObjectID(), eKillType::VIOLENT);

--- a/dScripts/02_server/Map/FV/Racing/RaceMaelstromGeiser.cpp
+++ b/dScripts/02_server/Map/FV/Racing/RaceMaelstromGeiser.cpp
@@ -29,7 +29,7 @@ void RaceMaelstromGeiser::OnProximityUpdate(Entity* self, Entity* entering, std:
 	Entity* player;
 
 	if (possessableComponent != nullptr) {
-		player = EntityManager::Instance()->GetEntity(possessableComponent->GetPossessor());
+		player = Game::entityManager->GetEntity(possessableComponent->GetPossessor());
 
 		if (player == nullptr) {
 			return;
@@ -43,7 +43,7 @@ void RaceMaelstromGeiser::OnProximityUpdate(Entity* self, Entity* entering, std:
 			return;
 		}
 
-		vehicle = EntityManager::Instance()->GetEntity(possessorComponent->GetPossessable());
+		vehicle = Game::entityManager->GetEntity(possessorComponent->GetPossessable());
 
 		if (vehicle == nullptr) {
 			return;

--- a/dScripts/02_server/Map/GF/GfCaptainsCannon.cpp
+++ b/dScripts/02_server/Map/GF/GfCaptainsCannon.cpp
@@ -40,7 +40,7 @@ void GfCaptainsCannon::OnUse(Entity* self, Entity* user) {
 void GfCaptainsCannon::OnTimerDone(Entity* self, std::string timerName) {
 	const auto playerId = self->GetVar<LWOOBJID>(u"userID");
 
-	auto* player = EntityManager::Instance()->GetEntity(playerId);
+	auto* player = Game::entityManager->GetEntity(playerId);
 
 	if (player == nullptr) {
 		self->SetVar<bool>(u"bIsInUse", false);
@@ -56,7 +56,7 @@ void GfCaptainsCannon::OnTimerDone(Entity* self, std::string timerName) {
 
 		self->AddTimer("cinematicTimer", cinematicTime);
 
-		const auto sharkObjects = EntityManager::Instance()->GetEntitiesInGroup("SharkCannon");
+		const auto sharkObjects = Game::entityManager->GetEntitiesInGroup("SharkCannon");
 
 		for (auto* shark : sharkObjects) {
 			if (shark->GetLOT() != m_SharkItemID) continue;

--- a/dScripts/02_server/Map/GF/GfTikiTorch.cpp
+++ b/dScripts/02_server/Map/GF/GfTikiTorch.cpp
@@ -32,7 +32,7 @@ void GfTikiTorch::OnTimerDone(Entity* self, std::string timerName) {
 	if (timerName == "Relight") {
 		LightTorch(self);
 	} else if (timerName == "InteractionCooldown") {
-		Entity* player = EntityManager::Instance()->GetEntity(self->GetI64(u"userID"));
+		Entity* player = Game::entityManager->GetEntity(self->GetI64(u"userID"));
 
 		if (player != nullptr && player->GetCharacter()) {
 			GameMessages::SendTerminateInteraction(player->GetObjectID(), eTerminateType::FROM_INTERACTION, self->GetObjectID());

--- a/dScripts/02_server/Map/GF/MastTeleport.cpp
+++ b/dScripts/02_server/Map/GF/MastTeleport.cpp
@@ -33,7 +33,7 @@ void MastTeleport::OnRebuildComplete(Entity* self, Entity* target) {
 void MastTeleport::OnTimerDone(Entity* self, std::string timerName) {
 	const auto playerId = self->GetVar<LWOOBJID>(u"userID");
 
-	auto* player = EntityManager::Instance()->GetEntity(playerId);
+	auto* player = Game::entityManager->GetEntity(playerId);
 
 	if (player == nullptr) return;
 
@@ -88,6 +88,6 @@ void MastTeleport::OnTimerDone(Entity* self, std::string timerName) {
 		);
 		auto* destroyableComponent = player->GetComponent<DestroyableComponent>();
 		if (destroyableComponent) destroyableComponent->SetStatusImmunity(eStateChangeType::POP, true, true, true, true, true, false, false, true, true);
-		EntityManager::Instance()->SerializeEntity(player);
+		Game::entityManager->SerializeEntity(player);
 	}
 }

--- a/dScripts/02_server/Map/General/ForceVolumeServer.cpp
+++ b/dScripts/02_server/Map/General/ForceVolumeServer.cpp
@@ -18,5 +18,5 @@ void ForceVolumeServer::OnStartup(Entity* self) {
 	phantomPhysicsComponent->SetDirection({ forceX, forceY, forceZ });
 	phantomPhysicsComponent->SetPhysicsEffectActive(true);
 
-	EntityManager::Instance()->SerializeEntity(self);
+	Game::entityManager->SerializeEntity(self);
 }

--- a/dScripts/02_server/Map/General/Ninjago/NjIceRailActivator.cpp
+++ b/dScripts/02_server/Map/General/Ninjago/NjIceRailActivator.cpp
@@ -10,13 +10,13 @@ void NjIceRailActivator::OnPlayerRailArrived(Entity* self, Entity* sender, const
 	if (breakPoint == waypoint) {
 		const auto& blockGroup = self->GetVar<std::u16string>(BlockGroupVariable);
 
-		for (auto* block : EntityManager::Instance()->GetEntitiesInGroup(GeneralUtils::UTF16ToWTF8(blockGroup))) {
+		for (auto* block : Game::entityManager->GetEntitiesInGroup(GeneralUtils::UTF16ToWTF8(blockGroup))) {
 			RenderComponent::PlayAnimation(block, u"explode");
 
 			const auto blockID = block->GetObjectID();
 
 			self->AddCallbackTimer(1.0f, [self, blockID]() {
-				auto* block = EntityManager::Instance()->GetEntity(blockID);
+				auto* block = Game::entityManager->GetEntity(blockID);
 
 				if (block != nullptr) {
 					block->Kill(self);

--- a/dScripts/02_server/Map/General/Ninjago/NjRailPostServer.cpp
+++ b/dScripts/02_server/Map/General/Ninjago/NjRailPostServer.cpp
@@ -42,7 +42,7 @@ void NjRailPostServer::OnRebuildNotifyState(Entity* self, eRebuildState state) {
 Entity* NjRailPostServer::GetRelatedRail(Entity* self) {
 	const auto& railGroup = self->GetVar<std::u16string>(RailGroupVariable);
 	if (!railGroup.empty()) {
-		for (auto* entity : EntityManager::Instance()->GetEntitiesInGroup(GeneralUtils::UTF16ToWTF8(railGroup))) {
+		for (auto* entity : Game::entityManager->GetEntitiesInGroup(GeneralUtils::UTF16ToWTF8(railGroup))) {
 			return entity;
 		}
 	}

--- a/dScripts/02_server/Map/General/PetDigServer.cpp
+++ b/dScripts/02_server/Map/General/PetDigServer.cpp
@@ -95,7 +95,7 @@ void PetDigServer::OnDie(Entity* self, Entity* killer) {
 	// TODO: Reset other pets
 
 	// Handles smashing leftovers (edge case for the AG X)
-	auto* xObject = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"X"));
+	auto* xObject = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"X"));
 	if (xObject != nullptr) {
 		xObject->Smash(xObject->GetObjectID(), eKillType::VIOLENT);
 	}
@@ -106,7 +106,7 @@ void PetDigServer::HandleXBuildDig(const Entity* self, Entity* owner, Entity* pe
 	if (playerID == LWOOBJID_EMPTY || playerID != owner->GetObjectID())
 		return;
 
-	auto* playerEntity = EntityManager::Instance()->GetEntity(playerID);
+	auto* playerEntity = Game::entityManager->GetEntity(playerID);
 	if (!playerEntity || !playerEntity->GetParentUser() || !playerEntity->GetParentUser()->GetLastUsedChar())
 		return;
 
@@ -134,7 +134,7 @@ void PetDigServer::HandleXBuildDig(const Entity* self, Entity* owner, Entity* pe
 		player->SetPlayerFlag(playerFlag, true);
 	}
 
-	auto* xObject = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"X"));
+	auto* xObject = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"X"));
 	if (xObject != nullptr) {
 		xObject->Smash(xObject->GetObjectID(), eKillType::VIOLENT);
 	}
@@ -211,8 +211,8 @@ void PetDigServer::SpawnPet(Entity* self, const Entity* owner, const DigInfo dig
 			new LDFData<float>(u"spawnTimer", 1.0)
 	};
 
-	auto* spawnedPet = EntityManager::Instance()->CreateEntity(info);
-	EntityManager::Instance()->ConstructEntity(spawnedPet);
+	auto* spawnedPet = Game::entityManager->CreateEntity(info);
+	Game::entityManager->ConstructEntity(spawnedPet);
 }
 
 Entity* PetDigServer::GetClosestTresure(NiPoint3 position) {
@@ -220,7 +220,7 @@ Entity* PetDigServer::GetClosestTresure(NiPoint3 position) {
 	Entity* closest = nullptr;
 
 	for (const auto tresureId : treasures) {
-		auto* tresure = EntityManager::Instance()->GetEntity(tresureId);
+		auto* tresure = Game::entityManager->GetEntity(tresureId);
 
 		if (tresure == nullptr) continue;
 

--- a/dScripts/02_server/Map/General/PropertyDevice.cpp
+++ b/dScripts/02_server/Map/General/PropertyDevice.cpp
@@ -5,7 +5,7 @@
 #include "eMissionState.h"
 
 void PropertyDevice::OnStartup(Entity* self) {
-	auto* zoneControl = EntityManager::Instance()->GetZoneControlEntity();
+	auto* zoneControl = Game::entityManager->GetZoneControlEntity();
 	if (zoneControl != nullptr) {
 		zoneControl->OnFireEventServerSide(self, "CheckForPropertyOwner");
 	}

--- a/dScripts/02_server/Map/General/QbSpawner.cpp
+++ b/dScripts/02_server/Map/General/QbSpawner.cpp
@@ -41,7 +41,7 @@ void QbSpawner::OnTimerDone(Entity* self, std::string timerName) {
 		auto gateObjID = self->GetVar<LWOOBJID>(u"gateObj");
 		if (!gateObjID) return;
 
-		auto* gate = EntityManager::Instance()->GetEntity(gateObjID);
+		auto* gate = Game::entityManager->GetEntity(gateObjID);
 		if (!gate) return;
 
 		auto oPos = gate->GetPosition();
@@ -75,12 +75,12 @@ void QbSpawner::OnTimerDone(Entity* self, std::string timerName) {
 					new LDFData<int>(u"mobTableLoc", i)
 				};
 
-				auto* child = EntityManager::Instance()->CreateEntity(info, nullptr, self);
-				EntityManager::Instance()->ConstructEntity(child);
+				auto* child = Game::entityManager->CreateEntity(info, nullptr, self);
+				Game::entityManager->ConstructEntity(child);
 
 				OnChildLoaded(self, child);
 			} else {
-				auto* mob = EntityManager::Instance()->GetEntity(mobTable[i]);
+				auto* mob = Game::entityManager->GetEntity(mobTable[i]);
 				AggroTargetObject(self, mob);
 			}
 		}
@@ -100,7 +100,7 @@ void QbSpawner::OnChildLoaded(Entity* self, Entity* child) {
 	const auto selfID = self->GetObjectID();
 
 	child->AddDieCallback([this, selfID, child]() {
-		auto* self = EntityManager::Instance()->GetEntity(selfID);
+		auto* self = Game::entityManager->GetEntity(selfID);
 		OnChildRemoved(self, child);
 		}
 	);
@@ -120,7 +120,7 @@ void QbSpawner::AggroTargetObject(Entity* self, Entity* enemy) {
 
 	auto gateObjID = self->GetVar<LWOOBJID>(u"gateObj");
 	if (gateObjID) {
-		auto* gate = EntityManager::Instance()->GetEntity(gateObjID);
+		auto* gate = Game::entityManager->GetEntity(gateObjID);
 		if (gate) {
 			auto* movementAIComponent = enemy->GetComponent<MovementAIComponent>();
 			if (movementAIComponent) movementAIComponent->SetDestination(gate->GetPosition());

--- a/dScripts/02_server/Map/General/WishingWellServer.cpp
+++ b/dScripts/02_server/Map/General/WishingWellServer.cpp
@@ -33,7 +33,7 @@ void WishingWellServer::OnUse(Entity* self, Entity* user) {
 	const auto userID = user->GetObjectID();
 
 	self->AddCallbackTimer(10, [self, userID]() {
-		auto* user = EntityManager::Instance()->GetEntity(userID);
+		auto* user = Game::entityManager->GetEntity(userID);
 
 		if (user == nullptr) return;
 

--- a/dScripts/02_server/Map/NS/NsConcertChoiceBuildManager.cpp
+++ b/dScripts/02_server/Map/NS/NsConcertChoiceBuildManager.cpp
@@ -40,8 +40,8 @@ void NsConcertChoiceBuildManager::SpawnCrate(Entity* self) {
 		new LDFData<float>(u"crateTime", crate.time),
 	};
 
-	auto* spawnedCrate = EntityManager::Instance()->CreateEntity(info);
-	EntityManager::Instance()->ConstructEntity(spawnedCrate);
+	auto* spawnedCrate = Game::entityManager->CreateEntity(info);
+	Game::entityManager->ConstructEntity(spawnedCrate);
 
 	spawnedCrate->AddDieCallback([self]() {
 		self->CancelAllTimers(); // Don't switch if the crate was smashed
@@ -56,7 +56,7 @@ void NsConcertChoiceBuildManager::SpawnCrate(Entity* self) {
 	self->AddCallbackTimer(crate.time, [self]() {
 		auto crateID = self->GetVar<LWOOBJID>(u"currentCrate");
 		if (crateID != LWOOBJID_EMPTY) {
-			EntityManager::Instance()->DestroyEntity(crateID);
+			Game::entityManager->DestroyEntity(crateID);
 			self->SetVar<LWOOBJID>(u"currentCrate", LWOOBJID_EMPTY);
 		}
 

--- a/dScripts/02_server/Map/NT/NtAssemblyTubeServer.cpp
+++ b/dScripts/02_server/Map/NT/NtAssemblyTubeServer.cpp
@@ -57,7 +57,7 @@ void NtAssemblyTubeServer::RunAssemblyTube(Entity* self, Entity* player) {
 		const auto animTime = 3;
 
 		self->AddCallbackTimer(animTime, [this, self, playerID]() {
-			auto* player = EntityManager::Instance()->GetEntity(playerID);
+			auto* player = Game::entityManager->GetEntity(playerID);
 
 			if (player == nullptr) {
 				return;
@@ -73,7 +73,7 @@ void NtAssemblyTubeServer::TeleportPlayer(Entity* self, Entity* player) {
 	auto* destination = self;
 
 	if (!destinationGroup.empty()) {
-		const auto& groupObjs = EntityManager::Instance()->GetEntitiesInGroup(GeneralUtils::UTF16ToWTF8(destinationGroup));
+		const auto& groupObjs = Game::entityManager->GetEntitiesInGroup(GeneralUtils::UTF16ToWTF8(destinationGroup));
 
 		if (!groupObjs.empty()) {
 			destination = groupObjs[0];
@@ -92,7 +92,7 @@ void NtAssemblyTubeServer::TeleportPlayer(Entity* self, Entity* player) {
 	const auto playerID = player->GetObjectID();
 
 	self->AddCallbackTimer(animTime, [this, self, playerID]() {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 
 		if (player == nullptr) {
 			return;

--- a/dScripts/02_server/Map/NT/NtCombatChallengeDummy.cpp
+++ b/dScripts/02_server/Map/NT/NtCombatChallengeDummy.cpp
@@ -4,7 +4,7 @@
 void NtCombatChallengeDummy::OnDie(Entity* self, Entity* killer) {
 	const auto challengeObjectID = self->GetVar<LWOOBJID>(u"challengeObjectID");
 
-	auto* challengeObject = EntityManager::Instance()->GetEntity(challengeObjectID);
+	auto* challengeObject = Game::entityManager->GetEntity(challengeObjectID);
 
 	if (challengeObject != nullptr) {
 		for (CppScripts::Script* script : CppScripts::GetEntityScripts(challengeObject)) {
@@ -16,7 +16,7 @@ void NtCombatChallengeDummy::OnDie(Entity* self, Entity* killer) {
 void NtCombatChallengeDummy::OnHitOrHealResult(Entity* self, Entity* attacker, int32_t damage) {
 	const auto challengeObjectID = self->GetVar<LWOOBJID>(u"challengeObjectID");
 
-	auto* challengeObject = EntityManager::Instance()->GetEntity(challengeObjectID);
+	auto* challengeObject = Game::entityManager->GetEntity(challengeObjectID);
 
 	if (challengeObject != nullptr) {
 		for (CppScripts::Script* script : CppScripts::GetEntityScripts(challengeObject)) {

--- a/dScripts/02_server/Map/NT/NtCombatChallengeExplodingDummy.cpp
+++ b/dScripts/02_server/Map/NT/NtCombatChallengeExplodingDummy.cpp
@@ -5,7 +5,7 @@
 void NtCombatChallengeExplodingDummy::OnDie(Entity* self, Entity* killer) {
 	const auto challengeObjectID = self->GetVar<LWOOBJID>(u"challengeObjectID");
 
-	auto* challengeObject = EntityManager::Instance()->GetEntity(challengeObjectID);
+	auto* challengeObject = Game::entityManager->GetEntity(challengeObjectID);
 
 	if (challengeObject != nullptr) {
 		for (CppScripts::Script* script : CppScripts::GetEntityScripts(challengeObject)) {
@@ -17,7 +17,7 @@ void NtCombatChallengeExplodingDummy::OnDie(Entity* self, Entity* killer) {
 void NtCombatChallengeExplodingDummy::OnHitOrHealResult(Entity* self, Entity* attacker, int32_t damage) {
 	const auto challengeObjectID = self->GetVar<LWOOBJID>(u"challengeObjectID");
 
-	auto* challengeObject = EntityManager::Instance()->GetEntity(challengeObjectID);
+	auto* challengeObject = Game::entityManager->GetEntity(challengeObjectID);
 
 	if (challengeObject != nullptr) {
 		for (CppScripts::Script* script : CppScripts::GetEntityScripts(challengeObject)) {

--- a/dScripts/02_server/Map/NT/NtCombatChallengeServer.cpp
+++ b/dScripts/02_server/Map/NT/NtCombatChallengeServer.cpp
@@ -19,7 +19,7 @@ void NtCombatChallengeServer::OnDie(Entity* self, Entity* killer) {
 void NtCombatChallengeServer::OnHitOrHealResult(Entity* self, Entity* attacker, int32_t damage) {
 	const auto playerID = self->GetVar<LWOOBJID>(u"playerID");
 
-	auto* player = EntityManager::Instance()->GetEntity(playerID);
+	auto* player = Game::entityManager->GetEntity(playerID);
 
 	if (player == nullptr) {
 		return;
@@ -69,7 +69,7 @@ void NtCombatChallengeServer::OnMessageBoxResponse(Entity* self, Entity* sender,
 void NtCombatChallengeServer::SpawnTargetDummy(Entity* self) {
 	const auto playerID = self->GetVar<LWOOBJID>(u"playerID");
 
-	auto* player = EntityManager::Instance()->GetEntity(playerID);
+	auto* player = Game::entityManager->GetEntity(playerID);
 
 	if (player == nullptr) {
 		return;
@@ -91,11 +91,11 @@ void NtCombatChallengeServer::SpawnTargetDummy(Entity* self) {
 	info.rot = self->GetRotation();
 	info.settings = { new LDFData<std::string>(u"custom_script_server", "scripts\\02_server\\Map\\NT\\L_NT_COMBAT_CHALLENGE_DUMMY.lua") };
 
-	auto* dummy = EntityManager::Instance()->CreateEntity(info);
+	auto* dummy = Game::entityManager->CreateEntity(info);
 
 	dummy->SetVar(u"challengeObjectID", self->GetObjectID());
 
-	EntityManager::Instance()->ConstructEntity(dummy);
+	Game::entityManager->ConstructEntity(dummy);
 
 	self->SetVar(u"currentDummy", dummy->GetObjectID());
 }
@@ -111,7 +111,7 @@ void NtCombatChallengeServer::OnChildLoaded(Entity* self, Entity* child) {
 
 	const auto playerID = self->GetVar<LWOOBJID>(u"playerID");
 
-	auto* player = EntityManager::Instance()->GetEntity(playerID);
+	auto* player = Game::entityManager->GetEntity(playerID);
 
 	if (player == nullptr) {
 		return;
@@ -121,7 +121,7 @@ void NtCombatChallengeServer::OnChildLoaded(Entity* self, Entity* child) {
 
 	self->SetVar(u"currentTargetID", child->GetObjectID());
 
-	EntityManager::Instance()->SerializeEntity(child);
+	Game::entityManager->SerializeEntity(child);
 
 	child->GetGroups().push_back("targets_" + std::to_string(self->GetObjectID()));
 }
@@ -130,7 +130,7 @@ void NtCombatChallengeServer::ResetGame(Entity* self) {
 	const auto totalDmg = self->GetVar<int32_t>(u"totalDmg");
 	const auto playerID = self->GetVar<LWOOBJID>(u"playerID");
 
-	auto* player = EntityManager::Instance()->GetEntity(playerID);
+	auto* player = Game::entityManager->GetEntity(playerID);
 
 	if (player != nullptr) {
 		auto* missionComponent = player->GetComponent<MissionComponent>();
@@ -150,7 +150,7 @@ void NtCombatChallengeServer::ResetGame(Entity* self) {
 	self->SetNetworkVar(u"totalDmg", false);
 	self->SetNetworkVar(u"update_time", 0);
 
-	const auto& targetObjs = EntityManager::Instance()->GetEntitiesInGroup("targets_" + std::to_string(self->GetObjectID()));
+	const auto& targetObjs = Game::entityManager->GetEntitiesInGroup("targets_" + std::to_string(self->GetObjectID()));
 
 	for (auto* target : targetObjs) {
 		target->Smash(self->GetObjectID());
@@ -158,7 +158,7 @@ void NtCombatChallengeServer::ResetGame(Entity* self) {
 
 	const auto currentID = self->GetVar<LWOOBJID>(u"currentDummy");
 
-	auto* current = EntityManager::Instance()->GetEntity(currentID);
+	auto* current = Game::entityManager->GetEntity(currentID);
 
 	if (current != nullptr) {
 		current->Smash(self->GetObjectID());

--- a/dScripts/02_server/Map/NT/NtImagBeamBuffer.cpp
+++ b/dScripts/02_server/Map/NT/NtImagBeamBuffer.cpp
@@ -40,7 +40,7 @@ void NtImagBeamBuffer::OnTimerDone(Entity* self, std::string timerName) {
 	}
 
 	for (const auto entityID : m_EntitiesInProximity) {
-		auto* entity = EntityManager::Instance()->GetEntity(entityID);
+		auto* entity = Game::entityManager->GetEntity(entityID);
 
 		if (entity == nullptr) {
 			continue;

--- a/dScripts/02_server/Map/NT/NtOverbuildServer.cpp
+++ b/dScripts/02_server/Map/NT/NtOverbuildServer.cpp
@@ -21,7 +21,7 @@ void NtOverbuildServer::SetVariables(Entity* self) {
 
 	// Find the second object Dr. Overbuild interacts with
 	LWOOBJID otherConvoObjectID = LWOOBJID_EMPTY;
-	for (auto* otherConvoObject : EntityManager::Instance()->GetEntitiesInGroup(GeneralUtils::UTF16ToWTF8(self->GetVar<std::u16string>(m_OtherEntitiesGroupVariable)))) {
+	for (auto* otherConvoObject : Game::entityManager->GetEntitiesInGroup(GeneralUtils::UTF16ToWTF8(self->GetVar<std::u16string>(m_OtherEntitiesGroupVariable)))) {
 		otherConvoObjectID = otherConvoObject->GetObjectID();
 		break;
 	}

--- a/dScripts/02_server/Map/NT/NtParadoxPanelServer.cpp
+++ b/dScripts/02_server/Map/NT/NtParadoxPanelServer.cpp
@@ -25,7 +25,7 @@ void NtParadoxPanelServer::OnUse(Entity* self, Entity* user) {
 		}
 
 		self->AddCallbackTimer(2, [this, self, playerID]() {
-			auto* player = EntityManager::Instance()->GetEntity(playerID);
+			auto* player = Game::entityManager->GetEntity(playerID);
 
 			if (player == nullptr) {
 				return;
@@ -55,7 +55,7 @@ void NtParadoxPanelServer::OnUse(Entity* self, Entity* user) {
 	GameMessages::SendPlayFXEffect(self, 6432, u"create", "console_sparks", LWOOBJID_EMPTY, 1.0, 1.0, true);
 
 	self->AddCallbackTimer(2, [this, self, playerID]() {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 
 		if (player == nullptr) {
 			return;

--- a/dScripts/02_server/Map/NT/NtParadoxTeleServer.cpp
+++ b/dScripts/02_server/Map/NT/NtParadoxTeleServer.cpp
@@ -33,7 +33,7 @@ void NtParadoxTeleServer::OnProximityUpdate(Entity* self, Entity* entering, std:
 		if (animTime == 0.0f) animTime = 2.0f;
 
 		self->AddCallbackTimer(animTime, [this, self, playerID]() {
-			auto* player = EntityManager::Instance()->GetEntity(playerID);
+			auto* player = Game::entityManager->GetEntity(playerID);
 
 			if (player == nullptr) {
 				return;
@@ -55,7 +55,7 @@ void NtParadoxTeleServer::TeleportPlayer(Entity* self, Entity* player) {
 	auto* destination = self;
 
 	if (!destinationGroup.empty()) {
-		const auto& groupObjs = EntityManager::Instance()->GetEntitiesInGroup(GeneralUtils::UTF16ToWTF8(destinationGroup));
+		const auto& groupObjs = Game::entityManager->GetEntitiesInGroup(GeneralUtils::UTF16ToWTF8(destinationGroup));
 
 		if (!groupObjs.empty()) {
 			destination = groupObjs[0];
@@ -81,7 +81,7 @@ void NtParadoxTeleServer::TeleportPlayer(Entity* self, Entity* player) {
 	const auto playerID = player->GetObjectID();
 
 	self->AddCallbackTimer(animTime, [this, self, playerID]() {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 
 		if (player == nullptr) {
 			return;

--- a/dScripts/02_server/Map/NT/NtSentinelWalkwayServer.cpp
+++ b/dScripts/02_server/Map/NT/NtSentinelWalkwayServer.cpp
@@ -25,7 +25,7 @@ void NtSentinelWalkwayServer::OnStartup(Entity* self) {
 	phantomPhysicsComponent->SetDirection(forward);
 	phantomPhysicsComponent->SetPhysicsEffectActive(true);
 
-	EntityManager::Instance()->SerializeEntity(self);
+	Game::entityManager->SerializeEntity(self);
 
 	self->SetProximityRadius(3, "speedboost");
 }

--- a/dScripts/02_server/Map/NT/NtVentureCannonServer.cpp
+++ b/dScripts/02_server/Map/NT/NtVentureCannonServer.cpp
@@ -44,7 +44,7 @@ void NtVentureCannonServer::OnUse(Entity* self, Entity* user) {
 		});
 
 	self->AddCallbackTimer(1.5f, [this, self, playerID]() {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 
 		if (player == nullptr) {
 			return;
@@ -57,7 +57,7 @@ void NtVentureCannonServer::OnUse(Entity* self, Entity* user) {
 void NtVentureCannonServer::EnterCannonEnded(Entity* self, Entity* player) {
 	const auto playerID = player->GetObjectID();
 
-	const auto& cannonEffectGroup = EntityManager::Instance()->GetEntitiesInGroup("cannonEffect");
+	const auto& cannonEffectGroup = Game::entityManager->GetEntitiesInGroup("cannonEffect");
 
 	if (!cannonEffectGroup.empty()) {
 		auto* cannonEffect = cannonEffectGroup[0];
@@ -83,7 +83,7 @@ void NtVentureCannonServer::EnterCannonEnded(Entity* self, Entity* player) {
 	);
 
 	self->AddCallbackTimer(1.5f, [this, self, playerID]() {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 
 		if (player == nullptr) {
 			return;
@@ -112,7 +112,7 @@ void NtVentureCannonServer::FirePlayer(Entity* self, Entity* player) {
 	auto* destination = self;
 
 	if (!destinationGroup.empty()) {
-		const auto& groupObjs = EntityManager::Instance()->GetEntitiesInGroup(GeneralUtils::UTF16ToWTF8(destinationGroup));
+		const auto& groupObjs = Game::entityManager->GetEntitiesInGroup(GeneralUtils::UTF16ToWTF8(destinationGroup));
 
 		if (!groupObjs.empty()) {
 			destination = groupObjs[0];

--- a/dScripts/02_server/Map/PR/HydrantBroken.cpp
+++ b/dScripts/02_server/Map/PR/HydrantBroken.cpp
@@ -7,7 +7,7 @@ void HydrantBroken::OnStartup(Entity* self) {
 
 	const auto hydrant = "hydrant" + self->GetVar<std::string>(u"hydrant");
 
-	const auto bouncers = EntityManager::Instance()->GetEntitiesInGroup(hydrant);
+	const auto bouncers = Game::entityManager->GetEntitiesInGroup(hydrant);
 
 	for (auto* bouncer : bouncers) {
 		self->SetVar<LWOOBJID>(u"bouncer", bouncer->GetObjectID());
@@ -22,7 +22,7 @@ void HydrantBroken::OnStartup(Entity* self) {
 
 void HydrantBroken::OnTimerDone(Entity* self, std::string timerName) {
 	if (timerName == "KillBroken") {
-		auto* bouncer = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"bouncer"));
+		auto* bouncer = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"bouncer"));
 
 		if (bouncer != nullptr) {
 			GameMessages::SendBouncerActiveStatus(bouncer->GetObjectID(), false, UNASSIGNED_SYSTEM_ADDRESS);

--- a/dScripts/02_server/Map/Property/AG_Small/EnemySpiderSpawner.cpp
+++ b/dScripts/02_server/Map/Property/AG_Small/EnemySpiderSpawner.cpp
@@ -19,7 +19,7 @@ void EnemySpiderSpawner::OnFireEventServerSide(Entity* self, Entity* sender, std
 		if (dest) {
 			dest->SetFaction(-1);
 		}
-		EntityManager::Instance()->SerializeEntity(self);
+		Game::entityManager->SerializeEntity(self);
 
 		// Keep track of who prepped me
 		self->SetI64(u"SpawnOwner", sender->GetObjectID());
@@ -48,9 +48,9 @@ void EnemySpiderSpawner::OnTimerDone(Entity* self, std::string timerName) {
 		info.spawnerID = self->GetI64(u"SpawnOwner");
 		info.spawnerNodeID = 0;
 
-		Entity* newEntity = EntityManager::Instance()->CreateEntity(info, nullptr);
+		Entity* newEntity = Game::entityManager->CreateEntity(info, nullptr);
 		if (newEntity) {
-			EntityManager::Instance()->ConstructEntity(newEntity);
+			Game::entityManager->ConstructEntity(newEntity);
 			newEntity->GetGroups().push_back("BabySpider");
 
 			/*

--- a/dScripts/02_server/Map/Property/AG_Small/ZoneAgProperty.cpp
+++ b/dScripts/02_server/Map/Property/AG_Small/ZoneAgProperty.cpp
@@ -128,13 +128,13 @@ void ZoneAgProperty::KillSpots(Entity* self) {
 	}
 
 	for (const auto& groupName : self->GetVar<std::vector<std::string>>(ROFTargetsGroup)) {
-		for (auto* spot : EntityManager::Instance()->GetEntitiesInGroup(groupName)) {
+		for (auto* spot : Game::entityManager->GetEntitiesInGroup(groupName)) {
 			spot->Kill();
 		}
 	}
 
 	DeactivateSpawner(self->GetVar<std::string>(LandTargetSpawner));
-	for (auto* landTarget : EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(LandTargetSpawner))) {
+	for (auto* landTarget : Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(LandTargetSpawner))) {
 		landTarget->Kill();
 	}
 }
@@ -197,20 +197,20 @@ void ZoneAgProperty::BaseTimerDone(Entity* self, const std::string& timerName) {
 		if (zoneId != 1150)
 			return;
 
-		const auto entities = EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(GuardGroup));
+		const auto entities = Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(GuardGroup));
 		if (entities.empty())
 			return;
 
 		auto* entity = entities[0];
 
-		GameMessages::SendNotifyClientObject(EntityManager::Instance()->GetZoneControlEntity()->GetObjectID(), u"GuardChat", 0, 0, entity->GetObjectID(), "", UNASSIGNED_SYSTEM_ADDRESS);
+		GameMessages::SendNotifyClientObject(Game::entityManager->GetZoneControlEntity()->GetObjectID(), u"GuardChat", 0, 0, entity->GetObjectID(), "", UNASSIGNED_SYSTEM_ADDRESS);
 		LoadProperty(self);
 
 		self->AddTimer("KillGuard", 5);
 	} else if (timerName == "KillGuard") {
 		KillGuard(self);
 	} else if (timerName == "tornadoOff") {
-		for (auto* entity : EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(FXManagerGroup))) {
+		for (auto* entity : Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(FXManagerGroup))) {
 			auto* renderComponent = entity->GetComponent<RenderComponent>();
 			if (renderComponent != nullptr) {
 				renderComponent->StopEffect("TornadoDebris", false);
@@ -222,7 +222,7 @@ void ZoneAgProperty::BaseTimerDone(Entity* self, const std::string& timerName) {
 		self->AddTimer("ShowVendor", 1.2f);
 		self->AddTimer("ShowClearEffects", 2);
 	} else if (timerName == "ShowClearEffects") {
-		for (auto* entity : EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(FXManagerGroup))) {
+		for (auto* entity : Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(FXManagerGroup))) {
 			auto* renderComponent = entity->GetComponent<RenderComponent>();
 			if (renderComponent != nullptr) {
 				renderComponent->PlayEffect(-1, u"beamOn", "beam");
@@ -236,7 +236,7 @@ void ZoneAgProperty::BaseTimerDone(Entity* self, const std::string& timerName) {
 		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"SkyOff", 0, 0, LWOOBJID_EMPTY,
 			"", UNASSIGNED_SYSTEM_ADDRESS);
 	} else if (timerName == "killSpider") {
-		for (auto* entity : EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(EnemiesGroup))) {
+		for (auto* entity : Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(EnemiesGroup))) {
 			entity->Kill();
 		}
 
@@ -257,7 +257,7 @@ void ZoneAgProperty::BaseTimerDone(Entity* self, const std::string& timerName) {
 		DeactivateSpawner(self->GetVar<std::string>(SpiderScreamSpawner));
 		DestroySpawner(self->GetVar<std::string>(SpiderScreamSpawner));
 
-		for (auto* player : EntityManager::Instance()->GetEntitiesByComponent(eReplicaComponentType::CHARACTER)) {
+		for (auto* player : Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::CHARACTER)) {
 			GameMessages::SendStop2DAmbientSound(player, true, GUIDMaelstrom);
 			GameMessages::SendPlay2DAmbientSound(player, GUIDPeaceful);
 		}
@@ -274,7 +274,7 @@ void ZoneAgProperty::BaseTimerDone(Entity* self, const std::string& timerName) {
 	} else if (timerName == "pollTornadoFX") {
 		StartTornadoFx(self);
 	} else if (timerName == "killFXObject") {
-		for (auto* entity : EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(FXManagerGroup))) {
+		for (auto* entity : Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(FXManagerGroup))) {
 			auto* renderComponent = entity->GetComponent<RenderComponent>();
 			if (renderComponent != nullptr) {
 				renderComponent->StopEffect("beam");
@@ -385,7 +385,7 @@ void ZoneAgProperty::RemovePlayerRef(Entity* self) {
 void ZoneAgProperty::BaseOnFireEventServerSide(Entity* self, Entity* sender, std::string args) {
 	if (args == "propertyRented") {
 		const auto playerId = self->GetVar<LWOOBJID>(u"playerID");
-		auto* player = EntityManager::Instance()->GetEntity(playerId);
+		auto* player = Game::entityManager->GetEntity(playerId);
 		if (player == nullptr)
 			return;
 
@@ -409,7 +409,7 @@ void ZoneAgProperty::BaseOnFireEventServerSide(Entity* self, Entity* sender, std
 		sender->SetNetworkVar<std::string>(u"PropertyOwnerID", std::to_string(self->GetVar<LWOOBJID>(u"PropertyOwner")));
 	} else if (args == "ClearProperty") {
 		const auto playerId = self->GetVar<LWOOBJID>(u"playerID");
-		auto* player = EntityManager::Instance()->GetEntity(playerId);
+		auto* player = Game::entityManager->GetEntity(playerId);
 		if (player == nullptr)
 			return;
 

--- a/dScripts/02_server/Map/Property/PropertyBankInteract.cpp
+++ b/dScripts/02_server/Map/Property/PropertyBankInteract.cpp
@@ -5,14 +5,14 @@
 #include "Entity.h"
 
 void PropertyBankInteract::OnStartup(Entity* self) {
-	auto* zoneControl = EntityManager::Instance()->GetZoneControlEntity();
+	auto* zoneControl = Game::entityManager->GetZoneControlEntity();
 	if (zoneControl != nullptr) {
 		zoneControl->OnFireEventServerSide(self, "CheckForPropertyOwner");
 	}
 }
 
 void PropertyBankInteract::OnPlayerLoaded(Entity* self, Entity* player) {
-	auto* zoneControl = EntityManager::Instance()->GetZoneControlEntity();
+	auto* zoneControl = Game::entityManager->GetZoneControlEntity();
 	if (zoneControl != nullptr) {
 		zoneControl->OnFireEventServerSide(self, "CheckForPropertyOwner");
 	}

--- a/dScripts/02_server/Map/VE/VeBricksampleServer.cpp
+++ b/dScripts/02_server/Map/VE/VeBricksampleServer.cpp
@@ -14,7 +14,7 @@ void VeBricksampleServer::OnUse(Entity* self, Entity* user) {
 		if (loot && inventoryComponent != nullptr && inventoryComponent->GetLotCount(loot) == 0) {
 			inventoryComponent->AddItem(loot, 1, eLootSourceType::ACTIVITY);
 
-			for (auto* brickEntity : EntityManager::Instance()->GetEntitiesInGroup("Bricks")) {
+			for (auto* brickEntity : Game::entityManager->GetEntitiesInGroup("Bricks")) {
 				GameMessages::SendNotifyClientObject(brickEntity->GetObjectID(), u"Pickedup");
 			}
 		}

--- a/dScripts/02_server/Map/VE/VeEpsilonServer.cpp
+++ b/dScripts/02_server/Map/VE/VeEpsilonServer.cpp
@@ -21,7 +21,7 @@ void VeEpsilonServer::OnMissionDialogueOK(Entity* self, Entity* target, int miss
 
 	// Notify the client that all objects have updated
 	self->AddCallbackTimer(3.0f, [this]() {
-		for (const auto* console : EntityManager::Instance()->GetEntitiesInGroup(m_ConsoleGroup)) {
+		for (const auto* console : Game::entityManager->GetEntitiesInGroup(m_ConsoleGroup)) {
 			GameMessages::SendNotifyClientObject(console->GetObjectID(), u"");
 		}
 		});

--- a/dScripts/02_server/Map/njhub/CatapultBaseServer.cpp
+++ b/dScripts/02_server/Map/njhub/CatapultBaseServer.cpp
@@ -19,7 +19,7 @@ void CatapultBaseServer::OnNotifyObject(Entity* self, Entity* sender, const std:
 void CatapultBaseServer::OnTimerDone(Entity* self, std::string timerName) {
 	if (timerName == "PlatAnim") {
 		// get the arm asset
-		const auto arm = EntityManager::Instance()->GetEntitiesInGroup(self->GetVarAsString(u"ArmGroup"));
+		const auto arm = Game::entityManager->GetEntitiesInGroup(self->GetVarAsString(u"ArmGroup"));
 
 		// tell the arm to the play the platform animation, which is just the arm laying there but with bouncer
 		for (auto* obj : arm) {
@@ -34,7 +34,7 @@ void CatapultBaseServer::OnTimerDone(Entity* self, std::string timerName) {
 		self->AddTimer("bounce", 3);
 	} else if (timerName == "launchAnim") {
 		// get the arm asset
-		auto* arm = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"Arm"));
+		auto* arm = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"Arm"));
 		if (arm == nullptr) return;
 
 		// tell the arm to player the launcher animation
@@ -42,7 +42,7 @@ void CatapultBaseServer::OnTimerDone(Entity* self, std::string timerName) {
 		self->AddTimer("resetArm", animTime);
 		RenderComponent::PlayAnimation(arm, u"launch");
 	} else if (timerName == "bounce") {
-		auto* bouncer = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"Bouncer"));
+		auto* bouncer = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"Bouncer"));
 		if (bouncer == nullptr) return;
 
 		// bounce all players
@@ -50,13 +50,13 @@ void CatapultBaseServer::OnTimerDone(Entity* self, std::string timerName) {
 		// add a delay to play the animation
 		self->AddTimer("launchAnim", .3);
 	} else if (timerName == "resetArm") {
-		auto* arm = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"Arm"));
+		auto* arm = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"Arm"));
 		if (arm == nullptr) return;
 
 		// set the arm back to natural state
 		RenderComponent::PlayAnimation(arm, u"idle");
 
-		auto* bouncer = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"Bouncer"));
+		auto* bouncer = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"Bouncer"));
 		if (bouncer == nullptr) return;
 
 		// kill the bouncer

--- a/dScripts/02_server/Map/njhub/CatapultBouncerServer.cpp
+++ b/dScripts/02_server/Map/njhub/CatapultBouncerServer.cpp
@@ -7,7 +7,7 @@ void CatapultBouncerServer::OnRebuildComplete(Entity* self, Entity* target) {
 
 	self->SetNetworkVar<bool>(u"Built", true);
 
-	const auto base = EntityManager::Instance()->GetEntitiesInGroup(self->GetVarAsString(u"BaseGroup"));
+	const auto base = Game::entityManager->GetEntitiesInGroup(self->GetVarAsString(u"BaseGroup"));
 
 	for (auto* obj : base) {
 		obj->NotifyObject(self, "BouncerBuilt");

--- a/dScripts/02_server/Map/njhub/CavePrisonCage.cpp
+++ b/dScripts/02_server/Map/njhub/CavePrisonCage.cpp
@@ -36,13 +36,13 @@ void CavePrisonCage::Setup(Entity* self, Spawner* spawner) {
 	info.spawnerID = self->GetObjectID();
 
 	// Spawn the villager inside the jail
-	auto* entity = EntityManager::Instance()->CreateEntity(info);
+	auto* entity = Game::entityManager->CreateEntity(info);
 
 	// Save the villeger ID
 	self->SetVar<LWOOBJID>(u"villager", entity->GetObjectID());
 
 	// Construct the entity
-	EntityManager::Instance()->ConstructEntity(entity);
+	Game::entityManager->ConstructEntity(entity);
 }
 
 void CavePrisonCage::OnRebuildNotifyState(Entity* self, eRebuildState state) {
@@ -77,7 +77,7 @@ void CavePrisonCage::SpawnCounterweight(Entity* self, Spawner* spawner) {
 
 		rebuildComponent->AddRebuildCompleteCallback([this, self](Entity* user) {
 			// The counterweight is a simple mover, which is not implemented, so we'll just set it's position
-			auto* counterweight = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"Counterweight"));
+			auto* counterweight = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"Counterweight"));
 
 			if (counterweight == nullptr) {
 				return;
@@ -87,7 +87,7 @@ void CavePrisonCage::SpawnCounterweight(Entity* self, Spawner* spawner) {
 			counterweight->SetPosition(counterweight->GetPosition() + NiPoint3(0, -2, 0));
 
 			// Serialize the counterweight
-			EntityManager::Instance()->SerializeEntity(counterweight);
+			Game::entityManager->SerializeEntity(counterweight);
 
 			// notifyPlatformAtLastWaypoint
 
@@ -95,7 +95,7 @@ void CavePrisonCage::SpawnCounterweight(Entity* self, Spawner* spawner) {
 			self->SetVar<LWOOBJID>(u"Builder", user->GetObjectID());
 
 			// Get the button and make sure it still exists
-			auto* button = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"Button"));
+			auto* button = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"Button"));
 
 			if (button == nullptr) {
 				return;
@@ -117,7 +117,7 @@ void CavePrisonCage::SpawnCounterweight(Entity* self, Spawner* spawner) {
 }
 
 void CavePrisonCage::GetButton(Entity* self) {
-	const auto buttons = EntityManager::Instance()->GetEntitiesInGroup("PrisonButton_0" + std::to_string(self->GetVarAs<int32_t>(u"myNumber")));
+	const auto buttons = Game::entityManager->GetEntitiesInGroup("PrisonButton_0" + std::to_string(self->GetVarAs<int32_t>(u"myNumber")));
 
 	if (buttons.size() == 0) {
 		// Try again in 0.5 seconds
@@ -146,7 +146,7 @@ void CavePrisonCage::OnTimerDone(Entity* self, std::string timerName) {
 		RenderComponent::PlayAnimation(self, u"idle-up");
 
 		// Get the villeger
-		auto* villager = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"villager"));
+		auto* villager = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"villager"));
 
 		if (villager == nullptr) {
 			return;
@@ -155,7 +155,7 @@ void CavePrisonCage::OnTimerDone(Entity* self, std::string timerName) {
 		GameMessages::SendNotifyClientObject(villager->GetObjectID(), u"TimeToChat", 0, 0, LWOOBJID_EMPTY, "", UNASSIGNED_SYSTEM_ADDRESS);
 
 		// Get the builder and make sure it still exists
-		auto* builder = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"Builder"));
+		auto* builder = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"Builder"));
 
 		if (builder == nullptr) {
 			return;
@@ -170,7 +170,7 @@ void CavePrisonCage::OnTimerDone(Entity* self, std::string timerName) {
 		self->AddTimer("VillagerEscape", 5.0f);
 	} else if (timerName == "VillagerEscape") {
 		// Get the villeger and make sure it still exists
-		auto* villager = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"villager"));
+		auto* villager = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"villager"));
 
 		if (villager == nullptr) {
 			return;
@@ -183,7 +183,7 @@ void CavePrisonCage::OnTimerDone(Entity* self, std::string timerName) {
 		self->AddTimer("SmashCounterweight", 2.0f);
 	} else if (timerName == "SmashCounterweight") {
 		// Get the counterweight and make sure it still exists
-		auto* counterweight = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"Counterweight"));
+		auto* counterweight = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"Counterweight"));
 
 		if (counterweight == nullptr) {
 			return;
@@ -193,7 +193,7 @@ void CavePrisonCage::OnTimerDone(Entity* self, std::string timerName) {
 		counterweight->Smash();
 
 		// Get the button and make sure it still exists
-		auto* button = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"Button"));
+		auto* button = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"Button"));
 
 		if (button == nullptr) {
 			return;

--- a/dScripts/02_server/Map/njhub/EnemySkeletonSpawner.cpp
+++ b/dScripts/02_server/Map/njhub/EnemySkeletonSpawner.cpp
@@ -28,13 +28,13 @@ void EnemySkeletonSpawner::OnTimerDone(Entity* self, std::string timerName) {
 		info.rot = self->GetRotation();
 		info.spawnerID = self->GetObjectID();
 
-		auto* spawnedEntity = EntityManager::Instance()->CreateEntity(info);
+		auto* spawnedEntity = Game::entityManager->CreateEntity(info);
 
 		if (spawnedEntity == nullptr) {
 			return;
 		}
 
-		EntityManager::Instance()->ConstructEntity(spawnedEntity);
+		Game::entityManager->ConstructEntity(spawnedEntity);
 
 		spawnedEntity->AddCallbackTimer(60, [spawnedEntity]() {
 			spawnedEntity->Smash(spawnedEntity->GetObjectID());

--- a/dScripts/02_server/Map/njhub/MonCoreSmashableDoors.cpp
+++ b/dScripts/02_server/Map/njhub/MonCoreSmashableDoors.cpp
@@ -9,7 +9,7 @@ void MonCoreSmashableDoors::OnDie(Entity* self, Entity* killer) {
 	auto triggerGroup = "CoreNookTrig0" + myNum;
 
 	// Get the trigger
-	auto triggers = EntityManager::Instance()->GetEntitiesInGroup(triggerGroup);
+	auto triggers = Game::entityManager->GetEntitiesInGroup(triggerGroup);
 
 	if (triggers.empty()) {
 		return;

--- a/dScripts/02_server/Map/njhub/NjNPCMissionSpinjitzuServer.cpp
+++ b/dScripts/02_server/Map/njhub/NjNPCMissionSpinjitzuServer.cpp
@@ -12,7 +12,7 @@ void NjNPCMissionSpinjitzuServer::OnMissionDialogueOK(Entity* self, Entity* targ
 
 		// Wait for an animation to complete and flag that the player has learned spinjitzu
 		self->AddCallbackTimer(5.0f, [targetID, element]() {
-			auto* target = EntityManager::Instance()->GetEntity(targetID);
+			auto* target = Game::entityManager->GetEntity(targetID);
 			if (target != nullptr) {
 				auto* character = target->GetCharacter();
 				if (character != nullptr) {

--- a/dScripts/02_server/Map/njhub/NjWuNPC.cpp
+++ b/dScripts/02_server/Map/njhub/NjWuNPC.cpp
@@ -28,7 +28,7 @@ void NjWuNPC::OnMissionDialogueOK(Entity* self, Entity* target, int missionID, e
 			character->SetPlayerFlag(ePlayerFlag::NJ_WU_SHOW_DAILY_CHEST, false);
 
 			// Hide the chest
-			for (auto* chest : EntityManager::Instance()->GetEntitiesInGroup(m_DragonChestGroup)) {
+			for (auto* chest : Game::entityManager->GetEntitiesInGroup(m_DragonChestGroup)) {
 				GameMessages::SendNotifyClientObject(chest->GetObjectID(), m_ShowChestNotification, 0, -1,
 					target->GetObjectID(), "", target->GetSystemAddress());
 			}
@@ -41,19 +41,19 @@ void NjWuNPC::OnMissionDialogueOK(Entity* self, Entity* target, int missionID, e
 			character->SetPlayerFlag(ePlayerFlag::NJ_WU_SHOW_DAILY_CHEST, true);
 
 			// Show the chest
-			for (auto* chest : EntityManager::Instance()->GetEntitiesInGroup(m_DragonChestGroup)) {
+			for (auto* chest : Game::entityManager->GetEntitiesInGroup(m_DragonChestGroup)) {
 				GameMessages::SendNotifyClientObject(chest->GetObjectID(), m_ShowChestNotification, 1, -1,
 					target->GetObjectID(), "", target->GetSystemAddress());
 			}
 
 			auto playerID = target->GetObjectID();
 			self->AddCallbackTimer(5.0f, [this, playerID]() {
-				auto* player = EntityManager::Instance()->GetEntity(playerID);
+				auto* player = Game::entityManager->GetEntity(playerID);
 				if (player == nullptr)
 					return;
 
 				// Stop the dragon effects
-				for (auto* dragon : EntityManager::Instance()->GetEntitiesInGroup(m_DragonStatueGroup)) {
+				for (auto* dragon : Game::entityManager->GetEntitiesInGroup(m_DragonStatueGroup)) {
 					GameMessages::SendStopFXEffect(dragon, true, "on");
 				}
 				});

--- a/dScripts/02_server/Map/njhub/RainOfArrows.cpp
+++ b/dScripts/02_server/Map/njhub/RainOfArrows.cpp
@@ -18,9 +18,9 @@ void RainOfArrows::OnRebuildComplete(Entity* self, Entity* target) {
 	info.rot = myRot;
 	info.spawnerID = self->GetObjectID();
 
-	auto* entity = EntityManager::Instance()->CreateEntity(info);
+	auto* entity = Game::entityManager->CreateEntity(info);
 
-	EntityManager::Instance()->ConstructEntity(entity);
+	Game::entityManager->ConstructEntity(entity);
 
 	self->SetVar<LWOOBJID>(u"ChildFX", entity->GetObjectID());
 	self->SetVar<LWOOBJID>(u"playerID", target->GetObjectID());
@@ -30,11 +30,11 @@ void RainOfArrows::OnRebuildComplete(Entity* self, Entity* target) {
 }
 
 void RainOfArrows::OnTimerDone(Entity* self, std::string timerName) {
-	auto* child = EntityManager::Instance()->GetEntity(
+	auto* child = Game::entityManager->GetEntity(
 		self->GetVar<LWOOBJID>(u"ChildFX")
 	);
 
-	auto* player = EntityManager::Instance()->GetEntity(
+	auto* player = Game::entityManager->GetEntity(
 		self->GetVar<LWOOBJID>(u"playerID")
 	);
 

--- a/dScripts/02_server/Map/njhub/boss_instance/NjMonastryBossInstance.cpp
+++ b/dScripts/02_server/Map/njhub/boss_instance/NjMonastryBossInstance.cpp
@@ -122,7 +122,7 @@ void NjMonastryBossInstance::OnActivityTimerDone(Entity* self, const std::string
 	if (timerName == WaitingForPlayersTimer) {
 		StartFight(self);
 	} else if (timerName == SpawnNextWaveTimer) {
-		auto* frakjaw = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(LedgeFrakjawVariable));
+		auto* frakjaw = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(LedgeFrakjawVariable));
 		if (frakjaw != nullptr) {
 			SummonWave(self, frakjaw);
 		}
@@ -145,7 +145,7 @@ void NjMonastryBossInstance::OnActivityTimerDone(Entity* self, const std::string
 			}
 		}
 	} else if (timerName + TimerSplitChar == UnstunTimer) {
-		auto* entity = EntityManager::Instance()->GetEntity(objectID);
+		auto* entity = Game::entityManager->GetEntity(objectID);
 		if (entity != nullptr) {
 			auto* combatAI = entity->GetComponent<BaseCombatAIComponent>();
 			if (combatAI != nullptr) {
@@ -164,7 +164,7 @@ void NjMonastryBossInstance::OnActivityTimerDone(Entity* self, const std::string
 		}
 	} else if (timerName == LowerFrakjawCamTimer) {
 		// Destroy the frakjaw on the ledge
-		auto* ledgeFrakjaw = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(LedgeFrakjawVariable));
+		auto* ledgeFrakjaw = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(LedgeFrakjawVariable));
 		if (ledgeFrakjaw != nullptr) {
 			ledgeFrakjaw->Kill();
 		}
@@ -188,7 +188,7 @@ void NjMonastryBossInstance::OnActivityTimerDone(Entity* self, const std::string
 			spawner->Activate();
 		}
 	} else if (timerName + TimerSplitChar == FrakjawSpawnInTimer) {
-		auto* lowerFrakjaw = EntityManager::Instance()->GetEntity(objectID);
+		auto* lowerFrakjaw = Game::entityManager->GetEntity(objectID);
 		if (lowerFrakjaw != nullptr) {
 			LowerFrakjawSummon(self, lowerFrakjaw);
 		}
@@ -250,7 +250,7 @@ void NjMonastryBossInstance::HandleCounterWeightSpawned(Entity* self, Entity* co
 						counterWeight->Kill();
 					}
 
-					auto* frakjaw = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(LedgeFrakjawVariable));
+					auto* frakjaw = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(LedgeFrakjawVariable));
 					if (frakjaw == nullptr) {
 						GameMessages::SendNotifyClientObject(self->GetObjectID(), u"LedgeFrakjawDead", 0,
 							0, LWOOBJID_EMPTY, "", UNASSIGNED_SYSTEM_ADDRESS);
@@ -342,7 +342,7 @@ void NjMonastryBossInstance::HandleLowerFrakjawHit(Entity* self, Entity* lowerFr
 		std::vector<LWOOBJID> newTrashMobs = {};
 
 		for (const auto& trashMobID : trashMobsAlive) {
-			auto* trashMob = EntityManager::Instance()->GetEntity(trashMobID);
+			auto* trashMob = Game::entityManager->GetEntity(trashMobID);
 			if (trashMob != nullptr) {
 				newTrashMobs.push_back(trashMobID);
 
@@ -393,7 +393,7 @@ void NjMonastryBossInstance::HandleWaveEnemyDied(Entity* self, Entity* waveEnemy
 }
 
 void NjMonastryBossInstance::TeleportPlayer(Entity* player, uint32_t position) {
-	for (const auto* spawnPoint : EntityManager::Instance()->GetEntitiesInGroup("SpawnPoint" + std::to_string(position))) {
+	for (const auto* spawnPoint : Game::entityManager->GetEntitiesInGroup("SpawnPoint" + std::to_string(position))) {
 		GameMessages::SendTeleport(player->GetObjectID(), spawnPoint->GetPosition(), spawnPoint->GetRotation(),
 			player->GetSystemAddress(), true);
 	}
@@ -433,7 +433,7 @@ void NjMonastryBossInstance::RemovePoison(Entity* self) {
 	const auto& totalPlayer = self->GetVar<std::vector<LWOOBJID>>(TotalPlayersLoadedVariable);
 	for (const auto& playerID : totalPlayer) {
 
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 		if (player != nullptr) {
 
 			auto* buffComponent = player->GetComponent<BuffComponent>();
@@ -505,7 +505,7 @@ void NjMonastryBossInstance::FightOver(Entity* self) {
 	GameMessages::SendNotifyClientObject(self->GetObjectID(), PlayCinematicNotification, 0, 0,
 		LWOOBJID_EMPTY, TreasureChestSpawning, UNASSIGNED_SYSTEM_ADDRESS);
 
-	auto treasureChests = EntityManager::Instance()->GetEntitiesInGroup(ChestSpawnpointGroup);
+	auto treasureChests = Game::entityManager->GetEntitiesInGroup(ChestSpawnpointGroup);
 	for (auto* treasureChest : treasureChests) {
 		auto info = EntityInfo{};
 
@@ -518,7 +518,7 @@ void NjMonastryBossInstance::FightOver(Entity* self) {
 		};
 
 		// Finally spawn a treasure chest at the correct spawn point
-		auto* chestObject = EntityManager::Instance()->CreateEntity(info);
-		EntityManager::Instance()->ConstructEntity(chestObject);
+		auto* chestObject = Game::entityManager->CreateEntity(info);
+		Game::entityManager->ConstructEntity(chestObject);
 	}
 }

--- a/dScripts/02_server/Minigame/General/MinigameTreasureChestServer.cpp
+++ b/dScripts/02_server/Minigame/General/MinigameTreasureChestServer.cpp
@@ -21,7 +21,7 @@ void MinigameTreasureChestServer::OnUse(Entity* self, Entity* user) {
 	uint32_t activityRating = 0;
 	if (team != nullptr) {
 		for (const auto& teamMemberID : team->members) {
-			auto* teamMember = EntityManager::Instance()->GetEntity(teamMemberID);
+			auto* teamMember = Game::entityManager->GetEntity(teamMemberID);
 			if (teamMember != nullptr) {
 				activityRating = CalculateActivityRating(self, teamMemberID);
 

--- a/dScripts/02_server/Objects/AgSurvivalBuffStation.cpp
+++ b/dScripts/02_server/Objects/AgSurvivalBuffStation.cpp
@@ -53,7 +53,7 @@ void AgSurvivalBuffStation::OnTimerDone(Entity* self, std::string timerName) {
 	}
 	auto team = self->GetVar<std::vector<LWOOBJID>>(u"BuilderTeam");
 	for (auto memberID : team) {
-		auto member = EntityManager::Instance()->GetEntity(memberID);
+		auto member = Game::entityManager->GetEntity(memberID);
 		if (member != nullptr && !member->GetIsDead()) {
 			GameMessages::SendDropClientLoot(member, self->GetObjectID(), powerupToDrop, 0, self->GetPosition());
 		} else {

--- a/dScripts/02_server/Objects/StinkyFishTarget.cpp
+++ b/dScripts/02_server/Objects/StinkyFishTarget.cpp
@@ -25,8 +25,8 @@ void StinkyFishTarget::OnSkillEventFired(Entity* self, Entity* caster, const std
 		new LDFData<bool>(u"no_timed_spawn", true)
 	};
 
-	auto* fish = EntityManager::Instance()->CreateEntity(entityInfo);
-	EntityManager::Instance()->ConstructEntity(fish);
+	auto* fish = Game::entityManager->CreateEntity(entityInfo);
+	Game::entityManager->ConstructEntity(fish);
 
 	self->SetVar<LWOOBJID>(u"fish", fish->GetObjectID());
 	self->AddTimer("smash", 5.0f);
@@ -35,7 +35,7 @@ void StinkyFishTarget::OnSkillEventFired(Entity* self, Entity* caster, const std
 void StinkyFishTarget::OnTimerDone(Entity* self, std::string timerName) {
 	if (timerName == "smash") {
 		const auto playerID = self->GetVar<LWOOBJID>(u"player");
-		auto* fish = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"fish"));
+		auto* fish = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"fish"));
 
 		if (fish) {
 			fish->Smash(playerID);

--- a/dScripts/ActivityManager.cpp
+++ b/dScripts/ActivityManager.cpp
@@ -20,7 +20,7 @@ void ActivityManager::UpdatePlayer(Entity* self, LWOOBJID playerID, const bool r
 	if (remove) {
 		sac->PlayerRemove(playerID);
 	} else {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 		if (player != nullptr) {
 			sac->PlayerJoin(player);
 			SetActivityScore(self, playerID, 0);
@@ -63,7 +63,7 @@ void ActivityManager::StopActivity(Entity* self, const LWOOBJID playerID, const 
 	if (quit) {
 		UpdatePlayer(self, playerID, true);
 	} else {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 		if (player == nullptr)
 			return;
 
@@ -96,7 +96,7 @@ bool ActivityManager::TakeActivityCost(const Entity* self, const LWOOBJID player
 	if (sac == nullptr)
 		return false;
 
-	auto* player = EntityManager::Instance()->GetEntity(playerID);
+	auto* player = Game::entityManager->GetEntity(playerID);
 	if (player == nullptr)
 		return false;
 

--- a/dScripts/BaseConsoleTeleportServer.cpp
+++ b/dScripts/BaseConsoleTeleportServer.cpp
@@ -45,7 +45,7 @@ void BaseConsoleTeleportServer::BaseOnMessageBoxResponse(Entity* self, Entity* s
 		const auto playerID = player->GetObjectID();
 
 		self->AddCallbackTimer(animTime, [playerID, self]() {
-			auto* player = EntityManager::Instance()->GetEntity(playerID);
+			auto* player = Game::entityManager->GetEntity(playerID);
 
 			if (player == nullptr) {
 				return;

--- a/dScripts/BasePropertyServer.cpp
+++ b/dScripts/BasePropertyServer.cpp
@@ -49,7 +49,7 @@ void BasePropertyServer::SetGameVariables(Entity* self) {
 }
 
 void BasePropertyServer::CheckForOwner(Entity* self) {
-	if (EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(PropertyPlaqueGroup)).empty()) {
+	if (Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(PropertyPlaqueGroup)).empty()) {
 		self->AddTimer(RunPlayerLoadedAgainTimer, 0.5f);
 		return;
 	}
@@ -87,9 +87,9 @@ void BasePropertyServer::BasePlayerLoaded(Entity* self, Entity* player) {
 	self->SetNetworkVar(PropertyOwnerIDVariable, propertyOwner);
 
 	if (rented) {
-		auto plaques = EntityManager::Instance()->GetEntitiesInGroup("PropertyVendor");
+		auto plaques = Game::entityManager->GetEntitiesInGroup("PropertyVendor");
 		for (auto* plaque : plaques) {
-			EntityManager::Instance()->DestructEntity(plaque);
+			Game::entityManager->DestructEntity(plaque);
 		}
 
 		const auto& mapID = dZoneManager::Instance()->GetZone()->GetZoneID();
@@ -164,9 +164,9 @@ void BasePropertyServer::BaseZonePropertyRented(Entity* self, Entity* player) co
 	self->AddTimer(BoundsVisOnTimer, 2);
 	self->SetVar<LWOOBJID>(PropertyOwnerVariable, player->GetObjectID());
 
-	auto plaques = EntityManager::Instance()->GetEntitiesInGroup("PropertyVendor");
+	auto plaques = Game::entityManager->GetEntitiesInGroup("PropertyVendor");
 	for (auto* plaque : plaques) {
-		EntityManager::Instance()->DestructEntity(plaque);
+		Game::entityManager->DestructEntity(plaque);
 	}
 
 	auto brickLinkMissionID = self->GetVar<uint32_t>(brickLinkMissionIDFlag);
@@ -234,7 +234,7 @@ void BasePropertyServer::StartMaelstrom(Entity* self, Entity* player) {
 }
 
 void BasePropertyServer::StartTornadoFx(Entity* self) const {
-	const auto entities = EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(FXManagerGroup));
+	const auto entities = Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(FXManagerGroup));
 	if (entities.empty()) {
 		self->AddTimer("pollTornadoFX", 0.1f);
 		return;
@@ -259,7 +259,7 @@ void BasePropertyServer::BasePlayerExit(Entity* self, Entity* player) {
 }
 
 void BasePropertyServer::KillGuard(Entity* self) {
-	const auto entities = EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(GuardGroup));
+	const auto entities = Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(GuardGroup));
 	if (entities.empty())
 		return;
 
@@ -328,12 +328,12 @@ void BasePropertyServer::BaseTimerDone(Entity* self, const std::string& timerNam
 		if (dZoneManager::Instance()->GetZoneID().GetMapID() == 1150)
 			return;
 
-		const auto entities = EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(GuardGroup));
+		const auto entities = Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(GuardGroup));
 		if (entities.empty())
 			return;
 
 		auto* guard = entities[0];
-		GameMessages::SendNotifyClientObject(EntityManager::Instance()->GetZoneControlEntity()->GetObjectID(),
+		GameMessages::SendNotifyClientObject(Game::entityManager->GetZoneControlEntity()->GetObjectID(),
 			u"GuardChat", 0, 0, guard->GetObjectID(),
 			"", UNASSIGNED_SYSTEM_ADDRESS);
 
@@ -341,7 +341,7 @@ void BasePropertyServer::BaseTimerDone(Entity* self, const std::string& timerNam
 	} else if (timerName == KillGuardTimer) {
 		KillGuard(self);
 	} else if (timerName == TornadoOffTimer) {
-		auto fxManagers = EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(FXManagerGroup));
+		auto fxManagers = Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(FXManagerGroup));
 
 		for (auto* fxManager : fxManagers) {
 			auto* renderComponent = fxManager->GetComponent<RenderComponent>();
@@ -354,7 +354,7 @@ void BasePropertyServer::BaseTimerDone(Entity* self, const std::string& timerNam
 
 		self->AddTimer(ShowClearEffectsTimer, 2);
 	} else if (timerName == ShowClearEffectsTimer) {
-		auto fxManagers = EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(FXManagerGroup));
+		auto fxManagers = Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(FXManagerGroup));
 
 		for (auto* fxManager : fxManagers) {
 			auto* renderComponent = fxManager->GetComponent<RenderComponent>();
@@ -370,7 +370,7 @@ void BasePropertyServer::BaseTimerDone(Entity* self, const std::string& timerNam
 		GameMessages::SendNotifyClientObject(controller->GetObjectID(), u"SkyOff", 0, 0,
 			LWOOBJID_EMPTY, "", UNASSIGNED_SYSTEM_ADDRESS);
 	} else if (timerName == KillStrombiesTimer) {
-		const auto enemies = EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(EnemiesGroup));
+		const auto enemies = Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(EnemiesGroup));
 		for (auto* enemy : enemies) {
 			RequestDie(self, enemy);
 		}
@@ -378,7 +378,7 @@ void BasePropertyServer::BaseTimerDone(Entity* self, const std::string& timerNam
 		DestroySpawner(self->GetVar<std::string>(SmashablesSpawner));
 		KillSpots(self);
 
-		auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
+		auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
 		if (player == nullptr)
 			return;
 
@@ -393,7 +393,7 @@ void BasePropertyServer::BaseTimerDone(Entity* self, const std::string& timerNam
 			DestroySpawner(behaviorObjectSpawner);
 		}
 
-		for (auto* entity : EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(ImagOrbGroup))) {
+		for (auto* entity : Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(ImagOrbGroup))) {
 			entity->Smash();
 		}
 
@@ -401,7 +401,7 @@ void BasePropertyServer::BaseTimerDone(Entity* self, const std::string& timerNam
 
 		self->AddTimer(ShowVendorTimer, 1.0f);
 	} else if (timerName == ShowVendorTimer) {
-		GameMessages::SendNotifyClientObject(EntityManager::Instance()->GetZoneControlEntity()->GetObjectID(),
+		GameMessages::SendNotifyClientObject(Game::entityManager->GetZoneControlEntity()->GetObjectID(),
 			u"vendorOn", 0, 0, LWOOBJID_EMPTY, "",
 			UNASSIGNED_SYSTEM_ADDRESS);
 
@@ -416,7 +416,7 @@ void BasePropertyServer::BaseTimerDone(Entity* self, const std::string& timerNam
 	} else if (timerName == PollTornadoFXTimer) {
 		StartTornadoFx(self);
 	} else if (timerName == KillFXObjectTimer) {
-		const auto fxManagers = EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(FXManagerGroup));
+		const auto fxManagers = Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(FXManagerGroup));
 		if (fxManagers.empty()) {
 			self->AddTimer(KillFXObjectTimer, 1.0f);
 			return;
@@ -436,7 +436,7 @@ void BasePropertyServer::BaseTimerDone(Entity* self, const std::string& timerNam
 
 void BasePropertyServer::HandleOrbsTimer(Entity* self) {
 	self->SetVar<bool>(CollidedVariable, false);
-	auto orbs = EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(ImagOrbGroup));
+	auto orbs = Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(ImagOrbGroup));
 	if (orbs.empty()) {
 		self->AddTimer(StartOrbTimer, 0.5f);
 		return;
@@ -455,12 +455,12 @@ void BasePropertyServer::HandleOrbsTimer(Entity* self) {
 				}
 
 				DestroySpawner(self->GetVar<std::string>(GeneratorFXSpawner));
-				GameMessages::SendNotifyClientObject(EntityManager::Instance()->GetZoneControlEntity()->GetObjectID(),
+				GameMessages::SendNotifyClientObject(Game::entityManager->GetZoneControlEntity()->GetObjectID(),
 					u"PlayCinematic", 0, 0, LWOOBJID_EMPTY,
 					"DestroyMaelstrom", UNASSIGNED_SYSTEM_ADDRESS);
 
 				// Notifies the client that the property has been claimed with a flag, completes missions too
-				auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
+				auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
 				if (player != nullptr) {
 					auto* character = player->GetCharacter();
 					if (character != nullptr) {
@@ -476,7 +476,7 @@ void BasePropertyServer::HandleOrbsTimer(Entity* self) {
 }
 
 void BasePropertyServer::HandleGeneratorTimer(Entity* self) {
-	auto generators = EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(GeneratorGroup));
+	auto generators = Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(GeneratorGroup));
 	if (generators.empty()) {
 		self->AddTimer(StartGeneratorTimer, 0.5f);
 		return;
@@ -496,7 +496,7 @@ void BasePropertyServer::HandleGeneratorTimer(Entity* self) {
 }
 
 void BasePropertyServer::HandleQuickBuildTimer(Entity* self) {
-	auto claimMarkers = EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(ClaimMarkerGroup));
+	auto claimMarkers = Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(ClaimMarkerGroup));
 	if (claimMarkers.empty()) {
 		self->AddTimer(StartQuickbuildTimer, 0.5f);
 		return;

--- a/dScripts/BaseSurvivalServer.cpp
+++ b/dScripts/BaseSurvivalServer.cpp
@@ -212,7 +212,7 @@ void BaseSurvivalServer::OnActivityTimerDone(Entity* self, const std::string& na
 		ActivityTimerStart(self, PlaySpawnSoundTimer, 3, 3);
 	} else if (name == PlaySpawnSoundTimer) {
 		for (const auto& playerID : state.players) {
-			auto* player = EntityManager::Instance()->GetEntity(playerID);
+			auto* player = Game::entityManager->GetEntity(playerID);
 			if (player != nullptr) {
 				GameMessages::SendPlayNDAudioEmitter(player, player->GetSystemAddress(), spawnSoundGUID);
 			}
@@ -221,7 +221,7 @@ void BaseSurvivalServer::OnActivityTimerDone(Entity* self, const std::string& na
 }
 
 void BaseSurvivalServer::ResetStats(LWOOBJID playerID) {
-	auto* player = EntityManager::Instance()->GetEntity(playerID);
+	auto* player = Game::entityManager->GetEntity(playerID);
 	if (player != nullptr) {
 
 		// Boost all the player stats when loading in
@@ -284,7 +284,7 @@ void BaseSurvivalServer::StartWaves(Entity* self) {
 	state.waitingPlayers.clear();
 
 	for (const auto& playerID : state.players) {
-		const auto player = EntityManager::Instance()->GetEntity(playerID);
+		const auto player = Game::entityManager->GetEntity(playerID);
 		if (player != nullptr) {
 			state.waitingPlayers.push_back(playerID);
 			UpdatePlayer(self, playerID);
@@ -311,7 +311,7 @@ bool BaseSurvivalServer::CheckAllPlayersDead() {
 	auto deadPlayers = 0;
 
 	for (const auto& playerID : state.players) {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 		if (player == nullptr || player->GetIsDead()) {
 			deadPlayers++;
 		}
@@ -323,9 +323,9 @@ bool BaseSurvivalServer::CheckAllPlayersDead() {
 void BaseSurvivalServer::SetPlayerSpawnPoints() {
 	auto spawnerIndex = 1;
 	for (const auto& playerID : state.players) {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 		if (player != nullptr) {
-			auto possibleSpawners = EntityManager::Instance()->GetEntitiesInGroup("P" + std::to_string(spawnerIndex) + "_Spawn");
+			auto possibleSpawners = Game::entityManager->GetEntitiesInGroup("P" + std::to_string(spawnerIndex) + "_Spawn");
 			if (!possibleSpawners.empty()) {
 				auto* spawner = possibleSpawners.at(0);
 				GameMessages::SendTeleport(playerID, spawner->GetPosition(), spawner->GetRotation(), player->GetSystemAddress(), true);
@@ -348,7 +348,7 @@ void BaseSurvivalServer::GameOver(Entity* self) {
 	SpawnerReset(spawnerNetworks.rewardNetworks);
 
 	for (const auto& playerID : state.players) {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 		if (player == nullptr)
 			continue;
 

--- a/dScripts/BaseWavesServer.cpp
+++ b/dScripts/BaseWavesServer.cpp
@@ -195,7 +195,7 @@ void BaseWavesServer::OnActivityTimerDone(Entity* self, const std::string& name)
 		ActivityTimerStart(self, PlaySpawnSoundTimer, 3, 3);
 	} else if (name == PlaySpawnSoundTimer) {
 		for (const auto& playerID : state.players) {
-			auto* player = EntityManager::Instance()->GetEntity(playerID);
+			auto* player = Game::entityManager->GetEntity(playerID);
 			if (player != nullptr) {
 				GameMessages::SendPlayNDAudioEmitter(player, player->GetSystemAddress(), spawnSoundGUID);
 			}
@@ -216,7 +216,7 @@ void BaseWavesServer::OnActivityTimerDone(Entity* self, const std::string& name)
 	} else if (name == GameOverWinTimer) {
 		GameOver(self, true);
 	} else if (name == CinematicDoneTimer) {
-		for (auto* boss : EntityManager::Instance()->GetEntitiesInGroup("boss")) {
+		for (auto* boss : Game::entityManager->GetEntitiesInGroup("boss")) {
 			boss->OnFireEventServerSide(self, "startAI");
 		}
 	}
@@ -224,7 +224,7 @@ void BaseWavesServer::OnActivityTimerDone(Entity* self, const std::string& name)
 
 // Done
 void BaseWavesServer::ResetStats(LWOOBJID playerID) {
-	auto* player = EntityManager::Instance()->GetEntity(playerID);
+	auto* player = Game::entityManager->GetEntity(playerID);
 	if (player != nullptr) {
 
 		// Boost all the player stats when loading in
@@ -284,7 +284,7 @@ void BaseWavesServer::StartWaves(Entity* self) {
 	state.waitingPlayers.clear();
 
 	for (const auto& playerID : state.players) {
-		const auto player = EntityManager::Instance()->GetEntity(playerID);
+		const auto player = Game::entityManager->GetEntity(playerID);
 		if (player != nullptr) {
 			state.waitingPlayers.push_back(playerID);
 
@@ -309,7 +309,7 @@ bool BaseWavesServer::CheckAllPlayersDead() {
 	auto deadPlayers = 0;
 
 	for (const auto& playerID : state.players) {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 		if (player == nullptr || player->GetIsDead()) {
 			deadPlayers++;
 		}
@@ -322,9 +322,9 @@ bool BaseWavesServer::CheckAllPlayersDead() {
 void BaseWavesServer::SetPlayerSpawnPoints(const LWOOBJID& specificPlayerID) {
 	auto spawnerIndex = 1;
 	for (const auto& playerID : state.players) {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 		if (player != nullptr && (specificPlayerID == LWOOBJID_EMPTY || playerID == specificPlayerID)) {
-			auto possibleSpawners = EntityManager::Instance()->GetEntitiesInGroup("P" + std::to_string(spawnerIndex) + "_Spawn");
+			auto possibleSpawners = Game::entityManager->GetEntitiesInGroup("P" + std::to_string(spawnerIndex) + "_Spawn");
 			if (!possibleSpawners.empty()) {
 				auto* spawner = possibleSpawners.at(0);
 				GameMessages::SendTeleport(playerID, spawner->GetPosition(), spawner->GetRotation(), player->GetSystemAddress(), true);
@@ -353,7 +353,7 @@ void BaseWavesServer::GameOver(Entity* self, bool won) {
 	ClearSpawners();
 
 	for (const auto& playerID : state.players) {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 		if (player == nullptr)
 			continue;
 
@@ -429,7 +429,7 @@ void BaseWavesServer::SpawnWave(Entity* self) {
 		}
 
 		for (const auto& playerID : state.players) {
-			auto* player = EntityManager::Instance()->GetEntity(playerID);
+			auto* player = Game::entityManager->GetEntity(playerID);
 			if (player && player->GetIsDead()) {
 				player->Resurrect();
 			}
@@ -471,7 +471,7 @@ bool BaseWavesServer::UpdateSpawnedEnemies(Entity* self, LWOOBJID enemyID, uint3
 
 	state.currentSpawned--;
 
-	auto* enemy = EntityManager::Instance()->GetEntity(enemyID);
+	auto* enemy = Game::entityManager->GetEntity(enemyID);
 	if (enemy != nullptr && enemy->IsPlayer() && IsPlayerInActivity(self, enemyID)) {
 		SetActivityValue(self, enemyID, 0, GetActivityValue(self, enemyID, 0) + score);
 	}
@@ -499,7 +499,7 @@ bool BaseWavesServer::UpdateSpawnedEnemies(Entity* self, LWOOBJID enemyID, uint3
 		const auto soloWaveMissions = waves.at(completedWave).soloMissions;
 
 		for (const auto& playerID : state.players) {
-			auto* player = EntityManager::Instance()->GetEntity(playerID);
+			auto* player = Game::entityManager->GetEntity(playerID);
 			if (player != nullptr && !player->GetIsDead()) {
 				SetActivityValue(self, playerID, 1, currentTime);
 				SetActivityValue(self, playerID, 2, state.waveNumber);
@@ -558,7 +558,7 @@ bool BaseWavesServer::UpdateSpawnedEnemies(Entity* self, LWOOBJID enemyID, uint3
 // Done
 void BaseWavesServer::UpdateMissionForAllPlayers(Entity* self, uint32_t missionID) {
 	for (const auto& playerID : state.players) {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 		if (player != nullptr) {
 			auto* missionComponent = player->GetComponent<MissionComponent>();
 			if (missionComponent == nullptr) return;

--- a/dScripts/Darkitect.cpp
+++ b/dScripts/Darkitect.cpp
@@ -12,7 +12,7 @@ void Darkitect::Reveal(Entity* self, Entity* player) {
 	GameMessages::SendNotifyClientObject(self->GetObjectID(), u"reveal", 0, 0, playerID, "", player->GetSystemAddress());
 
 	self->AddCallbackTimer(20, [this, self, playerID]() {
-		auto* player = EntityManager::Instance()->GetEntity(playerID);
+		auto* player = Game::entityManager->GetEntity(playerID);
 
 		if (!player) return;
 
@@ -29,7 +29,7 @@ void Darkitect::Reveal(Entity* self, Entity* player) {
 				character->SetPlayerFlag(1911, true);
 			}
 
-			EntityManager::Instance()->SerializeEntity(player);
+			Game::entityManager->SerializeEntity(player);
 		}
 		});
 }

--- a/dScripts/EquipmentScripts/PersonalFortress.cpp
+++ b/dScripts/EquipmentScripts/PersonalFortress.cpp
@@ -26,7 +26,7 @@ void PersonalFortress::OnStartup(Entity* self) {
 		true, true, true, true, true, true, true, true, true
 	);
 
-	EntityManager::Instance()->SerializeEntity(owner);
+	Game::entityManager->SerializeEntity(owner);
 }
 
 void PersonalFortress::OnDie(Entity* self, Entity* killer) {
@@ -47,7 +47,7 @@ void PersonalFortress::OnDie(Entity* self, Entity* killer) {
 		true, true, true, true, true, true, true, true, true
 	);
 
-	EntityManager::Instance()->SerializeEntity(owner);
+	Game::entityManager->SerializeEntity(owner);
 }
 
 void PersonalFortress::OnTimerDone(Entity* self, std::string timerName) {

--- a/dScripts/ScriptedPowerupSpawner.cpp
+++ b/dScripts/ScriptedPowerupSpawner.cpp
@@ -21,7 +21,7 @@ void ScriptedPowerupSpawner::OnTimerDone(Entity* self, std::string message) {
 		drops.emplace(itemLOT, 1);
 
 		// Spawn the required number of powerups
-		auto* owner = EntityManager::Instance()->GetEntity(self->GetSpawnerID());
+		auto* owner = Game::entityManager->GetEntity(self->GetSpawnerID());
 		if (owner != nullptr) {
 			auto* renderComponent = self->GetComponent<RenderComponent>();
 			for (auto i = 0; i < self->GetVar<uint32_t>(u"numberOfPowerups"); i++) {

--- a/dScripts/SpawnPetBaseServer.cpp
+++ b/dScripts/SpawnPetBaseServer.cpp
@@ -11,7 +11,7 @@ void SpawnPetBaseServer::OnStartup(Entity* self) {
 }
 
 void SpawnPetBaseServer::OnUse(Entity* self, Entity* user) {
-	auto possibleSpawners = EntityManager::Instance()->GetEntitiesInGroup(self->GetVar<std::string>(u"petType") + "Spawner");
+	auto possibleSpawners = Game::entityManager->GetEntitiesInGroup(self->GetVar<std::string>(u"petType") + "Spawner");
 	if (possibleSpawners.empty())
 		return;
 
@@ -33,8 +33,8 @@ void SpawnPetBaseServer::OnUse(Entity* self, Entity* user) {
 		new LDFData<float_t>(u"spawnTimer", 1.0f)
 	};
 
-	auto* pet = EntityManager::Instance()->CreateEntity(info);
-	EntityManager::Instance()->ConstructEntity(pet);
+	auto* pet = Game::entityManager->CreateEntity(info);
+	Game::entityManager->ConstructEntity(pet);
 
 	self->SetVar<std::string>(u"spawnedPets", self->GetVar<std::string>(u"spawnedPets") + ","
 		+ std::to_string(pet->GetObjectID()));
@@ -57,7 +57,7 @@ bool SpawnPetBaseServer::CheckNumberOfPets(Entity* self, Entity* user) {
 		if (petID.empty())
 			continue;
 
-		const auto* spawnedPet = EntityManager::Instance()->GetEntity(std::stoull(petID));
+		const auto* spawnedPet = Game::entityManager->GetEntity(std::stoull(petID));
 		if (spawnedPet == nullptr)
 			continue;
 

--- a/dScripts/ai/ACT/ActVehicleDeathTrigger.cpp
+++ b/dScripts/ai/ACT/ActVehicleDeathTrigger.cpp
@@ -14,7 +14,7 @@ void ActVehicleDeathTrigger::OnCollisionPhantom(Entity* self, Entity* target) {
 	Entity* player;
 
 	if (possessableComponent != nullptr) {
-		auto* player = EntityManager::Instance()->GetEntity(possessableComponent->GetPossessor());
+		auto* player = Game::entityManager->GetEntity(possessableComponent->GetPossessor());
 
 		if (player == nullptr) {
 			return;
@@ -28,7 +28,7 @@ void ActVehicleDeathTrigger::OnCollisionPhantom(Entity* self, Entity* target) {
 			return;
 		}
 
-		vehicle = EntityManager::Instance()->GetEntity(possessorComponent->GetPossessable());
+		vehicle = Game::entityManager->GetEntity(possessorComponent->GetPossessable());
 
 		if (vehicle == nullptr) {
 			return;

--- a/dScripts/ai/ACT/FootRace/BaseFootRaceManager.cpp
+++ b/dScripts/ai/ACT/FootRace/BaseFootRaceManager.cpp
@@ -11,7 +11,7 @@ void BaseFootRaceManager::OnFireEventServerSide(Entity* self, Entity* sender, st
 	if (splitArguments.size() > 1) {
 
 		const auto eventName = splitArguments[0];
-		const auto player = EntityManager::Instance()->GetEntity(std::stoull(splitArguments[1]));
+		const auto player = Game::entityManager->GetEntity(std::stoull(splitArguments[1]));
 
 		if (player != nullptr) {
 			if (eventName == "updatePlayer") {

--- a/dScripts/ai/AG/AgBusDoor.cpp
+++ b/dScripts/ai/AG/AgBusDoor.cpp
@@ -24,12 +24,12 @@ void AgBusDoor::OnProximityUpdate(Entity* self, Entity* entering, std::string na
 	m_OuterCounter = 0;
 
 	for (const auto& pair : proximityMonitorComponent->GetProximityObjects("busDoor")) {
-		auto* entity = EntityManager::Instance()->GetEntity(pair.first);
+		auto* entity = Game::entityManager->GetEntity(pair.first);
 		if (entity != nullptr && entity->IsPlayer()) m_Counter++;
 	}
 
 	for (const auto& pair : proximityMonitorComponent->GetProximityObjects("busDoorOuter")) {
-		auto* entity = EntityManager::Instance()->GetEntity(pair.first);
+		auto* entity = Game::entityManager->GetEntity(pair.first);
 		if (entity != nullptr && entity->IsPlayer()) m_OuterCounter++;
 	}
 

--- a/dScripts/ai/AG/AgFans.cpp
+++ b/dScripts/ai/AG/AgFans.cpp
@@ -25,7 +25,7 @@ void AgFans::OnStartup(Entity* self) {
 
 void AgFans::ToggleFX(Entity* self, bool hit) {
 	std::string fanGroup = self->GetGroups()[0];
-	std::vector<Entity*> fanVolumes = EntityManager::Instance()->GetEntitiesInGroup(fanGroup);
+	std::vector<Entity*> fanVolumes = Game::entityManager->GetEntitiesInGroup(fanGroup);
 
 	auto* renderComponent = static_cast<RenderComponent*>(self->GetComponent(eReplicaComponentType::RENDER));
 
@@ -45,9 +45,9 @@ void AgFans::ToggleFX(Entity* self, bool hit) {
 			PhantomPhysicsComponent* volumePhys = static_cast<PhantomPhysicsComponent*>(volume->GetComponent(eReplicaComponentType::PHANTOM_PHYSICS));
 			if (!volumePhys) continue;
 			volumePhys->SetPhysicsEffectActive(false);
-			EntityManager::Instance()->SerializeEntity(volume);
+			Game::entityManager->SerializeEntity(volume);
 			if (!hit) {
-				Entity* fxObj = EntityManager::Instance()->GetEntitiesInGroup(fanGroup + "fx")[0];
+				Entity* fxObj = Game::entityManager->GetEntitiesInGroup(fanGroup + "fx")[0];
 				RenderComponent::PlayAnimation(fxObj, u"trigger");
 			}
 		}
@@ -61,9 +61,9 @@ void AgFans::ToggleFX(Entity* self, bool hit) {
 			PhantomPhysicsComponent* volumePhys = static_cast<PhantomPhysicsComponent*>(volume->GetComponent(eReplicaComponentType::PHANTOM_PHYSICS));
 			if (!volumePhys) continue;
 			volumePhys->SetPhysicsEffectActive(true);
-			EntityManager::Instance()->SerializeEntity(volume);
+			Game::entityManager->SerializeEntity(volume);
 			if (!hit) {
-				Entity* fxObj = EntityManager::Instance()->GetEntitiesInGroup(fanGroup + "fx")[0];
+				Entity* fxObj = Game::entityManager->GetEntitiesInGroup(fanGroup + "fx")[0];
 				RenderComponent::PlayAnimation(fxObj, u"idle");
 			}
 		}

--- a/dScripts/ai/AG/AgImagSmashable.cpp
+++ b/dScripts/ai/AG/AgImagSmashable.cpp
@@ -36,9 +36,9 @@ void AgImagSmashable::CrateAnimal(Entity* self) {
 		info.spawnerID = self->GetSpawnerID();
 		info.spawnerNodeID = 0;
 
-		Entity* newEntity = EntityManager::Instance()->CreateEntity(info, nullptr);
+		Entity* newEntity = Game::entityManager->CreateEntity(info, nullptr);
 		if (newEntity) {
-			EntityManager::Instance()->ConstructEntity(newEntity);
+			Game::entityManager->ConstructEntity(newEntity);
 		}
 	}
 }

--- a/dScripts/ai/AG/AgJetEffectServer.cpp
+++ b/dScripts/ai/AG/AgJetEffectServer.cpp
@@ -12,7 +12,7 @@ void AgJetEffectServer::OnUse(Entity* self, Entity* user) {
 	);
 	inUse = true;
 
-	auto entities = EntityManager::Instance()->GetEntitiesInGroup("Jet_FX");
+	auto entities = Game::entityManager->GetEntitiesInGroup("Jet_FX");
 	if (entities.empty()) return;
 	GameMessages::SendPlayFXEffect(entities.at(0), 641, u"create", "radarDish", LWOOBJID_EMPTY, 1, 1, true);
 	self->AddTimer("radarDish", 2.0f);
@@ -22,7 +22,7 @@ void AgJetEffectServer::OnUse(Entity* self, Entity* user) {
 
 void AgJetEffectServer::OnRebuildComplete(Entity* self, Entity* target) {
 	if (self->GetLOT() != 6209) return;
-	auto entities = EntityManager::Instance()->GetEntitiesInGroup("Jet_FX");
+	auto entities = Game::entityManager->GetEntitiesInGroup("Jet_FX");
 	if (entities.empty()) return;
 	RenderComponent::PlayAnimation(entities.at(0), u"jetFX");
 
@@ -40,7 +40,7 @@ void AgJetEffectServer::OnTimerDone(Entity* self, std::string timerName) {
 	if (timerName == "radarDish") {
 		GameMessages::SendStopFXEffect(self, true, "radarDish");
 	} else if (timerName == "PlayEffect") {
-		auto entities = EntityManager::Instance()->GetEntitiesInGroup("mortarMain");
+		auto entities = Game::entityManager->GetEntitiesInGroup("mortarMain");
 		if (entities.empty()) return;
 
 		const auto selected = GeneralUtils::GenerateRandomNumber<int>(0, entities.size() - 1);

--- a/dScripts/ai/AG/AgQbElevator.cpp
+++ b/dScripts/ai/AG/AgQbElevator.cpp
@@ -26,7 +26,7 @@ void AgQbElevator::OnProximityUpdate(Entity* self, Entity* entering, std::string
 	if (self->GetBoolean(u"qbPlayerRdy")) return;
 
 	if (status == "ENTER") {
-		Entity* builder = EntityManager::Instance()->GetEntity(self->GetI64(u"qbPlayer"));
+		Entity* builder = Game::entityManager->GetEntity(self->GetI64(u"qbPlayer"));
 		if (builder && builder == entering) {
 			//the builder has entered so cancel the start timer and just start moving
 			self->SetBoolean(u"qbPlayerRdy", true);

--- a/dScripts/ai/AG/AgQbWall.cpp
+++ b/dScripts/ai/AG/AgQbWall.cpp
@@ -4,7 +4,7 @@ void AgQbWall::OnRebuildComplete(Entity* self, Entity* player) {
 	self->SetVar(u"player", player->GetObjectID());
 	auto targetWallSpawners = GeneralUtils::UTF16ToWTF8(self->GetVar<std::u16string>(u"spawner"));
 	if (targetWallSpawners != "") {
-		auto groupObjs = EntityManager::Instance()->GetEntitiesInGroup(targetWallSpawners);
+		auto groupObjs = Game::entityManager->GetEntitiesInGroup(targetWallSpawners);
 		for (auto* obj : groupObjs) {
 			if (obj) {
 				obj->SetVar(u"player", player->GetObjectID());

--- a/dScripts/ai/AG/AgSpaceStuff.cpp
+++ b/dScripts/ai/AG/AgSpaceStuff.cpp
@@ -15,9 +15,9 @@ void AgSpaceStuff::OnStartup(Entity* self) {
 	info.lot = 33;
 	info.spawnerID = self->GetObjectID();
 
-	auto* ref = EntityManager::Instance()->CreateEntity(info);
+	auto* ref = Game::entityManager->CreateEntity(info);
 
-	EntityManager::Instance()->ConstructEntity(ref);
+	Game::entityManager->ConstructEntity(ref);
 
 	self->SetVar(u"ShakeObject", ref->GetObjectID());
 
@@ -47,7 +47,7 @@ void AgSpaceStuff::OnTimerDone(Entity* self, std::string timerName) {
 void AgSpaceStuff::DoShake(Entity* self, bool explodeIdle) {
 
 	if (!explodeIdle) {
-		auto* ref = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"ShakeObject"));
+		auto* ref = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"ShakeObject"));
 
 		const auto randomTime = self->GetVar<int>(u"RandomTime");
 		auto time = GeneralUtils::GenerateRandomNumber<int>(0, randomTime + 1);
@@ -92,7 +92,7 @@ void AgSpaceStuff::DoShake(Entity* self, bool explodeIdle) {
 }
 
 Entity* AgSpaceStuff::GetEntityInGroup(const std::string& group) {
-	auto entities = EntityManager::Instance()->GetEntitiesInGroup(group);
+	auto entities = Game::entityManager->GetEntitiesInGroup(group);
 	Entity* en = nullptr;
 
 	for (auto entity : entities) {

--- a/dScripts/ai/FV/ActNinjaSensei.cpp
+++ b/dScripts/ai/FV/ActNinjaSensei.cpp
@@ -4,7 +4,7 @@
 #include "GameMessages.h"
 
 void ActNinjaSensei::OnStartup(Entity* self) {
-	auto students = EntityManager::Instance()->GetEntitiesInGroup(this->m_StudentGroup);
+	auto students = Game::entityManager->GetEntitiesInGroup(this->m_StudentGroup);
 	std::vector<Entity*> validStudents = {};
 	for (auto* student : students) {
 		if (student && student->GetLOT() == this->m_StudentLOT) validStudents.push_back(student);

--- a/dScripts/ai/FV/ActParadoxPipeFix.cpp
+++ b/dScripts/ai/FV/ActParadoxPipeFix.cpp
@@ -8,7 +8,7 @@
 void ActParadoxPipeFix::OnRebuildComplete(Entity* self, Entity* target) {
 	const auto myGroup = "AllPipes";
 
-	const auto groupObjs = EntityManager::Instance()->GetEntitiesInGroup(myGroup);
+	const auto groupObjs = Game::entityManager->GetEntitiesInGroup(myGroup);
 
 	auto indexCount = 0;
 
@@ -27,14 +27,14 @@ void ActParadoxPipeFix::OnRebuildComplete(Entity* self, Entity* target) {
 	}
 
 	if (indexCount >= 2) {
-		const auto refinery = EntityManager::Instance()->GetEntitiesInGroup("Paradox");
+		const auto refinery = Game::entityManager->GetEntitiesInGroup("Paradox");
 
 		if (!refinery.empty()) {
 			GameMessages::SendPlayFXEffect(refinery[0]->GetObjectID(), 3999, u"create", "pipeFX");
 		}
 
 		for (auto* object : groupObjs) {
-			auto* player = EntityManager::Instance()->GetEntity(object->GetVar<LWOOBJID>(u"PlayerID"));
+			auto* player = Game::entityManager->GetEntity(object->GetVar<LWOOBJID>(u"PlayerID"));
 
 			if (player != nullptr) {
 				auto* missionComponent = player->GetComponent<MissionComponent>();
@@ -53,7 +53,7 @@ void ActParadoxPipeFix::OnRebuildComplete(Entity* self, Entity* target) {
 
 void ActParadoxPipeFix::OnRebuildNotifyState(Entity* self, eRebuildState state) {
 	if (state == eRebuildState::RESETTING) {
-		const auto refinery = EntityManager::Instance()->GetEntitiesInGroup("Paradox");
+		const auto refinery = Game::entityManager->GetEntitiesInGroup("Paradox");
 
 		if (!refinery.empty()) {
 			GameMessages::SendStopFXEffect(refinery[0], true, "pipeFX");

--- a/dScripts/ai/FV/FvConsoleLeftQuickbuild.cpp
+++ b/dScripts/ai/FV/FvConsoleLeftQuickbuild.cpp
@@ -13,7 +13,7 @@ void FvConsoleLeftQuickbuild::OnRebuildNotifyState(Entity* self, eRebuildState s
 	if (state == eRebuildState::COMPLETED) {
 		self->SetVar(u"IAmBuilt", true);
 
-		const auto objects = EntityManager::Instance()->GetEntitiesInGroup("Facility");
+		const auto objects = Game::entityManager->GetEntitiesInGroup("Facility");
 
 		if (!objects.empty()) {
 			objects[0]->NotifyObject(self, "ConsoleLeftUp");
@@ -22,7 +22,7 @@ void FvConsoleLeftQuickbuild::OnRebuildNotifyState(Entity* self, eRebuildState s
 		self->SetVar(u"IAmBuilt", false);
 		self->SetVar(u"AmActive", false);
 
-		const auto objects = EntityManager::Instance()->GetEntitiesInGroup("Facility");
+		const auto objects = Game::entityManager->GetEntitiesInGroup("Facility");
 
 		if (!objects.empty()) {
 			objects[0]->NotifyObject(self, "ConsoleLeftDown");
@@ -38,7 +38,7 @@ void FvConsoleLeftQuickbuild::OnUse(Entity* self, Entity* user) {
 	if (self->GetVar<bool>(u"IAmBuilt")) {
 		self->SetVar(u"AmActive", true);
 
-		const auto objects = EntityManager::Instance()->GetEntitiesInGroup("Facility");
+		const auto objects = Game::entityManager->GetEntitiesInGroup("Facility");
 
 		if (!objects.empty()) {
 			objects[0]->NotifyObject(self, "ConsoleLeftActive");

--- a/dScripts/ai/FV/FvConsoleRightQuickbuild.cpp
+++ b/dScripts/ai/FV/FvConsoleRightQuickbuild.cpp
@@ -13,7 +13,7 @@ void FvConsoleRightQuickbuild::OnRebuildNotifyState(Entity* self, eRebuildState 
 	if (state == eRebuildState::COMPLETED) {
 		self->SetVar(u"IAmBuilt", true);
 
-		const auto objects = EntityManager::Instance()->GetEntitiesInGroup("Facility");
+		const auto objects = Game::entityManager->GetEntitiesInGroup("Facility");
 
 		if (!objects.empty()) {
 			objects[0]->NotifyObject(self, "ConsoleRightUp");
@@ -22,7 +22,7 @@ void FvConsoleRightQuickbuild::OnRebuildNotifyState(Entity* self, eRebuildState 
 		self->SetVar(u"IAmBuilt", false);
 		self->SetVar(u"AmActive", false);
 
-		const auto objects = EntityManager::Instance()->GetEntitiesInGroup("Facility");
+		const auto objects = Game::entityManager->GetEntitiesInGroup("Facility");
 
 		if (!objects.empty()) {
 			objects[0]->NotifyObject(self, "ConsoleRightDown");
@@ -38,7 +38,7 @@ void FvConsoleRightQuickbuild::OnUse(Entity* self, Entity* user) {
 	if (self->GetVar<bool>(u"IAmBuilt")) {
 		self->SetVar(u"AmActive", true);
 
-		const auto objects = EntityManager::Instance()->GetEntitiesInGroup("Facility");
+		const auto objects = Game::entityManager->GetEntitiesInGroup("Facility");
 
 		if (!objects.empty()) {
 			objects[0]->NotifyObject(self, "ConsoleRightActive");

--- a/dScripts/ai/FV/FvDragonSmashingGolemQb.cpp
+++ b/dScripts/ai/FV/FvDragonSmashingGolemQb.cpp
@@ -21,7 +21,7 @@ void FvDragonSmashingGolemQb::OnRebuildNotifyState(Entity* self, eRebuildState s
 
 		const auto dragonId = self->GetVar<LWOOBJID>(u"Dragon");
 
-		auto* dragon = EntityManager::Instance()->GetEntity(dragonId);
+		auto* dragon = Game::entityManager->GetEntity(dragonId);
 
 		if (dragon != nullptr) {
 			dragon->OnFireEventServerSide(self, "rebuildDone");

--- a/dScripts/ai/FV/FvFacilityBrick.cpp
+++ b/dScripts/ai/FV/FvFacilityBrick.cpp
@@ -46,14 +46,14 @@ void FvFacilityBrick::OnNotifyObject(Entity* self, Entity* sender, const std::st
 	}
 
 	if (self->GetVar<bool>(u"ConsoleLEFTActive") && self->GetVar<bool>(u"ConsoleRIGHTActive")) {
-		auto* object = EntityManager::Instance()->GetEntitiesInGroup("Brick")[0];
+		auto* object = Game::entityManager->GetEntitiesInGroup("Brick")[0];
 
 		if (object != nullptr) {
 			GameMessages::SendPlayFXEffect(object->GetObjectID(), 122, u"create", "bluebrick");
 			GameMessages::SendPlayFXEffect(object->GetObjectID(), 1034, u"cast", "imaginationexplosion");
 		}
 
-		object = EntityManager::Instance()->GetEntitiesInGroup("Canister")[0];
+		object = Game::entityManager->GetEntitiesInGroup("Canister")[0];
 
 		if (object != nullptr) {
 			object->Smash(self->GetObjectID(), eKillType::SILENT);
@@ -64,7 +64,7 @@ void FvFacilityBrick::OnNotifyObject(Entity* self, Entity* sender, const std::st
 	} else if (self->GetVar<bool>(u"ConsoleLEFTActive") || self->GetVar<bool>(u"ConsoleRIGHTActive")) {
 		brickSpawner->Activate();
 
-		auto* object = EntityManager::Instance()->GetEntitiesInGroup("Brick")[0];
+		auto* object = Game::entityManager->GetEntitiesInGroup("Brick")[0];
 
 		if (object != nullptr) {
 			GameMessages::SendStopFXEffect(object, true, "bluebrick");

--- a/dScripts/ai/FV/FvFlyingCreviceDragon.cpp
+++ b/dScripts/ai/FV/FvFlyingCreviceDragon.cpp
@@ -34,7 +34,7 @@ void FvFlyingCreviceDragon::OnTimerDone(Entity* self, std::string timerName) {
 		groupName = "dragonFireballs3";
 	}
 
-	const auto& group = EntityManager::Instance()->GetEntitiesInGroup(groupName);
+	const auto& group = Game::entityManager->GetEntitiesInGroup(groupName);
 
 	if (group.empty()) {
 		return;
@@ -73,7 +73,7 @@ void FvFlyingCreviceDragon::OnArrived(Entity* self) {
 	} else if (point == 12) {
 		RenderComponent::PlayAnimation(self, u"attack2", 2.0f);
 
-		const auto& group2 = EntityManager::Instance()->GetEntitiesInGroup("dragonFireballs2");
+		const auto& group2 = Game::entityManager->GetEntitiesInGroup("dragonFireballs2");
 
 		if (group2.empty()) {
 			return;

--- a/dScripts/ai/FV/FvNinjaGuard.cpp
+++ b/dScripts/ai/FV/FvNinjaGuard.cpp
@@ -22,13 +22,13 @@ void FvNinjaGuard::OnEmoteReceived(Entity* self, const int32_t emote, Entity* ta
 	RenderComponent::PlayAnimation(self, u"scared");
 
 	if (self->GetLOT() == 7412) {
-		auto* rightGuard = EntityManager::Instance()->GetEntity(m_RightGuard);
+		auto* rightGuard = Game::entityManager->GetEntity(m_RightGuard);
 
 		if (rightGuard != nullptr) {
 			RenderComponent::PlayAnimation(rightGuard, u"laugh_rt");
 		}
 	} else if (self->GetLOT() == 11128) {
-		auto* leftGuard = EntityManager::Instance()->GetEntity(m_LeftGuard);
+		auto* leftGuard = Game::entityManager->GetEntity(m_LeftGuard);
 
 		if (leftGuard != nullptr) {
 			RenderComponent::PlayAnimation(leftGuard, u"laugh_lt");

--- a/dScripts/ai/FV/FvPandaSpawnerServer.cpp
+++ b/dScripts/ai/FV/FvPandaSpawnerServer.cpp
@@ -9,7 +9,7 @@ void FvPandaSpawnerServer::OnCollisionPhantom(Entity* self, Entity* target) {
 	auto* character = target->GetCharacter();
 	if (character != nullptr && character->GetPlayerFlag(81)) {
 
-		auto raceObjects = EntityManager::Instance()->GetEntitiesInGroup("PandaRaceObject");
+		auto raceObjects = Game::entityManager->GetEntitiesInGroup("PandaRaceObject");
 		if (raceObjects.empty())
 			return;
 
@@ -19,7 +19,7 @@ void FvPandaSpawnerServer::OnCollisionPhantom(Entity* self, Entity* target) {
 			return;
 
 		// If the player already spawned a panda
-		auto playerPandas = EntityManager::Instance()->GetEntitiesInGroup("panda" + std::to_string(target->GetObjectID()));
+		auto playerPandas = Game::entityManager->GetEntitiesInGroup("panda" + std::to_string(target->GetObjectID()));
 		if (!playerPandas.empty()) {
 			GameMessages::SendFireEventClientSide(self->GetObjectID(), target->GetSystemAddress(), u"playerPanda",
 				target->GetObjectID(), 0, 0, target->GetObjectID());
@@ -27,7 +27,7 @@ void FvPandaSpawnerServer::OnCollisionPhantom(Entity* self, Entity* target) {
 		}
 
 		// If there's already too many spawned pandas
-		auto pandas = EntityManager::Instance()->GetEntitiesInGroup("pandas");
+		auto pandas = Game::entityManager->GetEntitiesInGroup("pandas");
 		if (pandas.size() > 4) {
 			GameMessages::SendFireEventClientSide(self->GetObjectID(), target->GetSystemAddress(), u"tooManyPandas",
 				target->GetObjectID(), 0, 0, target->GetObjectID());
@@ -43,7 +43,7 @@ void FvPandaSpawnerServer::OnCollisionPhantom(Entity* self, Entity* target) {
 			new LDFData<std::u16string>(u"groupID", u"panda" + (GeneralUtils::to_u16string(target->GetObjectID())) + u";pandas")
 		};
 
-		auto* panda = EntityManager::Instance()->CreateEntity(info);
-		EntityManager::Instance()->ConstructEntity(panda);
+		auto* panda = Game::entityManager->CreateEntity(info);
+		Game::entityManager->ConstructEntity(panda);
 	}
 }

--- a/dScripts/ai/GF/GfBanana.cpp
+++ b/dScripts/ai/GF/GfBanana.cpp
@@ -20,9 +20,9 @@ void GfBanana::SpawnBanana(Entity* self) {
 	info.lot = 6909;
 	info.spawnerID = self->GetObjectID();
 
-	auto* entity = EntityManager::Instance()->CreateEntity(info);
+	auto* entity = Game::entityManager->CreateEntity(info);
 
-	EntityManager::Instance()->ConstructEntity(entity);
+	Game::entityManager->ConstructEntity(entity);
 
 	self->SetVar(u"banana", entity->GetObjectID());
 
@@ -46,7 +46,7 @@ void GfBanana::OnHit(Entity* self, Entity* attacker) {
 
 	if (bananaId == LWOOBJID_EMPTY) return;
 
-	auto* bananaEntity = EntityManager::Instance()->GetEntity(bananaId);
+	auto* bananaEntity = Game::entityManager->GetEntity(bananaId);
 
 	if (bananaEntity == nullptr) {
 		self->SetVar(u"banana", LWOOBJID_EMPTY);
@@ -79,12 +79,12 @@ void GfBanana::OnHit(Entity* self, Entity* attacker) {
 	info.lot = 6718;
 	info.spawnerID = self->GetObjectID();
 
-	auto* entity = EntityManager::Instance()->CreateEntity(info);
+	auto* entity = Game::entityManager->CreateEntity(info);
 
-	EntityManager::Instance()->ConstructEntity(entity, UNASSIGNED_SYSTEM_ADDRESS);
+	Game::entityManager->ConstructEntity(entity, UNASSIGNED_SYSTEM_ADDRESS);
 	*/
 
-	EntityManager::Instance()->SerializeEntity(self);
+	Game::entityManager->SerializeEntity(self);
 }
 
 void GfBanana::OnTimerDone(Entity* self, std::string timerName) {

--- a/dScripts/ai/GF/GfCampfire.cpp
+++ b/dScripts/ai/GF/GfCampfire.cpp
@@ -83,7 +83,7 @@ void GfCampfire::OnTimerDone(Entity* self, std::string timerName) {
 
 		const auto targetId = self->GetVar<LWOOBJID>("target");
 
-		auto* entering = EntityManager::Instance()->GetEntity(targetId);
+		auto* entering = Game::entityManager->GetEntity(targetId);
 
 		if (entering == nullptr)
 		{

--- a/dScripts/ai/GF/PetDigBuild.cpp
+++ b/dScripts/ai/GF/PetDigBuild.cpp
@@ -30,8 +30,8 @@ void PetDigBuild::OnRebuildComplete(Entity* self, Entity* target) {
 		}
 	}
 
-	auto* treasure = EntityManager::Instance()->CreateEntity(info);
-	EntityManager::Instance()->ConstructEntity(treasure);
+	auto* treasure = Game::entityManager->CreateEntity(info);
+	Game::entityManager->ConstructEntity(treasure);
 	self->SetVar<LWOOBJID>(u"chestObj", treasure->GetObjectID());
 }
 
@@ -40,7 +40,7 @@ void PetDigBuild::OnDie(Entity* self, Entity* killer) {
 	if (treasureID == LWOOBJID_EMPTY)
 		return;
 
-	auto treasure = EntityManager::Instance()->GetEntity(treasureID);
+	auto treasure = Game::entityManager->GetEntity(treasureID);
 	if (treasure == nullptr)
 		return;
 

--- a/dScripts/ai/MINIGAME/SG_GF/SERVER/SGCannon.cpp
+++ b/dScripts/ai/MINIGAME/SG_GF/SERVER/SGCannon.cpp
@@ -78,7 +78,7 @@ void SGCannon::OnActivityStateChangeRequest(Entity* self, LWOOBJID senderID, int
 	const std::u16string& stringValue) {
 	Game::logger->Log("SGCannon", "Got activity state change request: %s", GeneralUtils::UTF16ToWTF8(stringValue).c_str());
 	if (stringValue == u"clientready") {
-		auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
+		auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
 		if (player != nullptr) {
 			Game::logger->Log("SGCannon", "Player is ready");
 			/*GameMessages::SendSetStunned(player->GetObjectID(), eStateChangeType::PUSH, player->GetSystemAddress(), LWOOBJID_EMPTY,
@@ -95,7 +95,7 @@ void SGCannon::OnActivityStateChangeRequest(Entity* self, LWOOBJID senderID, int
 
 				Game::logger->Log("SGCannon", "Setting player ID");
 
-				EntityManager::Instance()->SerializeEntity(self);
+				Game::entityManager->SerializeEntity(self);
 			} else {
 				Game::logger->Log("SGCannon", "Shooting gallery component is null");
 			}
@@ -111,7 +111,7 @@ void SGCannon::OnActivityStateChangeRequest(Entity* self, LWOOBJID senderID, int
 					possessor->SetPossessableType(ePossessionType::NO_POSSESSION);
 				}
 
-				EntityManager::Instance()->SerializeEntity(player);
+				Game::entityManager->SerializeEntity(player);
 			}
 
 			self->SetNetworkVar<bool>(HideScoreBoardVariable, true);
@@ -137,7 +137,7 @@ void SGCannon::OnActivityStateChangeRequest(Entity* self, LWOOBJID senderID, int
 }
 
 void SGCannon::OnMessageBoxResponse(Entity* self, Entity* sender, int32_t button, const std::u16string& identifier, const std::u16string& userData) {
-	auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
+	auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
 	if (!player) return;
 
 	if (identifier == u"Scoreboardinfo") {
@@ -193,7 +193,7 @@ void SGCannon::OnActivityTimerDone(Entity* self, const std::string& name) {
 				ActivityTimerStart(self, EndWaveTimer, timeLimit, timeLimit);
 			}
 
-			const auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
+			const auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
 			if (player != nullptr) {
 				GameMessages::SendPlayFXEffect(player->GetObjectID(), -1, u"SG-start", "");
 
@@ -234,13 +234,13 @@ void SGCannon::OnActivityTimerDone(Entity* self, const std::string& name) {
 			PauseChargeCannon(self);
 		}
 	} else if (name == GameOverTimer) {
-		auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
+		auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
 		if (player != nullptr) {
 			Game::logger->Log("SGCannon", "Sending ActivityPause true");
 
 			GameMessages::SendActivityPause(self->GetObjectID(), true, player->GetSystemAddress());
 
-			/*const auto leftoverCannonballs = EntityManager::Instance()->GetEntitiesInGroup("cannonball");
+			/*const auto leftoverCannonballs = Game::entityManager->GetEntitiesInGroup("cannonball");
 			if (leftoverCannonballs.empty()) {
 				RecordPlayerScore(self);
 
@@ -284,8 +284,8 @@ void SGCannon::OnActivityTimerDone(Entity* self, const std::string& name) {
 
 			Game::logger->Log("SGCannon", "Spawning enemy %i on path %s", toSpawn.lot, path->pathName.c_str());
 
-			auto* enemy = EntityManager::Instance()->CreateEntity(info, nullptr, self);
-			EntityManager::Instance()->ConstructEntity(enemy);
+			auto* enemy = Game::entityManager->CreateEntity(info, nullptr, self);
+			Game::entityManager->ConstructEntity(enemy);
 
 			auto* movementAI = new MovementAIComponent(enemy, {});
 
@@ -334,12 +334,12 @@ void SGCannon::StartGame(Entity* self) {
 	self->SetNetworkVar<bool>(AudioStartIntroVariable, true);
 	self->SetVar<LOT>(CurrentRewardVariable, LOT_NULL);
 
-	auto rewardObjects = EntityManager::Instance()->GetEntitiesInGroup(constants.rewardModelGroup);
+	auto rewardObjects = Game::entityManager->GetEntitiesInGroup(constants.rewardModelGroup);
 	for (auto* reward : rewardObjects) {
 		reward->OnFireEventServerSide(self, ModelToBuildEvent);
 	}
 
-	auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
+	auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
 	if (player != nullptr) {
 		GetLeaderboardData(self, player->GetObjectID(), GetActivityID(self));
 		Game::logger->Log("SGCannon", "Sending ActivityStart");
@@ -384,9 +384,9 @@ void SGCannon::SpawnNewModel(Entity* self) {
 		self->SetNetworkVar<int32_t>(RewardAddedVariable, currentReward);
 	}
 
-	auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
+	auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
 	if (player != nullptr) {
-		for (auto* rewardModel : EntityManager::Instance()->GetEntitiesInGroup(constants.rewardModelGroup)) {
+		for (auto* rewardModel : Game::entityManager->GetEntitiesInGroup(constants.rewardModelGroup)) {
 			uint32_t lootMatrix;
 			switch (self->GetVar<uint32_t>(MatrixVariable)) {
 			case 1:
@@ -422,7 +422,7 @@ void SGCannon::SpawnNewModel(Entity* self) {
 }
 
 void SGCannon::RemovePlayer(LWOOBJID playerID) {
-	auto* player = EntityManager::Instance()->GetEntity(playerID);
+	auto* player = Game::entityManager->GetEntity(playerID);
 	if (player == nullptr)
 		return;
 
@@ -508,7 +508,7 @@ void SGCannon::RecordPlayerScore(Entity* self) {
 }
 
 void SGCannon::PlaySceneAnimation(Entity* self, const std::u16string& animationName, bool onCannon, bool onPlayer, float_t priority) {
-	for (auto* cannon : EntityManager::Instance()->GetEntitiesInGroup("cannongroup")) {
+	for (auto* cannon : Game::entityManager->GetEntitiesInGroup("cannongroup")) {
 		RenderComponent::PlayAnimation(cannon, animationName, priority);
 	}
 
@@ -517,7 +517,7 @@ void SGCannon::PlaySceneAnimation(Entity* self, const std::u16string& animationN
 	}
 
 	if (onPlayer) {
-		auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
+		auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
 		if (player != nullptr) {
 			RenderComponent::PlayAnimation(player, animationName, priority);
 		}
@@ -538,7 +538,7 @@ void SGCannon::StopGame(Entity* self, bool cancel) {
 	self->SetNetworkVar<bool>(ReSetSuperChargeVariable, true);
 	self->SetNetworkVar<bool>(HideSuperChargeVariable, true);
 
-	auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
+	auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
 	if (player == nullptr)
 		return;
 
@@ -596,7 +596,7 @@ void SGCannon::StopGame(Entity* self, bool cancel) {
 	ActivityTimerStopAllTimers(self);
 
 	// Destroy all spawners
-	for (auto* entity : EntityManager::Instance()->GetEntitiesInGroup("SGEnemy")) {
+	for (auto* entity : Game::entityManager->GetEntitiesInGroup("SGEnemy")) {
 		entity->Kill();
 	}
 
@@ -663,7 +663,7 @@ void SGCannon::RegisterHit(Entity* self, Entity* target, const std::string& time
 
 	self->SetNetworkVar<std::u16string>(u"beatHighScore", GeneralUtils::to_u16string(newScore));
 
-	auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
+	auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
 	if (player == nullptr) return;
 
 	auto missionComponent = player->GetComponent<MissionComponent>();
@@ -713,7 +713,7 @@ void SGCannon::ToggleSuperCharge(Entity* self, bool enable) {
 	if (enable && self->GetVar<bool>(SuperChargeActiveVariable))
 		return;
 
-	auto* player = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
+	auto* player = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(PlayerIDVariable));
 
 	if (player == nullptr) {
 		Game::logger->Log("SGCannon", "Player not found in toggle super charge");
@@ -788,8 +788,8 @@ void SGCannon::ToggleSuperCharge(Entity* self, bool enable) {
 
 	shootingGalleryComponent->SetDynamicParams(properties);
 
-	EntityManager::Instance()->SerializeEntity(self);
-	EntityManager::Instance()->SerializeEntity(player);
+	Game::entityManager->SerializeEntity(self);
+	Game::entityManager->SerializeEntity(player);
 
 	self->SetNetworkVar<uint64_t>(CannonBallSkillIDVariable, skillID);
 	self->SetVar<bool>(SuperChargeActiveVariable, enable);

--- a/dScripts/ai/MINIGAME/SG_GF/ZoneSGServer.cpp
+++ b/dScripts/ai/MINIGAME/SG_GF/ZoneSGServer.cpp
@@ -2,7 +2,7 @@
 #include "EntityManager.h"
 
 void ZoneSGServer::OnStartup(Entity* self) {
-	const auto cannons = EntityManager::Instance()->GetEntitiesByLOT(1864);
+	const auto cannons = Game::entityManager->GetEntitiesByLOT(1864);
 	for (const auto& cannon : cannons)
 		self->SetVar<LWOOBJID>(CannonIDVariable, cannon->GetObjectID());
 }
@@ -10,7 +10,7 @@ void ZoneSGServer::OnStartup(Entity* self) {
 void ZoneSGServer::OnActivityStateChangeRequest(Entity* self, const LWOOBJID senderID, const int32_t value1,
 	const int32_t value2, const std::u16string& stringValue) {
 
-	auto* cannon = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(CannonIDVariable));
+	auto* cannon = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(CannonIDVariable));
 	if (cannon != nullptr) {
 		cannon->OnActivityStateChangeRequest(senderID, value1, value2, stringValue);
 	}
@@ -19,7 +19,7 @@ void ZoneSGServer::OnActivityStateChangeRequest(Entity* self, const LWOOBJID sen
 void ZoneSGServer::OnFireEventServerSide(Entity* self, Entity* sender, std::string args, int32_t param1, int32_t param2,
 	int32_t param3) {
 
-	auto* cannon = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(CannonIDVariable));
+	auto* cannon = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(CannonIDVariable));
 	if (cannon != nullptr) {
 		cannon->OnFireEventServerSide(sender, args, param1, param2, param3);
 	}

--- a/dScripts/ai/NS/NS_PP_01/PropertyDeathPlane.cpp
+++ b/dScripts/ai/NS/NS_PP_01/PropertyDeathPlane.cpp
@@ -4,7 +4,7 @@
 #include "EntityManager.h"
 
 void PropertyDeathPlane::OnCollisionPhantom(Entity* self, Entity* target) {
-	const auto teleportGroup = EntityManager::Instance()->GetEntitiesInGroup("Teleport");
+	const auto teleportGroup = Game::entityManager->GetEntitiesInGroup("Teleport");
 
 	if (teleportGroup.size() == 0) {
 		return;

--- a/dScripts/ai/NS/NsConcertInstrument.cpp
+++ b/dScripts/ai/NS/NsConcertInstrument.cpp
@@ -49,7 +49,7 @@ void NsConcertInstrument::OnFireEventServerSide(Entity* self, Entity* sender, st
 		if (activePlayerID == LWOOBJID_EMPTY)
 			return;
 
-		const auto activePlayer = EntityManager::Instance()->GetEntity(activePlayerID);
+		const auto activePlayer = Game::entityManager->GetEntity(activePlayerID);
 		if (activePlayer == nullptr)
 			return;
 
@@ -63,7 +63,7 @@ void NsConcertInstrument::OnTimerDone(Entity* self, std::string name) {
 		return;
 
 	// If for some reason the player becomes null (for example an unexpected leave), we need to clean up
-	const auto activePlayer = EntityManager::Instance()->GetEntity(activePlayerID);
+	const auto activePlayer = Game::entityManager->GetEntity(activePlayerID);
 	if (activePlayer == nullptr && name != "cleanupAfterStop") {
 		StopPlayingInstrument(self, nullptr);
 		return;
@@ -126,7 +126,7 @@ void NsConcertInstrument::StartPlayingInstrument(Entity* self, Entity* player) {
 		RenderComponent::PlayAnimation(player, animations.at(instrumentLot), 2.0f);
 		});
 
-	for (auto* soundBox : EntityManager::Instance()->GetEntitiesInGroup("Audio-Concert")) {
+	for (auto* soundBox : Game::entityManager->GetEntitiesInGroup("Audio-Concert")) {
 		auto* soundTrigger = soundBox->GetComponent<SoundTriggerComponent>();
 		if (soundTrigger != nullptr) {
 			soundTrigger->ActivateMusicCue(music.at(instrumentLot));
@@ -161,7 +161,7 @@ void NsConcertInstrument::StopPlayingInstrument(Entity* self, Entity* player) {
 
 	self->SetVar<bool>(u"beingPlayed", false);
 
-	for (auto* soundBox : EntityManager::Instance()->GetEntitiesInGroup("Audio-Concert")) {
+	for (auto* soundBox : Game::entityManager->GetEntitiesInGroup("Audio-Concert")) {
 		auto* soundTrigger = soundBox->GetComponent<SoundTriggerComponent>();
 		if (soundTrigger != nullptr) {
 			soundTrigger->DeactivateMusicCue(music.at(instrumentLot));

--- a/dScripts/ai/NS/NsConcertQuickBuild.cpp
+++ b/dScripts/ai/NS/NsConcertQuickBuild.cpp
@@ -42,7 +42,7 @@ void NsConcertQuickBuild::OnStartup(Entity* self) {
 
 	// Get the manager of the crate of this quick build
 	const auto groupNumber = std::stoi(splitGroup.at(3));
-	const auto managerObjects = EntityManager::Instance()->GetEntitiesInGroup("CB_" + std::to_string(groupNumber));
+	const auto managerObjects = Game::entityManager->GetEntitiesInGroup("CB_" + std::to_string(groupNumber));
 	if (managerObjects.empty())
 		return;
 
@@ -67,7 +67,7 @@ float NsConcertQuickBuild::GetBlinkTime(float time) {
 }
 
 void NsConcertQuickBuild::OnDie(Entity* self, Entity* killer) {
-	auto* managerObject = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"managerObject"));
+	auto* managerObject = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"managerObject"));
 	if (managerObject) {
 		managerObject->CancelAllTimers();
 		managerObject->AddCallbackTimer(1.0f, [managerObject]() {
@@ -90,7 +90,7 @@ void NsConcertQuickBuild::OnRebuildComplete(Entity* self, Entity* target) {
 	// Find all the quick build objects of the same lot
 	auto finishedQuickBuildObjects = std::vector<Entity*>();
 	for (auto quickBuildID : finishedQuickBuilds) {
-		const auto quickBuildObject = EntityManager::Instance()->GetEntity(quickBuildID);
+		const auto quickBuildObject = Game::entityManager->GetEntity(quickBuildID);
 		if (quickBuildObject && quickBuildObject->GetLOT() == self->GetLOT()) {
 			quickBuildObject->SetVar<LWOOBJID>(u"Player_" + (GeneralUtils::to_u16string(groupNumber)), target->GetObjectID());
 			finishedQuickBuildObjects.push_back(quickBuildObject);
@@ -101,7 +101,7 @@ void NsConcertQuickBuild::OnRebuildComplete(Entity* self, Entity* target) {
 	if (finishedQuickBuildObjects.size() >= 4) {
 
 		// Move all the platforms so the user can collect the imagination brick
-		const auto movingPlatforms = EntityManager::Instance()->GetEntitiesInGroup("ConcertPlatforms");
+		const auto movingPlatforms = Game::entityManager->GetEntitiesInGroup("ConcertPlatforms");
 		for (auto* movingPlatform : movingPlatforms) {
 			auto* component = movingPlatform->GetComponent<MovingPlatformComponent>();
 			if (component) {
@@ -184,7 +184,7 @@ void NsConcertQuickBuild::ProgressLicensedTechnician(Entity* self) {
 	for (auto i = 1; i < 5; i++) {
 		const auto playerID = self->GetVar<LWOOBJID>(u"Player_" + (GeneralUtils::to_u16string(i)));
 		if (playerID != LWOOBJID_EMPTY) {
-			const auto player = EntityManager::Instance()->GetEntity(playerID);
+			const auto player = Game::entityManager->GetEntity(playerID);
 			if (player) {
 				auto playerMissionComponent = player->GetComponent<MissionComponent>();
 				if (playerMissionComponent)
@@ -202,7 +202,7 @@ void NsConcertQuickBuild::UpdateEffects(Entity* self) {
 		return;
 
 	for (const auto& effectName : setIterator->second.effects) {
-		const auto effectObjects = EntityManager::Instance()->GetEntitiesInGroup(quickBuildFX.at(effectName));
+		const auto effectObjects = Game::entityManager->GetEntitiesInGroup(quickBuildFX.at(effectName));
 		for (auto* effectObject : effectObjects) {
 			GameMessages::SendPlayFXEffect(effectObject, 0, GeneralUtils::ASCIIToUTF16(effectName),
 				effectName + "Effect", LWOOBJID_EMPTY, 1, 1, true);
@@ -216,7 +216,7 @@ void NsConcertQuickBuild::CancelEffects(Entity* self) {
 		return;
 
 	for (const auto& effectName : setIterator->second.effects) {
-		const auto effectObjects = EntityManager::Instance()->GetEntitiesInGroup(quickBuildFX.at(effectName));
+		const auto effectObjects = Game::entityManager->GetEntitiesInGroup(quickBuildFX.at(effectName));
 		for (auto* effectObject : effectObjects) {
 			GameMessages::SendStopFXEffect(effectObject, true, effectName + "Effect");
 		}

--- a/dScripts/ai/NS/NsQbImaginationStatue.cpp
+++ b/dScripts/ai/NS/NsQbImaginationStatue.cpp
@@ -31,7 +31,7 @@ void NsQbImaginationStatue::OnTimerDone(Entity* self, std::string timerName) {
 void NsQbImaginationStatue::SpawnLoot(Entity* self) {
 	const auto playerId = self->GetVar<LWOOBJID>(u"Player");
 
-	auto* player = EntityManager::Instance()->GetEntity(playerId);
+	auto* player = Game::entityManager->GetEntity(playerId);
 
 	if (player == nullptr) return;
 

--- a/dScripts/ai/NS/WH/RockHydrantBroken.cpp
+++ b/dScripts/ai/NS/WH/RockHydrantBroken.cpp
@@ -7,7 +7,7 @@ void RockHydrantBroken::OnStartup(Entity* self) {
 
 	const auto hydrant = "hydrant" + self->GetVar<std::string>(u"hydrant");
 
-	const auto bouncers = EntityManager::Instance()->GetEntitiesInGroup(hydrant);
+	const auto bouncers = Game::entityManager->GetEntitiesInGroup(hydrant);
 
 	for (auto* bouncer : bouncers) {
 		self->SetVar<LWOOBJID>(u"bouncer", bouncer->GetObjectID());
@@ -23,7 +23,7 @@ void RockHydrantBroken::OnStartup(Entity* self) {
 
 void RockHydrantBroken::OnTimerDone(Entity* self, std::string timerName) {
 	if (timerName == "KillBroken") {
-		auto* bouncer = EntityManager::Instance()->GetEntity(self->GetVar<LWOOBJID>(u"bouncer"));
+		auto* bouncer = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"bouncer"));
 
 		if (bouncer != nullptr) {
 			GameMessages::SendBouncerActiveStatus(bouncer->GetObjectID(), false, UNASSIGNED_SYSTEM_ADDRESS);

--- a/dScripts/ai/NS/WH/RockHydrantSmashable.cpp
+++ b/dScripts/ai/NS/WH/RockHydrantSmashable.cpp
@@ -15,7 +15,7 @@ void RockHydrantSmashable::OnDie(Entity* self, Entity* killer) {
 	info.settings = { data };
 	info.spawnerID = self->GetSpawnerID();
 
-	auto* hydrant = EntityManager::Instance()->CreateEntity(info);
+	auto* hydrant = Game::entityManager->CreateEntity(info);
 
-	EntityManager::Instance()->ConstructEntity(hydrant);
+	Game::entityManager->ConstructEntity(hydrant);
 }

--- a/dScripts/ai/NS/WhFans.cpp
+++ b/dScripts/ai/NS/WhFans.cpp
@@ -23,7 +23,7 @@ void WhFans::ToggleFX(Entity* self, bool hit) {
 		fanGroup = "";
 	}
 
-	std::vector<Entity*> fanVolumes = EntityManager::Instance()->GetEntitiesInGroup(fanGroup);
+	std::vector<Entity*> fanVolumes = Game::entityManager->GetEntitiesInGroup(fanGroup);
 
 	auto* renderComponent = self->GetComponent<RenderComponent>();
 
@@ -41,7 +41,7 @@ void WhFans::ToggleFX(Entity* self, bool hit) {
 			auto volumePhys = volume->GetComponent<PhantomPhysicsComponent>();
 			if (!volumePhys) continue;
 			volumePhys->SetPhysicsEffectActive(false);
-			EntityManager::Instance()->SerializeEntity(volume);
+			Game::entityManager->SerializeEntity(volume);
 		}
 	} else if (!self->GetVar<bool>(u"on") && self->GetVar<bool>(u"alive")) {
 		RenderComponent::PlayAnimation(self, u"fan-on");
@@ -52,7 +52,7 @@ void WhFans::ToggleFX(Entity* self, bool hit) {
 			auto volumePhys = volume->GetComponent<PhantomPhysicsComponent>();
 			if (!volumePhys) continue;
 			volumePhys->SetPhysicsEffectActive(true);
-			EntityManager::Instance()->SerializeEntity(volume);
+			Game::entityManager->SerializeEntity(volume);
 		}
 	}
 }

--- a/dScripts/ai/PETS/HydrantSmashable.cpp
+++ b/dScripts/ai/PETS/HydrantSmashable.cpp
@@ -15,7 +15,7 @@ void HydrantSmashable::OnDie(Entity* self, Entity* killer) {
 	info.settings = { data };
 	info.spawnerID = self->GetSpawnerID();
 
-	auto* hydrant = EntityManager::Instance()->CreateEntity(info);
+	auto* hydrant = Game::entityManager->CreateEntity(info);
 
-	EntityManager::Instance()->ConstructEntity(hydrant);
+	Game::entityManager->ConstructEntity(hydrant);
 }

--- a/dScripts/ai/PROPERTY/AG/AgPropGuard.cpp
+++ b/dScripts/ai/PROPERTY/AG/AgPropGuard.cpp
@@ -31,10 +31,10 @@ void AgPropGuard::OnMissionDialogueOK(Entity* self, Entity* target, int missionI
 		(missionID == 320 && state == eMissionState::AVAILABLE) /*||
 		(state == eMissionState::COMPLETE && missionID == 891 && missionState == eMissionState::READY_TO_COMPLETE)*/
 		) {
-		//GameMessages::SendNotifyClientObject(EntityManager::Instance()->GetZoneControlEntity()->GetObjectID(), u"GuardChat", target->GetObjectID(), 0, target->GetObjectID(), "", target->GetSystemAddress());
+		//GameMessages::SendNotifyClientObject(Game::entityManager->GetZoneControlEntity()->GetObjectID(), u"GuardChat", target->GetObjectID(), 0, target->GetObjectID(), "", target->GetSystemAddress());
 
 		target->GetCharacter()->SetPlayerFlag(113, true);
 
-		EntityManager::Instance()->GetZoneControlEntity()->AddTimer("GuardFlyAway", 1.0f);
+		Game::entityManager->GetZoneControlEntity()->AddTimer("GuardFlyAway", 1.0f);
 	}
 }

--- a/dScripts/ai/PROPERTY/AgPropguards.cpp
+++ b/dScripts/ai/PROPERTY/AgPropguards.cpp
@@ -20,7 +20,7 @@ void AgPropguards::OnMissionDialogueOK(Entity* self, Entity* target, int mission
 		GameMessages::SendPlayCinematic(target->GetObjectID(), u"MissionCam", target->GetSystemAddress());
 	} else if (missionState == eMissionState::COMPLETE_READY_TO_COMPLETE) {
 		// Makes the guard disappear once the mission has been completed
-		const auto zoneControlID = EntityManager::Instance()->GetZoneControlEntity()->GetObjectID();
+		const auto zoneControlID = Game::entityManager->GetZoneControlEntity()->GetObjectID();
 		GameMessages::SendNotifyClientObject(zoneControlID, u"GuardChat", 0, 0, self->GetObjectID(),
 			"", UNASSIGNED_SYSTEM_ADDRESS);
 

--- a/dScripts/ai/RACING/OBJECTS/FvRaceSmashEggImagineServer.cpp
+++ b/dScripts/ai/RACING/OBJECTS/FvRaceSmashEggImagineServer.cpp
@@ -12,14 +12,14 @@ void FvRaceSmashEggImagineServer::OnDie(Entity* self, Entity* killer) {
 		auto* destroyableComponent = killer->GetComponent<DestroyableComponent>();
 		if (destroyableComponent != nullptr) {
 			destroyableComponent->SetImagination(destroyableComponent->GetImagination() + 10);
-			EntityManager::Instance()->SerializeEntity(killer);
+			Game::entityManager->SerializeEntity(killer);
 		}
 
 		// get possessor to progress statistics and tasks.
 		auto* possessableComponent = killer->GetComponent<PossessableComponent>();
 		if (possessableComponent != nullptr) {
 
-			auto* possessor = EntityManager::Instance()->GetEntity(possessableComponent->GetPossessor());
+			auto* possessor = Game::entityManager->GetEntity(possessableComponent->GetPossessor());
 			if (possessor != nullptr) {
 
 				auto* missionComponent = possessor->GetComponent<MissionComponent>();

--- a/dScripts/ai/RACING/OBJECTS/RaceImagineCrateServer.cpp
+++ b/dScripts/ai/RACING/OBJECTS/RaceImagineCrateServer.cpp
@@ -30,14 +30,14 @@ void RaceImagineCrateServer::OnDie(Entity* self, Entity* killer) {
 	if (destroyableComponent != nullptr) {
 		destroyableComponent->SetImagination(60);
 
-		EntityManager::Instance()->SerializeEntity(killer);
+		Game::entityManager->SerializeEntity(killer);
 	}
 
 	// Find possessor of race car to progress missions and update stats.
 	auto* possessableComponent = killer->GetComponent<PossessableComponent>();
 	if (possessableComponent != nullptr) {
 
-		auto* possessor = EntityManager::Instance()->GetEntity(possessableComponent->GetPossessor());
+		auto* possessor = Game::entityManager->GetEntity(possessableComponent->GetPossessor());
 		if (possessor != nullptr) {
 
 			auto* missionComponent = possessor->GetComponent<MissionComponent>();

--- a/dScripts/ai/RACING/OBJECTS/RaceImaginePowerup.cpp
+++ b/dScripts/ai/RACING/OBJECTS/RaceImaginePowerup.cpp
@@ -15,7 +15,7 @@ void RaceImaginePowerup::OnFireEventServerSide(Entity* self, Entity* sender, std
 			return;
 		}
 
-		auto* vehicle = EntityManager::Instance()->GetEntity(possessorComponent->GetPossessable());
+		auto* vehicle = Game::entityManager->GetEntity(possessorComponent->GetPossessable());
 
 		if (vehicle == nullptr) {
 			return;

--- a/dScripts/ai/RACING/OBJECTS/RaceSmashServer.cpp
+++ b/dScripts/ai/RACING/OBJECTS/RaceSmashServer.cpp
@@ -11,7 +11,7 @@ void RaceSmashServer::OnDie(Entity* self, Entity* killer) {
 	auto* possessableComponent = killer->GetComponent<PossessableComponent>();
 	if (possessableComponent != nullptr) {
 
-		auto* possessor = EntityManager::Instance()->GetEntity(possessableComponent->GetPossessor());
+		auto* possessor = Game::entityManager->GetEntity(possessableComponent->GetPossessor());
 		if (possessor != nullptr) {
 
 			auto* missionComponent = possessor->GetComponent<MissionComponent>();

--- a/dScripts/ai/WILD/WildNinjaSensei.cpp
+++ b/dScripts/ai/WILD/WildNinjaSensei.cpp
@@ -8,27 +8,27 @@ void WildNinjaSensei::OnStartup(Entity* self) {
 
 void WildNinjaSensei::OnTimerDone(Entity* self, std::string timerName) {
 	if (timerName == "CraneStart") {
-		auto ninjas = EntityManager::Instance()->GetEntitiesInGroup("Ninjastuff");
+		auto ninjas = Game::entityManager->GetEntitiesInGroup("Ninjastuff");
 		for (auto ninja : ninjas) ninja->NotifyObject(self, "Crane");
 		self->AddTimer("Bow", 15.5f);
 		self->AddTimer("TigerStart", 25);
 		GameMessages::SendPlayAnimation(self, u"crane");
 	} else if (timerName == "TigerStart") {
-		auto ninjas = EntityManager::Instance()->GetEntitiesInGroup("Ninjastuff");
+		auto ninjas = Game::entityManager->GetEntitiesInGroup("Ninjastuff");
 		GameMessages::SendPlayAnimation(self, u"bow");
 		for (auto ninja : ninjas) ninja->NotifyObject(self, "Tiger");
 		self->AddTimer("Bow", 15.5f);
 		self->AddTimer("MantisStart", 25);
 		GameMessages::SendPlayAnimation(self, u"tiger");
 	} else if (timerName == "MantisStart") {
-		auto ninjas = EntityManager::Instance()->GetEntitiesInGroup("Ninjastuff");
+		auto ninjas = Game::entityManager->GetEntitiesInGroup("Ninjastuff");
 		GameMessages::SendPlayAnimation(self, u"tiger");
 		for (auto ninja : ninjas) ninja->NotifyObject(self, "Mantis");
 		self->AddTimer("Bow", 15.5f);
 		self->AddTimer("CraneStart", 25);
 		GameMessages::SendPlayAnimation(self, u"mantis");
 	} else if (timerName == "Bow") {
-		auto ninjas = EntityManager::Instance()->GetEntitiesInGroup("Ninjastuff");
+		auto ninjas = Game::entityManager->GetEntitiesInGroup("Ninjastuff");
 		for (auto ninja : ninjas) ninja->NotifyObject(self, "Bow");
 		GameMessages::SendPlayAnimation(self, u"bow");
 	}

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -253,6 +253,7 @@ int main(int argc, char** argv) {
 
 	PerformanceManager::SelectProfile(zoneID);
 
+	Game::entityManager = new EntityManager();
 	//Load our level:
 	if (zoneID != 0) {
 		dpWorld::Instance().Initialize(zoneID);
@@ -299,10 +300,9 @@ int main(int argc, char** argv) {
 
 			Game::logger->Log("WorldServer", "FDB Checksum calculated as: %s", databaseChecksum.c_str());
 		}
+	} else {
+		Game::entityManager->Initialize();
 	}
-
-	Game::entityManager = new EntityManager();
-	Game::entityManager->Initialize();
 
 	uint32_t currentFrameDelta = highFrameDelta;
 	// These values are adjust them selves to the current framerate should it update.

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -71,6 +71,7 @@
 #include "eMasterMessageType.h"
 #include "eGameMessageType.h"
 #include "ZCompression.h"
+#include "EntityManager.h"
 
 namespace Game {
 	dLogger* logger = nullptr;
@@ -83,6 +84,7 @@ namespace Game {
 	std::mt19937 randomEngine;
 	SystemAddress chatSysAddr;
 	bool shouldShutdown = false;
+	EntityManager* entityManager = nullptr;
 } // namespace Game
 
 bool chatDisabled = false;
@@ -225,6 +227,8 @@ int main(int argc, char** argv) {
 
 	//Set up other things:
 	Game::randomEngine = std::mt19937(time(0));
+	Game::entityManager = new EntityManager();
+	Game::entityManager->Initialize();
 
 	//Run it until server gets a kill message from Master:
 	auto lastTime = std::chrono::high_resolution_clock::now();
@@ -383,12 +387,12 @@ int main(int argc, char** argv) {
 			Metrics::EndMeasurement(MetricVariable::Physics);
 
 			Metrics::StartMeasurement(MetricVariable::UpdateEntities);
-			EntityManager::Instance()->UpdateEntities(deltaTime);
+			Game::entityManager->UpdateEntities(deltaTime);
 			Metrics::EndMeasurement(MetricVariable::UpdateEntities);
 
 			Metrics::StartMeasurement(MetricVariable::Ghosting);
 			if (std::chrono::duration<float>(currentTime - ghostingLastTime).count() >= 1.0f) {
-				EntityManager::Instance()->UpdateGhosting();
+				Game::entityManager->UpdateGhosting();
 				ghostingLastTime = currentTime;
 			}
 			Metrics::EndMeasurement(MetricVariable::Ghosting);
@@ -558,7 +562,7 @@ void HandlePacketChat(Packet* packet) {
 				LWOOBJID playerID;
 				inStream.Read(playerID);
 
-				auto player = EntityManager::Instance()->GetEntity(playerID);
+				auto player = Game::entityManager->GetEntity(playerID);
 				if (!player) return;
 
 				auto sysAddr = player->GetSystemAddress();
@@ -614,7 +618,7 @@ void HandlePacketChat(Packet* packet) {
 				inStream.Read(playerId);
 				inStream.Read(expire);
 
-				auto* entity = EntityManager::Instance()->GetEntity(playerId);
+				auto* entity = Game::entityManager->GetEntity(playerId);
 
 				if (entity != nullptr) {
 					entity->GetParentUser()->SetMuteExpire(expire);
@@ -678,7 +682,7 @@ void HandlePacket(Packet* packet) {
 			return;
 		}
 
-		auto* entity = EntityManager::Instance()->GetEntity(c->GetObjectID());
+		auto* entity = Game::entityManager->GetEntity(c->GetObjectID());
 
 		if (!entity) {
 			entity = Player::GetPlayer(packet->systemAddress);
@@ -695,7 +699,7 @@ void HandlePacket(Packet* packet) {
 
 			Game::logger->Log("WorldServer", "Deleting player %llu", entity->GetObjectID());
 
-			EntityManager::Instance()->DestroyEntity(entity);
+			Game::entityManager->DestroyEntity(entity);
 		}
 
 		{
@@ -917,7 +921,7 @@ void HandlePacket(Packet* packet) {
 		if (Game::server->GetZoneID() != 0) {
 			auto user = UserManager::Instance()->GetUser(packet->systemAddress);
 			if (!user) return;
-			EntityManager::Instance()->DestroyEntity(user->GetLastUsedChar()->GetEntity());
+			Game::entityManager->DestroyEntity(user->GetLastUsedChar()->GetEntity());
 		}
 
 		//This loops prevents users who aren't authenticated to double-request the char list, which
@@ -1005,20 +1009,20 @@ void HandlePacket(Packet* packet) {
 
 				EntityInfo info{};
 				info.lot = 1;
-				Entity* player = EntityManager::Instance()->CreateEntity(info, UserManager::Instance()->GetUser(packet->systemAddress));
+				Entity* player = Game::entityManager->CreateEntity(info, UserManager::Instance()->GetUser(packet->systemAddress));
 
 				WorldPackets::SendCreateCharacter(packet->systemAddress, player, c->GetXMLData(), username, c->GetGMLevel());
 				WorldPackets::SendServerState(packet->systemAddress);
 
 				const auto respawnPoint = player->GetCharacter()->GetRespawnPoint(dZoneManager::Instance()->GetZone()->GetWorldID());
 
-				EntityManager::Instance()->ConstructEntity(player, UNASSIGNED_SYSTEM_ADDRESS, true);
+				Game::entityManager->ConstructEntity(player, UNASSIGNED_SYSTEM_ADDRESS, true);
 
 				if (respawnPoint != NiPoint3::ZERO) {
 					GameMessages::SendPlayerReachedRespawnCheckpoint(player, respawnPoint, NiQuaternion::IDENTITY);
 				}
 
-				EntityManager::Instance()->ConstructAllEntities(packet->systemAddress);
+				Game::entityManager->ConstructAllEntities(packet->systemAddress);
 
 				auto* characterComponent = player->GetComponent<CharacterComponent>();
 				if (characterComponent) {
@@ -1330,6 +1334,7 @@ void FinalizeShutdown() {
 	if (Game::server) delete Game::server;
 	if (Game::logger) delete Game::logger;
 	if (Game::config) delete Game::config;
+	if (Game::entityManager) delete Game::entityManager;
 
 	worldShutdownSequenceComplete = true;
 

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -252,7 +252,6 @@ int main(int argc, char** argv) {
 	auto ghostingLastTime = std::chrono::high_resolution_clock::now();
 
 	PerformanceManager::SelectProfile(zoneID);
-	Game::entityManager = new EntityManager();
 
 	//Load our level:
 	if (zoneID != 0) {
@@ -300,9 +299,10 @@ int main(int argc, char** argv) {
 
 			Game::logger->Log("WorldServer", "FDB Checksum calculated as: %s", databaseChecksum.c_str());
 		}
-	} else {
-		Game::entityManager->Initialize();
 	}
+
+	Game::entityManager = new EntityManager();
+	Game::entityManager->Initialize();
 
 	uint32_t currentFrameDelta = highFrameDelta;
 	// These values are adjust them selves to the current framerate should it update.

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -252,6 +252,7 @@ int main(int argc, char** argv) {
 	auto ghostingLastTime = std::chrono::high_resolution_clock::now();
 
 	PerformanceManager::SelectProfile(zoneID);
+	Game::entityManager = new EntityManager();
 
 	//Load our level:
 	if (zoneID != 0) {
@@ -299,10 +300,9 @@ int main(int argc, char** argv) {
 
 			Game::logger->Log("WorldServer", "FDB Checksum calculated as: %s", databaseChecksum.c_str());
 		}
+	} else {
+		Game::entityManager->Initialize();
 	}
-
-	Game::entityManager = new EntityManager();
-	Game::entityManager->Initialize();
 
 	uint32_t currentFrameDelta = highFrameDelta;
 	// These values are adjust them selves to the current framerate should it update.

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -227,8 +227,6 @@ int main(int argc, char** argv) {
 
 	//Set up other things:
 	Game::randomEngine = std::mt19937(time(0));
-	Game::entityManager = new EntityManager();
-	Game::entityManager->Initialize();
 
 	//Run it until server gets a kill message from Master:
 	auto lastTime = std::chrono::high_resolution_clock::now();
@@ -302,6 +300,9 @@ int main(int argc, char** argv) {
 			Game::logger->Log("WorldServer", "FDB Checksum calculated as: %s", databaseChecksum.c_str());
 		}
 	}
+
+	Game::entityManager = new EntityManager();
+	Game::entityManager->Initialize();
 
 	uint32_t currentFrameDelta = highFrameDelta;
 	// These values are adjust them selves to the current framerate should it update.

--- a/dZoneManager/Level.cpp
+++ b/dZoneManager/Level.cpp
@@ -332,7 +332,7 @@ void Level::ReadSceneObjectDataChunk(std::istream& file, Header& header) {
 				if (zoneControlObject != nullptr && info.lot == zoneControlObject->GetLOT())
 					goto deleteSettings;
 
-				EntityManager::Instance()->CreateEntity(info, nullptr);
+				Game::entityManager->CreateEntity(info, nullptr);
 			} else {
 			deleteSettings:
 

--- a/dZoneManager/Spawner.cpp
+++ b/dZoneManager/Spawner.cpp
@@ -46,7 +46,7 @@ Spawner::Spawner(const SpawnerInfo info) {
 	}
 
 	if (m_Info.spawnOnSmashGroupName != "") {
-		std::vector<Entity*> spawnSmashEntities = EntityManager::Instance()->GetEntitiesInGroup(m_Info.spawnOnSmashGroupName);
+		std::vector<Entity*> spawnSmashEntities = Game::entityManager->GetEntitiesInGroup(m_Info.spawnOnSmashGroupName);
 		std::vector<Spawner*> spawnSmashSpawners = dZoneManager::Instance()->GetSpawnersInGroup(m_Info.spawnOnSmashGroupName);
 		std::vector<Spawner*> spawnSmashSpawnersN = dZoneManager::Instance()->GetSpawnersByName(m_Info.spawnOnSmashGroupName);
 		for (Entity* ssEntity : spawnSmashEntities) {
@@ -102,11 +102,11 @@ Entity* Spawner::Spawn(std::vector<SpawnerNode*> freeNodes, const bool force) {
 			m_EntityInfo.spawnerID = m_Info.spawnerID;
 		}
 
-		Entity* rezdE = EntityManager::Instance()->CreateEntity(m_EntityInfo, nullptr);
+		Entity* rezdE = Game::entityManager->CreateEntity(m_EntityInfo, nullptr);
 
 		rezdE->GetGroups() = m_Info.groups;
 
-		EntityManager::Instance()->ConstructEntity(rezdE);
+		Game::entityManager->ConstructEntity(rezdE);
 
 		m_Entities.insert({ rezdE->GetObjectID(), spawnNode });
 		spawnNode->entities.push_back(rezdE->GetObjectID());
@@ -143,7 +143,7 @@ void Spawner::Reset() {
 void Spawner::DestroyAllEntities(){
 	for (auto* node : m_Info.nodes) {
 		for (const auto& element : node->entities) {
-			auto* entity = EntityManager::Instance()->GetEntity(element);
+			auto* entity = Game::entityManager->GetEntity(element);
 			if (entity == nullptr) continue;
 			entity->Kill();
 		}

--- a/dZoneManager/dZoneManager.cpp
+++ b/dZoneManager/dZoneManager.cpp
@@ -22,19 +22,21 @@ dZoneManager* dZoneManager::m_Address = nullptr;
 void dZoneManager::Initialize(const LWOZONEID& zoneID) {
 	Game::logger->Log("dZoneManager", "Preparing zone: %i/%i/%i", zoneID.GetMapID(), zoneID.GetInstanceID(), zoneID.GetCloneID());
 
-	int64_t startTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+	int64_t startTime = 0;
+	int64_t endTime = 0;
+
+	startTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
 
 	LoadZone(zoneID);
 
-	EntityInfo info;
-	info.id = 0x3FFFFFFFFFFE;
-	info.lot = LOT_ZONE_CONTROL;
+	LOT zoneControlTemplate = 2365;
 
 	CDZoneTableTable* zoneTable = CDClientManager::Instance().GetTable<CDZoneTableTable>();
-	if (zoneTable) {
+	if (zoneTable != nullptr) {
 		const CDZoneTable* zone = zoneTable->Query(zoneID.GetMapID());
-		if (zone) {
-			info.lot = zone->zoneControlTemplate != -1 ? zone->zoneControlTemplate : LOT_ZONE_CONTROL;
+
+		if (zone != nullptr) {
+			zoneControlTemplate = zone->zoneControlTemplate != -1 ? zone->zoneControlTemplate : 2365;
 			const auto min = zone->ghostdistance_min != -1.0f ? zone->ghostdistance_min : 100;
 			const auto max = zone->ghostdistance != -1.0f ? zone->ghostdistance : 100;
 			Game::entityManager->SetGhostDistanceMax(max + min);
@@ -43,7 +45,7 @@ void dZoneManager::Initialize(const LWOZONEID& zoneID) {
 		}
 	}
 
-	Game::logger->Log("dZoneManager", "Creating zone control object %i", info.lot);
+	Game::logger->Log("dZoneManager", "Creating zone control object %i", zoneControlTemplate);
 
 	// Create ZoneControl object
 	if (!Game::entityManager) {
@@ -51,11 +53,15 @@ void dZoneManager::Initialize(const LWOZONEID& zoneID) {
 		throw std::invalid_argument("No entity manager loaded. Cannot proceed.");
 	}
 	Game::entityManager->Initialize();
-	m_ZoneControlObject = Game::entityManager->CreateEntity(info, nullptr, nullptr, true);
+	EntityInfo info;
+	info.lot = zoneControlTemplate;
+	info.id = 70368744177662;
+	Entity* zoneControl = Game::entityManager->CreateEntity(info, nullptr, nullptr, true);
+	m_ZoneControlObject = zoneControl;
 
 	m_pZone->Initalize();
 
-	int64_t endTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
+	endTime = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
 
 	LoadWorldConfig();
 
@@ -67,10 +73,10 @@ void dZoneManager::Initialize(const LWOZONEID& zoneID) {
 dZoneManager::~dZoneManager() {
 	if (m_pZone) delete m_pZone;
 
-	for (auto&[spawnerId, spawner] : m_Spawners) {
-		if (spawner) {
-			delete spawner;
-			spawner = nullptr;
+	for (std::pair<LWOOBJID, Spawner*> p : m_Spawners) {
+		if (p.second) {
+			delete p.second;
+			p.second = nullptr;
 		}
 	}
 	if (m_WorldConfig) delete m_WorldConfig;

--- a/dZoneManager/dZoneManager.cpp
+++ b/dZoneManager/dZoneManager.cpp
@@ -78,6 +78,8 @@ dZoneManager::~dZoneManager() {
 			delete p.second;
 			p.second = nullptr;
 		}
+
+		m_Spawners.erase(p.first);
 	}
 	if (m_WorldConfig) delete m_WorldConfig;
 }

--- a/dZoneManager/dZoneManager.cpp
+++ b/dZoneManager/dZoneManager.cpp
@@ -39,8 +39,8 @@ void dZoneManager::Initialize(const LWOZONEID& zoneID) {
 			zoneControlTemplate = zone->zoneControlTemplate != -1 ? zone->zoneControlTemplate : 2365;
 			const auto min = zone->ghostdistance_min != -1.0f ? zone->ghostdistance_min : 100;
 			const auto max = zone->ghostdistance != -1.0f ? zone->ghostdistance : 100;
-			EntityManager::Instance()->SetGhostDistanceMax(max + min);
-			EntityManager::Instance()->SetGhostDistanceMin(max);
+			Game::entityManager->SetGhostDistanceMax(max + min);
+			Game::entityManager->SetGhostDistanceMin(max);
 			m_PlayerLoseCoinsOnDeath = zone->PlayerLoseCoinsOnDeath;
 		}
 	}
@@ -51,7 +51,7 @@ void dZoneManager::Initialize(const LWOZONEID& zoneID) {
 	EntityInfo info;
 	info.lot = zoneControlTemplate;
 	info.id = 70368744177662;
-	Entity* zoneControl = EntityManager::Instance()->CreateEntity(info, nullptr, nullptr, true);
+	Entity* zoneControl = Game::entityManager->CreateEntity(info, nullptr, nullptr, true);
 	m_ZoneControlObject = zoneControl;
 
 	m_pZone->Initalize();
@@ -148,9 +148,9 @@ LWOOBJID dZoneManager::MakeSpawner(SpawnerInfo info) {
 	entityInfo.id = objectId;
 	entityInfo.lot = 176;
 
-	auto* entity = EntityManager::Instance()->CreateEntity(entityInfo, nullptr, nullptr, false, objectId);
+	auto* entity = Game::entityManager->CreateEntity(entityInfo, nullptr, nullptr, false, objectId);
 
-	EntityManager::Instance()->ConstructEntity(entity);
+	Game::entityManager->ConstructEntity(entity);
 
 	AddSpawner(objectId, spawner);
 
@@ -175,7 +175,7 @@ void dZoneManager::RemoveSpawner(const LWOOBJID id) {
 		return;
 	}
 
-	auto* entity = EntityManager::Instance()->GetEntity(id);
+	auto* entity = Game::entityManager->GetEntity(id);
 
 	if (entity != nullptr) {
 		entity->Kill();

--- a/dZoneManager/dZoneManager.cpp
+++ b/dZoneManager/dZoneManager.cpp
@@ -46,7 +46,11 @@ void dZoneManager::Initialize(const LWOZONEID& zoneID) {
 	Game::logger->Log("dZoneManager", "Creating zone control object %i", info.lot);
 
 	// Create ZoneControl object
-	if (Game::entityManager) Game::entityManager->Initialize();
+	if (!Game::entityManager) {
+		Game::logger->Log("dZoneManager", "ERROR: No entity manager loaded. Cannot proceed.");
+		throw std::invalid_argument("No entity manager loaded. Cannot proceed.");
+	}
+	Game::entityManager->Initialize();
 	m_ZoneControlObject = Game::entityManager->CreateEntity(info, nullptr, nullptr, true);
 
 	m_pZone->Initalize();

--- a/tests/dGameTests/GameDependencies.cpp
+++ b/tests/dGameTests/GameDependencies.cpp
@@ -1,13 +1,14 @@
 #include "GameDependencies.h"
 
 namespace Game {
-	dLogger* logger;
-	dServer* server;
-	dZoneManager* zoneManager;
-	dChatFilter* chatFilter;
-	dConfig* config;
+	dLogger* logger = nullptr;
+	dServer* server = nullptr;
+	dZoneManager* zoneManager = nullptr;
+	dChatFilter* chatFilter = nullptr;
+	dConfig* config = nullptr;
 	std::mt19937 randomEngine;
-	RakPeerInterface* chatServer;
-	AssetManager* assetManager;
+	RakPeerInterface* chatServer = nullptr;
+	AssetManager* assetManager = nullptr;
 	SystemAddress chatSysAddr;
+	EntityManager* entityManager = nullptr;
 }

--- a/tests/dGameTests/GameDependencies.h
+++ b/tests/dGameTests/GameDependencies.h
@@ -32,11 +32,12 @@ protected:
 		Game::logger = new dLogger("./testing.log", true, true);
 		Game::server = new dServerMock();
 		Game::config = new dConfig("worldconfig.ini");
+		Game::entityManager = new EntityManager();
 	}
 
 	void TearDownDependencies() {
 		if (Game::server) delete Game::server;
-		delete EntityManager::Instance();
+		if (Game::entityManager) delete Game::entityManager;
 		if (Game::logger) {
 			Game::logger->Flush();
 			delete Game::logger;
@@ -44,7 +45,7 @@ protected:
 		if (Game::config) delete Game::config;
 	}
 
-	EntityInfo info;
+	EntityInfo info{};
 };
 
 #endif //!__GAMEDEPENDENCIES__H__


### PR DESCRIPTION
Makes the code more testable.

There are the same number of `Game::entityManager` as there are `EntityManager::Instance()`

Server still runs.
