### PR TITLE
Added Player Rewards for Solo Racing

### DIFF
--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -375,12 +375,10 @@ void RacingControlComponent::HandleMessageBoxResponse(Entity* player, int32_t bu
 
 		// Calculate the score, different loot depending on player count
 		auto playersRating = m_LoadedPlayers;
-		if(m_LoadedPlayers = 1){
-			if (m_SoloRacing) {
+		if(m_LoadedPlayers == 1 && m_SoloRacing) {
 			playersRating *= 2;
-			}
 		}
-		
+
         const auto score = playersRating * 10 + data->finished;
 		LootGenerator::Instance().GiveActivityLoot(player, m_Parent, m_ActivityID, score);
 

--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -375,9 +375,12 @@ void RacingControlComponent::HandleMessageBoxResponse(Entity* player, int32_t bu
 
 		// Calculate the score, different loot depending on player count
 		auto playersRating = m_LoadedPlayers;
-        if (m_SoloRacing) {
+		if(m_LoadedPlayers = 1){
+			if (m_SoloRacing) {
 			playersRating *= 2;
+			}
 		}
+		
         const auto score = playersRating * 10 + data->finished;
 		LootGenerator::Instance().GiveActivityLoot(player, m_Parent, m_ActivityID, score);
 

--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -374,7 +374,7 @@ void RacingControlComponent::HandleMessageBoxResponse(Entity* player, int32_t bu
 		data->collectedRewards = true;
 
 		// Calculate the score, different loot depending on player count
-		auto playersRating = m_LoadedPlayers * 10;
+		auto playersRating = m_LoadedPlayers;
         if (m_SoloRacing) {
 			playersRating *= 2;
 		}

--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -374,8 +374,11 @@ void RacingControlComponent::HandleMessageBoxResponse(Entity* player, int32_t bu
 		data->collectedRewards = true;
 
 		// Calculate the score, different loot depending on player count
-		const auto score = m_LoadedPlayers * 10 + data->finished;
-
+		auto playersRating = m_LoadedPlayers * 10;
+        if (m_SoloRacing) {
+			playersRating *= 2;
+		}
+        const auto score = playersRating * 10 + data->finished;
 		LootGenerator::Instance().GiveActivityLoot(player, m_Parent, m_ActivityID, score);
 
 		// Giving rewards


### PR DESCRIPTION
DESC: Added player rewards for solo racers. 

MOTIVATION: Solo racing currently does not give rewards to solo racers. This hinders the experience for those who do race alone, whether on a solo racing enabled server or local server.

Types of Changes:Modified how score is calculated in the case of solo racing in order to give solo racers rewards

Testing: Tested racing solo prior to this change, and did not receive coin or faction tokens. After making the change, faction tokens and coins were given as a reward for completing a solo race.

Thanks to EmosewaMC for contributing

Fixes #999 
