### PR TITLE
Pet Dig Distance Slightly Raised to Help Combat Skeleton Dragon Dig issue on Crux

### DIFF
--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -449,7 +449,7 @@ void PetComponent::Update(float deltaTime) {
 
 		NiPoint3 tresurePosition = closestTresure->GetPosition();
 		float distance = Vector3::DistanceSquared(position, tresurePosition);
-		if (distance < 3 * 3) {
+		if (distance < 5 * 5) {
 			m_Interaction = closestTresure->GetObjectID();
 
 			Command(NiPoint3::ZERO, LWOOBJID_EMPTY, 1, 202, true);


### PR DESCRIPTION
Description: Slightly increased the distance for pet digs which should help combat the issue with skeleton dragons being unable to dig up bones on Crux.

MOTIVATION: Currently there is an issue with bone digs on crux due to the navmesh. This is a small fix to help combat that issue

DESCRIPTION: Increases dig distance slightly

TESTING: Tested using the dragon to dig up bones over time

Thanks to flamethrower for reporting the issue