### PR TITLE
fix: Nexus Tower Combat Challenge can be started twice if two players start it at the same time

### DIFF
--- a/dScripts/02_server/Map/NT/NtCombatChallengeServer.cpp
+++ b/dScripts/02_server/Map/NT/NtCombatChallengeServer.cpp
@@ -43,7 +43,7 @@ void NtCombatChallengeServer::OnFireEventServerSide(Entity* self, Entity* sender
 
 
 void NtCombatChallengeServer::OnMessageBoxResponse(Entity* self, Entity* sender, int32_t button, const std::u16string& identifier, const std::u16string& userData) {
-	if (identifier == u"PlayButton" && button == 1 && !self->GetVar<bool>(u"bInUse")) {
+	if (identifier == u"PlayButton" && button == 1 && !self->GetNetworkVar<bool>(u"bInUse")) {
 		self->SetNetworkVar(u"bInUse", true);
 
 		self->SetVar(u"playerID", sender->GetObjectID());

--- a/dScripts/02_server/Map/NT/NtCombatChallengeServer.cpp
+++ b/dScripts/02_server/Map/NT/NtCombatChallengeServer.cpp
@@ -43,7 +43,7 @@ void NtCombatChallengeServer::OnFireEventServerSide(Entity* self, Entity* sender
 
 
 void NtCombatChallengeServer::OnMessageBoxResponse(Entity* self, Entity* sender, int32_t button, const std::u16string& identifier, const std::u16string& userData) {
-	if (identifier == u"PlayButton" && button == 1) {
+	if (identifier == u"PlayButton" && button == 1 && !self->GetVar<bool>(u"bInUse")) {
 		self->SetNetworkVar(u"bInUse", true);
 
 		self->SetVar(u"playerID", sender->GetObjectID());


### PR DESCRIPTION
DESC: Fix for dual instance starting when two players hit start on the challenge at the same time.

MOTIVATION: Want to fix issue for any future occurances

TESTING: Will test tomorrow/later

Fixes #1135 