### PR TITLE
freemoney type fix

### DIFF
--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -1443,7 +1443,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 	}
 
 	if ((chatCommand == "freemoney" && entity->GetGMLevel() >= eGameMasterLevel::DEVELOPER) && args.size() == 1) {
-		int32_t money;
+		int64_t money;
 
 		if (!GeneralUtils::TryParse(args[0], money)) {
 			ChatPackets::SendSystemMessage(sysAddr, u"Invalid money.");


### PR DESCRIPTION
DESCRIPTION: Changed freemoney gmlevel 9 command to parse 64 bit integers as opposed to 32 bit.

MOTIVATION: Messing with admin commands and realizing it was originally 32 bit.

TYPES OF CHANGES: Changing variable type.

TESTING: Running freemoney gmlevel 9 command with values between 32 and 64 bits.