### PR TITLE
Loot memory savings

### DIFF
--- a/CMakeVariables.txt
+++ b/CMakeVariables.txt
@@ -22,3 +22,5 @@ __maria_db_connector_compile_jobs__=1
 __enable_testing__=1
 # The path to OpenSSL.  Change this if your OpenSSL install path is different than the default.
 OPENSSL_ROOT_DIR=/usr/local/opt/openssl@3/
+# Uncomment the below line to cache the entire CDClient into memory
+# CDCLIENT_CACHE_ALL=1

--- a/dDatabase/CDClientDatabase.h
+++ b/dDatabase/CDClientDatabase.h
@@ -13,15 +13,7 @@
 #include <sstream>
 #include <iostream>
 
- // Enable this to cache all entries in each table for fast access, comes with more memory cost
- //#define CDCLIENT_CACHE_ALL
-
-/*!
-  \file CDClientDatabase.hpp
-  \brief An interface between the CDClient.sqlite file and the server
- */
-
- //! The CDClient Database namespace
+//! The CDClient Database namespace
 namespace CDClientDatabase {
 
 	//! Opens a connection with the CDClient

--- a/dDatabase/CDClientManager.cpp
+++ b/dDatabase/CDClientManager.cpp
@@ -55,7 +55,7 @@ CDClientManager::CDClientManager() {
 	CDBehaviorParameterTable::Instance().LoadValuesFromDatabase();
 	CDBehaviorTemplateTable::Instance().LoadValuesFromDatabase();
 	CDBrickIDTableTable::Instance().LoadValuesFromDatabase();
-	CDComponentsRegistryTable::Instance().LoadValuesFromDatabase();
+	CDCLIENT_DONT_CACHE_TABLE(CDComponentsRegistryTable::Instance().LoadValuesFromDatabase());
 	CDCurrencyTableTable::Instance().LoadValuesFromDatabase();
 	CDDestructibleComponentTable::Instance().LoadValuesFromDatabase();
 	CDEmoteTableTable::Instance().LoadValuesFromDatabase();
@@ -65,8 +65,8 @@ CDClientManager::CDClientManager() {
 	CDItemSetSkillsTable::Instance().LoadValuesFromDatabase();
 	CDItemSetsTable::Instance().LoadValuesFromDatabase();
 	CDLevelProgressionLookupTable::Instance().LoadValuesFromDatabase();
-	CDLootMatrixTable::Instance().LoadValuesFromDatabase();
-	CDLootTableTable::Instance().LoadValuesFromDatabase();
+	CDCLIENT_DONT_CACHE_TABLE(CDLootMatrixTable::Instance().LoadValuesFromDatabase());
+	CDCLIENT_DONT_CACHE_TABLE(CDLootTableTable::Instance().LoadValuesFromDatabase());
 	CDMissionEmailTable::Instance().LoadValuesFromDatabase();
 	CDMissionNPCComponentTable::Instance().LoadValuesFromDatabase();
 	CDMissionTasksTable::Instance().LoadValuesFromDatabase();

--- a/dDatabase/CDClientManager.cpp
+++ b/dDatabase/CDClientManager.cpp
@@ -38,43 +38,53 @@
 #include "CDFeatureGatingTable.h"
 #include "CDRailActivatorComponent.h"
 
+// Uncomment this to cache the full cdclient database into memory. This will make the server load faster, but will use more memory.
+// A vanilla CDClient takes about 46MB of memory + the regular world data.
+// #define CDCLIENT_CACHE_ALL
+
+#ifdef CDCLIENT_CACHE_ALL
+	#define CDCLIENT_DONT_CACHE_TABLE(x) x
+#else
+	#define CDCLIENT_DONT_CACHE_TABLE(x)
+#endif
+
 CDClientManager::CDClientManager() {
-	CDActivityRewardsTable::Instance();
-	CDAnimationsTable::Instance();
-	CDBehaviorParameterTable::Instance();
-	CDBehaviorTemplateTable::Instance();
-	CDComponentsRegistryTable::Instance();
-	CDCurrencyTableTable::Instance();
-	CDDestructibleComponentTable::Instance();
-	CDEmoteTableTable::Instance();
-	CDInventoryComponentTable::Instance();
-	CDItemComponentTable::Instance();
-	CDItemSetsTable::Instance();
-	CDItemSetSkillsTable::Instance();
-	CDLevelProgressionLookupTable::Instance();
-	CDLootMatrixTable::Instance();
-	CDLootTableTable::Instance();
-	CDMissionNPCComponentTable::Instance();
-	CDMissionTasksTable::Instance();
-	CDMissionsTable::Instance();
-	CDObjectSkillsTable::Instance();
-	CDObjectsTable::Instance();
-	CDPhysicsComponentTable::Instance();
-	CDRebuildComponentTable::Instance();
-	CDScriptComponentTable::Instance();
-	CDSkillBehaviorTable::Instance();
-	CDZoneTableTable::Instance();
-	CDVendorComponentTable::Instance();
-	CDActivitiesTable::Instance();
-	CDPackageComponentTable::Instance();
-	CDProximityMonitorComponentTable::Instance();
-	CDMovementAIComponentTable::Instance();
-	CDBrickIDTableTable::Instance();
-	CDRarityTableTable::Instance();
-	CDMissionEmailTable::Instance();
-	CDRewardsTable::Instance();
-	CDPropertyEntranceComponentTable::Instance();
-	CDPropertyTemplateTable::Instance();
-	CDFeatureGatingTable::Instance();
-	CDRailActivatorComponentTable::Instance();
+	CDActivityRewardsTable::Instance().LoadValuesFromDatabase();
+	CDActivitiesTable::Instance().LoadValuesFromDatabase();
+	CDCLIENT_DONT_CACHE_TABLE(CDAnimationsTable::Instance().LoadValuesFromDatabase());
+	CDBehaviorParameterTable::Instance().LoadValuesFromDatabase();
+	CDBehaviorTemplateTable::Instance().LoadValuesFromDatabase();
+	CDBrickIDTableTable::Instance().LoadValuesFromDatabase();
+	CDComponentsRegistryTable::Instance().LoadValuesFromDatabase();
+	CDCurrencyTableTable::Instance().LoadValuesFromDatabase();
+	CDDestructibleComponentTable::Instance().LoadValuesFromDatabase();
+	CDEmoteTableTable::Instance().LoadValuesFromDatabase();
+	CDFeatureGatingTable::Instance().LoadValuesFromDatabase();
+	CDInventoryComponentTable::Instance().LoadValuesFromDatabase();
+	CDCLIENT_DONT_CACHE_TABLE(CDItemComponentTable::Instance().LoadValuesFromDatabase());
+	CDItemSetSkillsTable::Instance().LoadValuesFromDatabase();
+	CDItemSetsTable::Instance().LoadValuesFromDatabase();
+	CDLevelProgressionLookupTable::Instance().LoadValuesFromDatabase();
+	CDLootMatrixTable::Instance().LoadValuesFromDatabase();
+	CDLootTableTable::Instance().LoadValuesFromDatabase();
+	CDMissionEmailTable::Instance().LoadValuesFromDatabase();
+	CDMissionNPCComponentTable::Instance().LoadValuesFromDatabase();
+	CDMissionTasksTable::Instance().LoadValuesFromDatabase();
+	CDMissionsTable::Instance().LoadValuesFromDatabase();
+	CDMovementAIComponentTable::Instance().LoadValuesFromDatabase();
+	CDObjectSkillsTable::Instance().LoadValuesFromDatabase();
+	CDCLIENT_DONT_CACHE_TABLE(CDObjectsTable::Instance().LoadValuesFromDatabase());
+	CDPhysicsComponentTable::Instance().LoadValuesFromDatabase();
+	CDPackageComponentTable::Instance().LoadValuesFromDatabase();
+	CDProximityMonitorComponentTable::Instance().LoadValuesFromDatabase();
+	CDPropertyEntranceComponentTable::Instance().LoadValuesFromDatabase();
+	CDPropertyTemplateTable::Instance().LoadValuesFromDatabase();
+	CDRailActivatorComponentTable::Instance().LoadValuesFromDatabase();
+	CDRarityTableTable::Instance().LoadValuesFromDatabase();
+	CDRebuildComponentTable::Instance().LoadValuesFromDatabase();
+	CDRewardsTable::Instance().LoadValuesFromDatabase();
+	CDScriptComponentTable::Instance().LoadValuesFromDatabase();
+	CDSkillBehaviorTable::Instance().LoadValuesFromDatabase();
+	CDVendorComponentTable::Instance().LoadValuesFromDatabase();
+	CDZoneTableTable::Instance().LoadValuesFromDatabase();
 }

--- a/dDatabase/Tables/CDActivitiesTable.cpp
+++ b/dDatabase/Tables/CDActivitiesTable.cpp
@@ -1,7 +1,6 @@
 #include "CDActivitiesTable.h"
 
-CDActivitiesTable::CDActivitiesTable(void) {
-
+void CDActivitiesTable::LoadValuesFromDatabase() {
 	// First, get the size of the table
 	unsigned int size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM Activities");
@@ -55,8 +54,3 @@ std::vector<CDActivities> CDActivitiesTable::Query(std::function<bool(CDActiviti
 
 	return data;
 }
-
-std::vector<CDActivities> CDActivitiesTable::GetEntries(void) const {
-	return this->entries;
-}
-

--- a/dDatabase/Tables/CDActivitiesTable.h
+++ b/dDatabase/Tables/CDActivitiesTable.h
@@ -30,9 +30,10 @@ private:
 	std::vector<CDActivities> entries;
 
 public:
-	CDActivitiesTable();
+	void LoadValuesFromDatabase();
+
 	// Queries the table with a custom "where" clause
 	std::vector<CDActivities> Query(std::function<bool(CDActivities)> predicate);
 
-	std::vector<CDActivities> GetEntries(void) const;
+	const std::vector<CDActivities>& GetEntries() const { return this->entries; }
 };

--- a/dDatabase/Tables/CDActivityRewardsTable.cpp
+++ b/dDatabase/Tables/CDActivityRewardsTable.cpp
@@ -1,6 +1,6 @@
 #include "CDActivityRewardsTable.h"
 
-CDActivityRewardsTable::CDActivityRewardsTable(void) {
+void CDActivityRewardsTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -43,8 +43,3 @@ std::vector<CDActivityRewards> CDActivityRewardsTable::Query(std::function<bool(
 
 	return data;
 }
-
-std::vector<CDActivityRewards> CDActivityRewardsTable::GetEntries(void) const {
-	return this->entries;
-}
-

--- a/dDatabase/Tables/CDActivityRewardsTable.h
+++ b/dDatabase/Tables/CDActivityRewardsTable.h
@@ -18,10 +18,10 @@ private:
 	std::vector<CDActivityRewards> entries;
 
 public:
-	CDActivityRewardsTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDActivityRewards> Query(std::function<bool(CDActivityRewards)> predicate);
 
-	std::vector<CDActivityRewards> GetEntries(void) const;
+	std::vector<CDActivityRewards> GetEntries() const;
 
 };

--- a/dDatabase/Tables/CDAnimationsTable.cpp
+++ b/dDatabase/Tables/CDAnimationsTable.cpp
@@ -2,6 +2,35 @@
 #include "GeneralUtils.h"
 #include "Game.h"
 
+
+void CDAnimationsTable::LoadValuesFromDatabase() {
+	auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM Animations");
+	while (!tableData.eof()) {
+		std::string animation_type = tableData.getStringField("animation_type", "");
+		DluAssert(!animation_type.empty());
+		AnimationGroupID animationGroupID = tableData.getIntField("animationGroupID", -1);
+		DluAssert(animationGroupID != -1);
+
+		CDAnimation entry;
+		entry.animation_name = tableData.getStringField("animation_name", "");
+		entry.chance_to_play = tableData.getFloatField("chance_to_play", 1.0f);
+		UNUSED_COLUMN(entry.min_loops = tableData.getIntField("min_loops", 0);)
+		UNUSED_COLUMN(entry.max_loops = tableData.getIntField("max_loops", 0);)
+		entry.animation_length = tableData.getFloatField("animation_length", 0.0f);
+		UNUSED_COLUMN(entry.hideEquip = tableData.getIntField("hideEquip", 0) == 1;)
+		UNUSED_COLUMN(entry.ignoreUpperBody = tableData.getIntField("ignoreUpperBody", 0) == 1;)
+		UNUSED_COLUMN(entry.restartable = tableData.getIntField("restartable", 0) == 1;)
+		UNUSED_COLUMN(entry.face_animation_name = tableData.getStringField("face_animation_name", "");)
+		UNUSED_COLUMN(entry.priority = tableData.getFloatField("priority", 0.0f);)
+		UNUSED_COLUMN(entry.blendTime = tableData.getFloatField("blendTime", 0.0f);)
+
+		this->animations[CDAnimationKey(animation_type, animationGroupID)].push_back(entry);
+		tableData.nextRow();
+	}
+
+	tableData.finalize();
+}
+
 bool CDAnimationsTable::CacheData(CppSQLite3Statement& queryToCache) {
 	auto tableData = queryToCache.execQuery();
 	// If we received a bad lookup, cache it anyways so we do not run the query again.

--- a/dDatabase/Tables/CDAnimationsTable.h
+++ b/dDatabase/Tables/CDAnimationsTable.h
@@ -27,6 +27,7 @@ class CDAnimationsTable : public CDTable<CDAnimationsTable> {
 	typedef std::string AnimationID;
 	typedef std::pair<std::string, AnimationGroupID> CDAnimationKey;
 public:
+	void LoadValuesFromDatabase();
 	/**
 	 * Given an animationType and the previousAnimationName played, return the next animationType to play.
 	 * If there are more than 1 animationTypes that can be played, one is selected at random but also does not allow

--- a/dDatabase/Tables/CDBehaviorParameterTable.cpp
+++ b/dDatabase/Tables/CDBehaviorParameterTable.cpp
@@ -1,7 +1,7 @@
 #include "CDBehaviorParameterTable.h"
 #include "GeneralUtils.h"
 
-CDBehaviorParameterTable::CDBehaviorParameterTable(void) {
+void CDBehaviorParameterTable::LoadValuesFromDatabase() {
 	auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM BehaviorParameter");
 	uint32_t uniqueParameterId = 0;
 	uint64_t hash = 0;
@@ -53,4 +53,3 @@ std::map<std::string, float> CDBehaviorParameterTable::GetParametersByBehaviorID
 	}
 	return returnInfo;
 }
-

--- a/dDatabase/Tables/CDBehaviorParameterTable.h
+++ b/dDatabase/Tables/CDBehaviorParameterTable.h
@@ -16,7 +16,8 @@ private:
 	std::unordered_map<uint64_t, CDBehaviorParameter> m_Entries;
 	std::unordered_map<std::string, uint32_t> m_ParametersList;
 public:
-	CDBehaviorParameterTable();
+	void LoadValuesFromDatabase();
+
 	float GetValue(const uint32_t behaviorID, const std::string& name, const float defaultValue = 0);
 
 	std::map<std::string, float> GetParametersByBehaviorID(uint32_t behaviorID);

--- a/dDatabase/Tables/CDBehaviorTemplateTable.cpp
+++ b/dDatabase/Tables/CDBehaviorTemplateTable.cpp
@@ -1,6 +1,6 @@
 #include "CDBehaviorTemplateTable.h"
 
-CDBehaviorTemplateTable::CDBehaviorTemplateTable(void) {
+void CDBehaviorTemplateTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -48,7 +48,7 @@ std::vector<CDBehaviorTemplate> CDBehaviorTemplateTable::Query(std::function<boo
 	return data;
 }
 
-std::vector<CDBehaviorTemplate> CDBehaviorTemplateTable::GetEntries(void) const {
+const std::vector<CDBehaviorTemplate>& CDBehaviorTemplateTable::GetEntries() const {
 	return this->entries;
 }
 
@@ -64,4 +64,3 @@ const CDBehaviorTemplate CDBehaviorTemplateTable::GetByBehaviorID(uint32_t behav
 		return entry->second;
 	}
 }
-

--- a/dDatabase/Tables/CDBehaviorTemplateTable.h
+++ b/dDatabase/Tables/CDBehaviorTemplateTable.h
@@ -19,11 +19,12 @@ private:
 	std::unordered_map<uint32_t, CDBehaviorTemplate> entriesMappedByBehaviorID;
 	std::unordered_set<std::string> m_EffectHandles;
 public:
-	CDBehaviorTemplateTable();
+	void LoadValuesFromDatabase();
+
 	// Queries the table with a custom "where" clause
 	std::vector<CDBehaviorTemplate> Query(std::function<bool(CDBehaviorTemplate)> predicate);
 
-	std::vector<CDBehaviorTemplate> GetEntries(void) const;
+	const std::vector<CDBehaviorTemplate>& GetEntries(void) const;
 
 	const CDBehaviorTemplate GetByBehaviorID(uint32_t behaviorID);
 };

--- a/dDatabase/Tables/CDBrickIDTableTable.cpp
+++ b/dDatabase/Tables/CDBrickIDTableTable.cpp
@@ -1,6 +1,6 @@
 #include "CDBrickIDTableTable.h"
 
-CDBrickIDTableTable::CDBrickIDTableTable(void) {
+void CDBrickIDTableTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -39,7 +39,7 @@ std::vector<CDBrickIDTable> CDBrickIDTableTable::Query(std::function<bool(CDBric
 	return data;
 }
 
-std::vector<CDBrickIDTable> CDBrickIDTableTable::GetEntries(void) const {
+const std::vector<CDBrickIDTable>& CDBrickIDTableTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDBrickIDTableTable.h
+++ b/dDatabase/Tables/CDBrickIDTableTable.h
@@ -21,9 +21,9 @@ private:
 	std::vector<CDBrickIDTable> entries;
 
 public:
-	CDBrickIDTableTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDBrickIDTable> Query(std::function<bool(CDBrickIDTable)> predicate);
 
-	std::vector<CDBrickIDTable> GetEntries(void) const;
+	const std::vector<CDBrickIDTable>& GetEntries() const;
 };

--- a/dDatabase/Tables/CDComponentsRegistryTable.cpp
+++ b/dDatabase/Tables/CDComponentsRegistryTable.cpp
@@ -1,25 +1,7 @@
 #include "CDComponentsRegistryTable.h"
 #include "eReplicaComponentType.h"
 
-#define CDCLIENT_CACHE_ALL
-
-CDComponentsRegistryTable::CDComponentsRegistryTable(void) {
-
-#ifdef CDCLIENT_CACHE_ALL
-	// First, get the size of the table
-	unsigned int size = 0;
-	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM ComponentsRegistry");
-	while (!tableSize.eof()) {
-		size = tableSize.getIntField(0, 0);
-
-		tableSize.nextRow();
-	}
-
-	tableSize.finalize();
-
-	// Reserve the size
-	//this->entries.reserve(size);
-
+void CDComponentsRegistryTable::LoadValuesFromDatabase() {
 	// Now get the data
 	auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM ComponentsRegistry");
 	while (!tableData.eof()) {
@@ -34,60 +16,35 @@ CDComponentsRegistryTable::CDComponentsRegistryTable(void) {
 	}
 
 	tableData.finalize();
-#endif
 }
 
 int32_t CDComponentsRegistryTable::GetByIDAndType(uint32_t id, eReplicaComponentType componentType, int32_t defaultValue) {
-	const auto& iter = this->mappedEntries.find(((uint64_t)componentType) << 32 | ((uint64_t)id));
+	auto iter = mappedEntries.find(((uint64_t)componentType) << 32 | ((uint64_t)id));
 
 	if (iter == this->mappedEntries.end()) {
 		return defaultValue;
 	}
 
 	return iter->second;
-
-#ifndef CDCLIENT_CACHE_ALL
 	// Now get the data
-	std::stringstream query;
+	auto query = CDClientDatabase::CreatePreppedStmt("SELECT * FROM ComponentsRegistry WHERE id = ? AND component_type = ?;");
+	query.bind(1, static_cast<int32_t>(id));
+	query.bind(2, static_cast<int32_t>(componentType));
 
-	query << "SELECT * FROM ComponentsRegistry WHERE id = " << std::to_string(id);
-
-	auto tableData = CDClientDatabase::ExecuteQuery(query.str());
+	auto tableData = query.execQuery();
 	while (!tableData.eof()) {
 		CDComponentsRegistry entry;
 		entry.id = tableData.getIntField("id", -1);
-		entry.component_type = tableData.getIntField("component_type", -1);
+		entry.component_type = static_cast<eReplicaComponentType>(tableData.getIntField("component_type", 0));
 		entry.component_id = tableData.getIntField("component_id", -1);
 
-		//this->entries.push_back(entry);
-
-		//Darwin's stuff:
-		const auto& it = this->mappedEntries.find(entry.id);
-		if (it != mappedEntries.end()) {
-			const auto& iter = it->second.find(entry.component_type);
-			if (iter == it->second.end()) {
-				it->second.insert(std::make_pair(entry.component_type, entry.component_id));
-			}
-		} else {
-			std::map<unsigned int, unsigned int> map;
-			map.insert(std::make_pair(entry.component_type, entry.component_id));
-			this->mappedEntries.insert(std::make_pair(entry.id, map));
-		}
+		this->mappedEntries.insert_or_assign(((uint64_t)entry.component_type) << 32 | ((uint64_t)entry.id), entry.component_id);
 
 		tableData.nextRow();
 	}
 
-	tableData.finalize();
+	iter = this->mappedEntries.find(((uint64_t)componentType) << 32 | ((uint64_t)id));
 
-	const auto& it2 = this->mappedEntries.find(id);
-	if (it2 != mappedEntries.end()) {
-		const auto& iter = it2->second.find(componentType);
-		if (iter != it2->second.end()) {
-			return iter->second;
-		}
-	}
-
-	return defaultValue;
-#endif
+	return iter == this->mappedEntries.end() ? defaultValue : iter->second;
 }
 

--- a/dDatabase/Tables/CDComponentsRegistryTable.h
+++ b/dDatabase/Tables/CDComponentsRegistryTable.h
@@ -13,7 +13,7 @@ struct CDComponentsRegistry {
 
 class CDComponentsRegistryTable : public CDTable<CDComponentsRegistryTable> {
 private:
-	std::map<uint64_t, uint32_t> mappedEntries; //id, component_type, component_id
+	std::unordered_map<uint64_t, uint32_t> mappedEntries; //id, component_type, component_id
 
 public:
 	void LoadValuesFromDatabase();

--- a/dDatabase/Tables/CDComponentsRegistryTable.h
+++ b/dDatabase/Tables/CDComponentsRegistryTable.h
@@ -16,6 +16,6 @@ private:
 	std::map<uint64_t, uint32_t> mappedEntries; //id, component_type, component_id
 
 public:
-	CDComponentsRegistryTable();
+	void LoadValuesFromDatabase();
 	int32_t GetByIDAndType(uint32_t id, eReplicaComponentType componentType, int32_t defaultValue = 0);
 };

--- a/dDatabase/Tables/CDCurrencyTableTable.cpp
+++ b/dDatabase/Tables/CDCurrencyTableTable.cpp
@@ -1,7 +1,7 @@
 #include "CDCurrencyTableTable.h"
 
 //! Constructor
-CDCurrencyTableTable::CDCurrencyTableTable(void) {
+void CDCurrencyTableTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -43,7 +43,7 @@ std::vector<CDCurrencyTable> CDCurrencyTableTable::Query(std::function<bool(CDCu
 	return data;
 }
 
-std::vector<CDCurrencyTable> CDCurrencyTableTable::GetEntries(void) const {
+const std::vector<CDCurrencyTable>& CDCurrencyTableTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDCurrencyTableTable.h
+++ b/dDatabase/Tables/CDCurrencyTableTable.h
@@ -23,9 +23,9 @@ private:
 	std::vector<CDCurrencyTable> entries;
 
 public:
-	CDCurrencyTableTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDCurrencyTable> Query(std::function<bool(CDCurrencyTable)> predicate);
 
-	std::vector<CDCurrencyTable> GetEntries(void) const;
+	const std::vector<CDCurrencyTable>& GetEntries() const;
 };

--- a/dDatabase/Tables/CDDestructibleComponentTable.cpp
+++ b/dDatabase/Tables/CDDestructibleComponentTable.cpp
@@ -1,8 +1,6 @@
 #include "CDDestructibleComponentTable.h"
 
-//! Constructor
-CDDestructibleComponentTable::CDDestructibleComponentTable(void) {
-
+void CDDestructibleComponentTable::LoadValuesFromDatabase() {
 	// First, get the size of the table
 	unsigned int size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM DestructibleComponent");
@@ -52,7 +50,7 @@ std::vector<CDDestructibleComponent> CDDestructibleComponentTable::Query(std::fu
 	return data;
 }
 
-std::vector<CDDestructibleComponent> CDDestructibleComponentTable::GetEntries(void) const {
+const std::vector<CDDestructibleComponent>& CDDestructibleComponentTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDDestructibleComponentTable.h
+++ b/dDatabase/Tables/CDDestructibleComponentTable.h
@@ -25,9 +25,9 @@ private:
 	std::vector<CDDestructibleComponent> entries;
 
 public:
-	CDDestructibleComponentTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDDestructibleComponent> Query(std::function<bool(CDDestructibleComponent)> predicate);
 
-	std::vector<CDDestructibleComponent> GetEntries(void) const;
+	const std::vector<CDDestructibleComponent>& GetEntries(void) const;
 };

--- a/dDatabase/Tables/CDEmoteTable.cpp
+++ b/dDatabase/Tables/CDEmoteTable.cpp
@@ -1,40 +1,26 @@
 #include "CDEmoteTable.h"
 
-//! Constructor
-CDEmoteTableTable::CDEmoteTableTable(void) {
+void CDEmoteTableTable::LoadValuesFromDatabase() {
 	auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM Emotes");
 	while (!tableData.eof()) {
-		CDEmoteTable* entry = new CDEmoteTable();
-		entry->ID = tableData.getIntField("id", -1);
-		entry->animationName = tableData.getStringField("animationName", "");
-		entry->iconFilename = tableData.getStringField("iconFilename", "");
-		entry->channel = tableData.getIntField("channel", -1);
-		entry->locked = tableData.getIntField("locked", -1) != 0;
-		entry->localize = tableData.getIntField("localize", -1) != 0;
-		entry->locState = tableData.getIntField("locStatus", -1);
-		entry->gateVersion = tableData.getStringField("gate_version", "");
+		CDEmoteTable entry;
+		entry.ID = tableData.getIntField("id", -1);
+		entry.animationName = tableData.getStringField("animationName", "");
+		entry.iconFilename = tableData.getStringField("iconFilename", "");
+		entry.channel = tableData.getIntField("channel", -1);
+		entry.locked = tableData.getIntField("locked", -1) != 0;
+		entry.localize = tableData.getIntField("localize", -1) != 0;
+		entry.locState = tableData.getIntField("locStatus", -1);
+		entry.gateVersion = tableData.getStringField("gate_version", "");
 
-		entries.insert(std::make_pair(entry->ID, entry));
+		entries.insert(std::make_pair(entry.ID, entry));
 		tableData.nextRow();
 	}
 
 	tableData.finalize();
 }
 
-//! Destructor
-CDEmoteTableTable::~CDEmoteTableTable(void) {
-	for (auto e : entries) {
-		if (e.second) delete e.second;
-	}
-
-	entries.clear();
-}
-
 CDEmoteTable* CDEmoteTableTable::GetEmote(int id) {
-	for (auto e : entries) {
-		if (e.first == id) return e.second;
-	}
-
-	return nullptr;
+	auto itr = entries.find(id);
+	return itr != entries.end() ? &itr->second : nullptr;
 }
-

--- a/dDatabase/Tables/CDEmoteTable.h
+++ b/dDatabase/Tables/CDEmoteTable.h
@@ -28,11 +28,10 @@ struct CDEmoteTable {
 
 class CDEmoteTableTable : public CDTable<CDEmoteTableTable> {
 private:
-	std::map<int, CDEmoteTable*> entries;
+	std::map<int, CDEmoteTable> entries;
 
 public:
-	CDEmoteTableTable();
-	~CDEmoteTableTable();
+	void LoadValuesFromDatabase();
 	// Returns an emote by ID
 	CDEmoteTable* GetEmote(int id);
 };

--- a/dDatabase/Tables/CDFeatureGatingTable.cpp
+++ b/dDatabase/Tables/CDFeatureGatingTable.cpp
@@ -1,7 +1,6 @@
 #include "CDFeatureGatingTable.h"
 
-//! Constructor
-CDFeatureGatingTable::CDFeatureGatingTable(void) {
+void CDFeatureGatingTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -53,7 +52,7 @@ bool CDFeatureGatingTable::FeatureUnlocked(const std::string& feature) const {
 	return false;
 }
 
-std::vector<CDFeatureGating> CDFeatureGatingTable::GetEntries(void) const {
+const std::vector<CDFeatureGating>& CDFeatureGatingTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDFeatureGatingTable.h
+++ b/dDatabase/Tables/CDFeatureGatingTable.h
@@ -16,11 +16,12 @@ private:
 	std::vector<CDFeatureGating> entries;
 
 public:
-	CDFeatureGatingTable();
+	void LoadValuesFromDatabase();
+
 	// Queries the table with a custom "where" clause
 	std::vector<CDFeatureGating> Query(std::function<bool(CDFeatureGating)> predicate);
 
 	bool FeatureUnlocked(const std::string& feature) const;
 
-	std::vector<CDFeatureGating> GetEntries(void) const;
+	const std::vector<CDFeatureGating>& GetEntries(void) const;
 };

--- a/dDatabase/Tables/CDInventoryComponentTable.cpp
+++ b/dDatabase/Tables/CDInventoryComponentTable.cpp
@@ -1,7 +1,6 @@
 #include "CDInventoryComponentTable.h"
 
-//! Constructor
-CDInventoryComponentTable::CDInventoryComponentTable(void) {
+void CDInventoryComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -42,7 +41,7 @@ std::vector<CDInventoryComponent> CDInventoryComponentTable::Query(std::function
 	return data;
 }
 
-std::vector<CDInventoryComponent> CDInventoryComponentTable::GetEntries(void) const {
+const std::vector<CDInventoryComponent>& CDInventoryComponentTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDInventoryComponentTable.h
+++ b/dDatabase/Tables/CDInventoryComponentTable.h
@@ -15,9 +15,9 @@ private:
 	std::vector<CDInventoryComponent> entries;
 
 public:
-	CDInventoryComponentTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDInventoryComponent> Query(std::function<bool(CDInventoryComponent)> predicate);
 
-	std::vector<CDInventoryComponent> GetEntries(void) const;
+	const std::vector<CDInventoryComponent>& GetEntries() const;
 };

--- a/dDatabase/Tables/CDItemComponentTable.cpp
+++ b/dDatabase/Tables/CDItemComponentTable.cpp
@@ -3,11 +3,7 @@
 
 CDItemComponent CDItemComponentTable::Default = {};
 
-//! Constructor
-CDItemComponentTable::CDItemComponentTable(void) {
-	Default = CDItemComponent();
-
-#ifdef CDCLIENT_CACHE_ALL
+void CDItemComponentTable::LoadValuesFromDatabase() {
 	// First, get the size of the table
 	unsigned int size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM ItemComponent");
@@ -55,13 +51,13 @@ CDItemComponentTable::CDItemComponentTable(void) {
 		entry.currencyLOT = tableData.getIntField("currencyLOT", -1);
 		entry.altCurrencyCost = tableData.getIntField("altCurrencyCost", -1);
 		entry.subItems = tableData.getStringField("subItems", "");
-		entry.audioEventUse = tableData.getStringField("audioEventUse", "");
+		UNUSED_COLUMN(entry.audioEventUse = tableData.getStringField("audioEventUse", ""));
 		entry.noEquipAnimation = tableData.getIntField("noEquipAnimation", -1) == 1 ? true : false;
 		entry.commendationLOT = tableData.getIntField("commendationLOT", -1);
 		entry.commendationCost = tableData.getIntField("commendationCost", -1);
-		entry.audioEquipMetaEventSet = tableData.getStringField("audioEquipMetaEventSet", "");
+		UNUSED_COLUMN(entry.audioEquipMetaEventSet = tableData.getStringField("audioEquipMetaEventSet", ""));
 		entry.currencyCosts = tableData.getStringField("currencyCosts", "");
-		entry.ingredientInfo = tableData.getStringField("ingredientInfo", "");
+		UNUSED_COLUMN(entry.ingredientInfo = tableData.getStringField("ingredientInfo", ""));
 		entry.locStatus = tableData.getIntField("locStatus", -1);
 		entry.forgeType = tableData.getIntField("forgeType", -1);
 		entry.SellMultiplier = tableData.getFloatField("SellMultiplier", -1.0f);
@@ -71,7 +67,6 @@ CDItemComponentTable::CDItemComponentTable(void) {
 	}
 
 	tableData.finalize();
-#endif
 }
 
 const CDItemComponent& CDItemComponentTable::GetItemComponentByID(unsigned int skillID) {
@@ -80,12 +75,10 @@ const CDItemComponent& CDItemComponentTable::GetItemComponentByID(unsigned int s
 		return it->second;
 	}
 
-#ifndef CDCLIENT_CACHE_ALL
-	std::stringstream query;
+	auto query = CDClientDatabase::CreatePreppedStmt("SELECT * FROM ItemComponent WHERE id = ?;");
+	query.bind(1, static_cast<int32_t>(skillID));
 
-	query << "SELECT * FROM ItemComponent WHERE id = " << std::to_string(skillID);
-
-	auto tableData = CDClientDatabase::ExecuteQuery(query.str());
+	auto tableData = query.execQuery();
 	if (tableData.eof()) {
 		entries.insert(std::make_pair(skillID, Default));
 		return Default;
@@ -144,7 +137,6 @@ const CDItemComponent& CDItemComponentTable::GetItemComponentByID(unsigned int s
 	if (it2 != this->entries.end()) {
 		return it2->second;
 	}
-#endif
 
 	return Default;
 }

--- a/dDatabase/Tables/CDItemComponentTable.h
+++ b/dDatabase/Tables/CDItemComponentTable.h
@@ -54,7 +54,7 @@ private:
 	std::map<unsigned int, CDItemComponent> entries;
 
 public:
-	CDItemComponentTable();
+	void LoadValuesFromDatabase();
 	static std::map<LOT, uint32_t> ParseCraftingCurrencies(const CDItemComponent& itemComponent);
 
 	// Gets an entry by ID

--- a/dDatabase/Tables/CDItemSetSkillsTable.cpp
+++ b/dDatabase/Tables/CDItemSetSkillsTable.cpp
@@ -1,7 +1,6 @@
 #include "CDItemSetSkillsTable.h"
 
-//! Constructor
-CDItemSetSkillsTable::CDItemSetSkillsTable(void) {
+void CDItemSetSkillsTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -41,7 +40,7 @@ std::vector<CDItemSetSkills> CDItemSetSkillsTable::Query(std::function<bool(CDIt
 	return data;
 }
 
-std::vector<CDItemSetSkills> CDItemSetSkillsTable::GetEntries(void) const {
+const std::vector<CDItemSetSkills>& CDItemSetSkillsTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDItemSetSkillsTable.h
+++ b/dDatabase/Tables/CDItemSetSkillsTable.h
@@ -14,11 +14,11 @@ private:
 	std::vector<CDItemSetSkills> entries;
 
 public:
-	CDItemSetSkillsTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDItemSetSkills> Query(std::function<bool(CDItemSetSkills)> predicate);
 
-	std::vector<CDItemSetSkills> GetEntries(void) const;
+	const std::vector<CDItemSetSkills>& GetEntries() const;
 
 	std::vector<CDItemSetSkills> GetBySkillID(unsigned int SkillSetID);
 };

--- a/dDatabase/Tables/CDItemSetsTable.cpp
+++ b/dDatabase/Tables/CDItemSetsTable.cpp
@@ -1,7 +1,6 @@
 #include "CDItemSetsTable.h"
 
-//! Constructor
-CDItemSetsTable::CDItemSetsTable(void) {
+void CDItemSetsTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -53,7 +52,7 @@ std::vector<CDItemSets> CDItemSetsTable::Query(std::function<bool(CDItemSets)> p
 	return data;
 }
 
-std::vector<CDItemSets> CDItemSetsTable::GetEntries(void) const {
+const std::vector<CDItemSets>& CDItemSetsTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDItemSetsTable.h
+++ b/dDatabase/Tables/CDItemSetsTable.h
@@ -26,10 +26,10 @@ private:
 	std::vector<CDItemSets> entries;
 
 public:
-	CDItemSetsTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDItemSets> Query(std::function<bool(CDItemSets)> predicate);
 
-	std::vector<CDItemSets> GetEntries(void) const;
+	const std::vector<CDItemSets>& GetEntries(void) const;
 };
 

--- a/dDatabase/Tables/CDLevelProgressionLookupTable.cpp
+++ b/dDatabase/Tables/CDLevelProgressionLookupTable.cpp
@@ -1,7 +1,6 @@
 #include "CDLevelProgressionLookupTable.h"
 
-//! Constructor
-CDLevelProgressionLookupTable::CDLevelProgressionLookupTable(void) {
+void CDLevelProgressionLookupTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -32,7 +31,6 @@ CDLevelProgressionLookupTable::CDLevelProgressionLookupTable(void) {
 	tableData.finalize();
 }
 
-//! Queries the table with a custom "where" clause
 std::vector<CDLevelProgressionLookup> CDLevelProgressionLookupTable::Query(std::function<bool(CDLevelProgressionLookup)> predicate) {
 
 	std::vector<CDLevelProgressionLookup> data = cpplinq::from(this->entries)
@@ -42,8 +40,7 @@ std::vector<CDLevelProgressionLookup> CDLevelProgressionLookupTable::Query(std::
 	return data;
 }
 
-//! Gets all the entries in the table
-std::vector<CDLevelProgressionLookup> CDLevelProgressionLookupTable::GetEntries(void) const {
+const std::vector<CDLevelProgressionLookup>& CDLevelProgressionLookupTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDLevelProgressionLookupTable.h
+++ b/dDatabase/Tables/CDLevelProgressionLookupTable.h
@@ -14,10 +14,10 @@ private:
 	std::vector<CDLevelProgressionLookup> entries;
 
 public:
-	CDLevelProgressionLookupTable();
+	void LoadValuesFromDatabase();
+
 	// Queries the table with a custom "where" clause
 	std::vector<CDLevelProgressionLookup> Query(std::function<bool(CDLevelProgressionLookup)> predicate);
 
-	// Gets all the entries in the table
-	std::vector<CDLevelProgressionLookup> GetEntries(void) const;
+	const std::vector<CDLevelProgressionLookup>& GetEntries() const;
 };

--- a/dDatabase/Tables/CDLootMatrixTable.cpp
+++ b/dDatabase/Tables/CDLootMatrixTable.cpp
@@ -1,7 +1,6 @@
 #include "CDLootMatrixTable.h"
 
-//! Constructor
-CDLootMatrixTable::CDLootMatrixTable(void) {
+void CDLootMatrixTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -47,7 +46,7 @@ std::vector<CDLootMatrix> CDLootMatrixTable::Query(std::function<bool(CDLootMatr
 	return data;
 }
 
-const std::vector<CDLootMatrix>& CDLootMatrixTable::GetEntries(void) const {
+const std::vector<CDLootMatrix>& CDLootMatrixTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDLootMatrixTable.cpp
+++ b/dDatabase/Tables/CDLootMatrixTable.cpp
@@ -1,52 +1,46 @@
 #include "CDLootMatrixTable.h"
 
 void CDLootMatrixTable::LoadValuesFromDatabase() {
-
-	// First, get the size of the table
-	unsigned int size = 0;
-	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM LootMatrix");
-	while (!tableSize.eof()) {
-		size = tableSize.getIntField(0, 0);
-
-		tableSize.nextRow();
-	}
-
-	tableSize.finalize();
-
-	// Reserve the size
-	this->entries.reserve(size);
-
 	// Now get the data
 	auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM LootMatrix");
 	while (!tableData.eof()) {
 		CDLootMatrix entry;
-		entry.LootMatrixIndex = tableData.getIntField("LootMatrixIndex", -1);
+		uint32_t lootMatrixIndex = tableData.getIntField("LootMatrixIndex", -1);
 		entry.LootTableIndex = tableData.getIntField("LootTableIndex", -1);
 		entry.RarityTableIndex = tableData.getIntField("RarityTableIndex", -1);
 		entry.percent = tableData.getFloatField("percent", -1.0f);
 		entry.minToDrop = tableData.getIntField("minToDrop", -1);
 		entry.maxToDrop = tableData.getIntField("maxToDrop", -1);
-		entry.id = tableData.getIntField("id", -1);
 		entry.flagID = tableData.getIntField("flagID", -1);
 		UNUSED(entry.gate_version = tableData.getStringField("gate_version", ""));
 
-		this->entries.push_back(entry);
+		this->entries[lootMatrixIndex].push_back(entry);
 		tableData.nextRow();
 	}
-
-	tableData.finalize();
 }
 
-std::vector<CDLootMatrix> CDLootMatrixTable::Query(std::function<bool(CDLootMatrix)> predicate) {
+const LootMatrixEntries& CDLootMatrixTable::GetMatrix(uint32_t matrixId) {
+	auto itr = this->entries.find(matrixId);
+	if (itr != this->entries.end()) {
+		return itr->second;
+	}
+	auto query = CDClientDatabase::CreatePreppedStmt("SELECT * FROM LootMatrix where LootMatrixIndex = ?;");
+	query.bind(1, static_cast<int32_t>(matrixId));
 
-	std::vector<CDLootMatrix> data = cpplinq::from(this->entries)
-		>> cpplinq::where(predicate)
-		>> cpplinq::to_vector();
+	auto tableData = query.execQuery();
+	while (!tableData.eof()) {
+		CDLootMatrix entry;
+		entry.LootTableIndex = tableData.getIntField("LootTableIndex", -1);
+		entry.RarityTableIndex = tableData.getIntField("RarityTableIndex", -1);
+		entry.percent = tableData.getFloatField("percent", -1.0f);
+		entry.minToDrop = tableData.getIntField("minToDrop", -1);
+		entry.maxToDrop = tableData.getIntField("maxToDrop", -1);
+		entry.flagID = tableData.getIntField("flagID", -1);
+		UNUSED(entry.gate_version = tableData.getStringField("gate_version", ""));
 
-	return data;
-}
-
-const std::vector<CDLootMatrix>& CDLootMatrixTable::GetEntries() const {
-	return this->entries;
+		this->entries[matrixId].push_back(entry);
+		tableData.nextRow();
+	}
+	return this->entries[matrixId];
 }
 

--- a/dDatabase/Tables/CDLootMatrixTable.h
+++ b/dDatabase/Tables/CDLootMatrixTable.h
@@ -20,10 +20,10 @@ private:
 	std::vector<CDLootMatrix> entries;
 
 public:
-	CDLootMatrixTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDLootMatrix> Query(std::function<bool(CDLootMatrix)> predicate);
 
-	const std::vector<CDLootMatrix>& GetEntries(void) const;
+	const std::vector<CDLootMatrix>& GetEntries() const;
 };
 

--- a/dDatabase/Tables/CDLootMatrixTable.h
+++ b/dDatabase/Tables/CDLootMatrixTable.h
@@ -4,26 +4,25 @@
 #include "CDTable.h"
 
 struct CDLootMatrix {
-	unsigned int LootMatrixIndex;           //!< The Loot Matrix Index
 	unsigned int LootTableIndex;            //!< The Loot Table Index
 	unsigned int RarityTableIndex;          //!< The Rarity Table Index
 	float percent;                   //!< The percent that this matrix is used?
 	unsigned int minToDrop;                 //!< The minimum amount of loot from this matrix to drop
 	unsigned int maxToDrop;                 //!< The maximum amount of loot from this matrix to drop
-	unsigned int id;                        //!< The ID of the Loot Matrix
 	unsigned int flagID;                    //!< ???
 	UNUSED(std::string gate_version);          //!< The Gate Version
 };
 
-class CDLootMatrixTable : public CDTable<CDLootMatrixTable> {
-private:
-	std::vector<CDLootMatrix> entries;
+typedef uint32_t LootMatrixIndex;
+typedef std::vector<CDLootMatrix> LootMatrixEntries;
 
+class CDLootMatrixTable : public CDTable<CDLootMatrixTable> {
 public:
 	void LoadValuesFromDatabase();
-	// Queries the table with a custom "where" clause
-	std::vector<CDLootMatrix> Query(std::function<bool(CDLootMatrix)> predicate);
 
-	const std::vector<CDLootMatrix>& GetEntries() const;
+	// Gets a matrix by ID or inserts a blank one if none existed.
+	const LootMatrixEntries& GetMatrix(uint32_t matrixId);
+private:
+	std::unordered_map<LootMatrixIndex, LootMatrixEntries> entries;
 };
 

--- a/dDatabase/Tables/CDLootTableTable.cpp
+++ b/dDatabase/Tables/CDLootTableTable.cpp
@@ -1,51 +1,37 @@
 #include "CDLootTableTable.h"
 
 void CDLootTableTable::LoadValuesFromDatabase() {
-
-	// First, get the size of the table
-	unsigned int size = 0;
-	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM LootTable");
-	while (!tableSize.eof()) {
-		size = tableSize.getIntField(0, 0);
-
-		tableSize.nextRow();
-	}
-
-	tableSize.finalize();
-
-	// Reserve the size
-	this->entries.reserve(size);
-
 	// Now get the data
 	auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM LootTable");
 	while (!tableData.eof()) {
 		CDLootTable entry;
-		entry.id = tableData.getIntField("id", -1);
+		uint32_t lootTableIndex = tableData.getIntField("LootTableIndex", -1);
 		entry.itemid = tableData.getIntField("itemid", -1);
-		entry.LootTableIndex = tableData.getIntField("LootTableIndex", -1);
-		entry.id = tableData.getIntField("id", -1);
 		entry.MissionDrop = tableData.getIntField("MissionDrop", -1) == 1 ? true : false;
 		entry.sortPriority = tableData.getIntField("sortPriority", -1);
 
-		this->entries.push_back(entry);
+		this->entries[lootTableIndex].push_back(entry);
 		tableData.nextRow();
 	}
-
-	tableData.finalize();
 }
 
-//! Queries the table with a custom "where" clause
-std::vector<CDLootTable> CDLootTableTable::Query(std::function<bool(CDLootTable)> predicate) {
+const LootTableEntries& CDLootTableTable::GetTable(uint32_t tableId) {
+	auto itr = this->entries.find(tableId);
+	if (itr != this->entries.end()) {
+		return itr->second;
+	}
+	auto query = CDClientDatabase::CreatePreppedStmt("SELECT * FROM LootTable WHERE LootTableIndex = ?;");
+	query.bind(1, static_cast<int32_t>(tableId));
 
-	std::vector<CDLootTable> data = cpplinq::from(this->entries)
-		>> cpplinq::where(predicate)
-		>> cpplinq::to_vector();
+	auto tableData = query.execQuery();
+	while (!tableData.eof()) {
+		CDLootTable entry;
+		entry.itemid = tableData.getIntField("itemid", -1);
+		entry.MissionDrop = tableData.getIntField("MissionDrop", -1) == 1 ? true : false;
+		entry.sortPriority = tableData.getIntField("sortPriority", -1);
 
-	return data;
+		this->entries[tableId].push_back(entry);
+		tableData.nextRow();
+	}
+	return this->entries[tableId];
 }
-
-//! Gets all the entries in the table
-const std::vector<CDLootTable>& CDLootTableTable::GetEntries() const {
-	return this->entries;
-}
-

--- a/dDatabase/Tables/CDLootTableTable.cpp
+++ b/dDatabase/Tables/CDLootTableTable.cpp
@@ -1,7 +1,6 @@
 #include "CDLootTableTable.h"
 
-//! Constructor
-CDLootTableTable::CDLootTableTable(void) {
+void CDLootTableTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -46,7 +45,7 @@ std::vector<CDLootTable> CDLootTableTable::Query(std::function<bool(CDLootTable)
 }
 
 //! Gets all the entries in the table
-const std::vector<CDLootTable>& CDLootTableTable::GetEntries(void) const {
+const std::vector<CDLootTable>& CDLootTableTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDLootTableTable.h
+++ b/dDatabase/Tables/CDLootTableTable.h
@@ -6,20 +6,20 @@
 struct CDLootTable {
 	unsigned int itemid;                 //!< The LOT of the item
 	unsigned int LootTableIndex;         //!< The Loot Table Index
-	unsigned int id;                     //!< The ID
 	bool MissionDrop;               //!< Whether or not this loot table is a mission drop
 	unsigned int sortPriority;           //!< The sorting priority
 };
 
+typedef uint32_t LootTableIndex;
+typedef std::vector<CDLootTable> LootTableEntries;
+
 class CDLootTableTable : public CDTable<CDLootTableTable> {
 private:
-	std::vector<CDLootTable> entries;
+	std::unordered_map<LootTableIndex, LootTableEntries> entries;
 
 public:
 	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
-	std::vector<CDLootTable> Query(std::function<bool(CDLootTable)> predicate);
-
-	const std::vector<CDLootTable>& GetEntries() const;
+	const LootTableEntries& GetTable(uint32_t tableId);
 };
 

--- a/dDatabase/Tables/CDLootTableTable.h
+++ b/dDatabase/Tables/CDLootTableTable.h
@@ -16,10 +16,10 @@ private:
 	std::vector<CDLootTable> entries;
 
 public:
-	CDLootTableTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDLootTable> Query(std::function<bool(CDLootTable)> predicate);
 
-	const std::vector<CDLootTable>& GetEntries(void) const;
+	const std::vector<CDLootTable>& GetEntries() const;
 };
 

--- a/dDatabase/Tables/CDMissionEmailTable.cpp
+++ b/dDatabase/Tables/CDMissionEmailTable.cpp
@@ -1,7 +1,6 @@
 #include "CDMissionEmailTable.h"
 
-//! Constructor
-CDMissionEmailTable::CDMissionEmailTable(void) {
+void CDMissionEmailTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -48,7 +47,7 @@ std::vector<CDMissionEmail> CDMissionEmailTable::Query(std::function<bool(CDMiss
 }
 
 //! Gets all the entries in the table
-std::vector<CDMissionEmail> CDMissionEmailTable::GetEntries(void) const {
+const std::vector<CDMissionEmail>& CDMissionEmailTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDMissionEmailTable.h
+++ b/dDatabase/Tables/CDMissionEmailTable.h
@@ -20,9 +20,9 @@ private:
 	std::vector<CDMissionEmail> entries;
 
 public:
-	CDMissionEmailTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDMissionEmail> Query(std::function<bool(CDMissionEmail)> predicate);
 
-	std::vector<CDMissionEmail> GetEntries(void) const;
+	const std::vector<CDMissionEmail>& GetEntries() const;
 };

--- a/dDatabase/Tables/CDMissionNPCComponentTable.cpp
+++ b/dDatabase/Tables/CDMissionNPCComponentTable.cpp
@@ -1,7 +1,6 @@
 #include "CDMissionNPCComponentTable.h"
 
-//! Constructor
-CDMissionNPCComponentTable::CDMissionNPCComponentTable(void) {
+void CDMissionNPCComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -45,7 +44,7 @@ std::vector<CDMissionNPCComponent> CDMissionNPCComponentTable::Query(std::functi
 }
 
 //! Gets all the entries in the table
-std::vector<CDMissionNPCComponent> CDMissionNPCComponentTable::GetEntries(void) const {
+const std::vector<CDMissionNPCComponent>& CDMissionNPCComponentTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDMissionNPCComponentTable.h
+++ b/dDatabase/Tables/CDMissionNPCComponentTable.h
@@ -16,12 +16,12 @@ private:
 	std::vector<CDMissionNPCComponent> entries;
 
 public:
-	CDMissionNPCComponentTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDMissionNPCComponent> Query(std::function<bool(CDMissionNPCComponent)> predicate);
 
 	// Gets all the entries in the table
-	std::vector<CDMissionNPCComponent> GetEntries(void) const;
+	const std::vector<CDMissionNPCComponent>& GetEntries() const;
 
 };
 

--- a/dDatabase/Tables/CDMissionTasksTable.cpp
+++ b/dDatabase/Tables/CDMissionTasksTable.cpp
@@ -1,7 +1,6 @@
 #include "CDMissionTasksTable.h"
 
-//! Constructor
-CDMissionTasksTable::CDMissionTasksTable(void) {
+void CDMissionTasksTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -56,16 +55,14 @@ std::vector<CDMissionTasks*> CDMissionTasksTable::GetByMissionID(uint32_t missio
 
 	for (auto& entry : this->entries) {
 		if (entry.id == missionID) {
-			CDMissionTasks* task = const_cast<CDMissionTasks*>(&entry);
-
-			tasks.push_back(task);
+			tasks.push_back(&entry);
 		}
 	}
 
 	return tasks;
 }
 
-const std::vector<CDMissionTasks>& CDMissionTasksTable::GetEntries(void) const {
+const std::vector<CDMissionTasks>& CDMissionTasksTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDMissionTasksTable.h
+++ b/dDatabase/Tables/CDMissionTasksTable.h
@@ -24,12 +24,12 @@ private:
 	std::vector<CDMissionTasks> entries;
 
 public:
-	CDMissionTasksTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDMissionTasks> Query(std::function<bool(CDMissionTasks)> predicate);
 
 	std::vector<CDMissionTasks*> GetByMissionID(uint32_t missionID);
 
-	const std::vector<CDMissionTasks>& GetEntries(void) const;
+	const std::vector<CDMissionTasks>& GetEntries() const;
 };
 

--- a/dDatabase/Tables/CDMissionsTable.cpp
+++ b/dDatabase/Tables/CDMissionsTable.cpp
@@ -2,8 +2,7 @@
 
 CDMissions CDMissionsTable::Default = {};
 
-//! Constructor
-CDMissionsTable::CDMissionsTable(void) {
+void CDMissionsTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;

--- a/dDatabase/Tables/CDMissionsTable.h
+++ b/dDatabase/Tables/CDMissionsTable.h
@@ -65,12 +65,12 @@ private:
 	std::vector<CDMissions> entries;
 
 public:
-	CDMissionsTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDMissions> Query(std::function<bool(CDMissions)> predicate);
 
 	// Gets all the entries in the table
-	const std::vector<CDMissions>& GetEntries(void) const;
+	const std::vector<CDMissions>& GetEntries() const;
 
 	const CDMissions* GetPtrByMissionID(uint32_t missionID) const;
 

--- a/dDatabase/Tables/CDMovementAIComponentTable.cpp
+++ b/dDatabase/Tables/CDMovementAIComponentTable.cpp
@@ -1,7 +1,6 @@
 #include "CDMovementAIComponentTable.h"
 
-//! Constructor
-CDMovementAIComponentTable::CDMovementAIComponentTable(void) {
+void CDMovementAIComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -37,7 +36,6 @@ CDMovementAIComponentTable::CDMovementAIComponentTable(void) {
 	tableData.finalize();
 }
 
-//! Queries the table with a custom "where" clause
 std::vector<CDMovementAIComponent> CDMovementAIComponentTable::Query(std::function<bool(CDMovementAIComponent)> predicate) {
 
 	std::vector<CDMovementAIComponent> data = cpplinq::from(this->entries)
@@ -47,8 +45,7 @@ std::vector<CDMovementAIComponent> CDMovementAIComponentTable::Query(std::functi
 	return data;
 }
 
-//! Gets all the entries in the table
-std::vector<CDMovementAIComponent> CDMovementAIComponentTable::GetEntries(void) const {
+const std::vector<CDMovementAIComponent>& CDMovementAIComponentTable::GetEntries(void) const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDMovementAIComponentTable.h
+++ b/dDatabase/Tables/CDMovementAIComponentTable.h
@@ -19,10 +19,10 @@ private:
 	std::vector<CDMovementAIComponent> entries;
 
 public:
-	CDMovementAIComponentTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDMovementAIComponent> Query(std::function<bool(CDMovementAIComponent)> predicate);
 
 	// Gets all the entries in the table
-	std::vector<CDMovementAIComponent> GetEntries(void) const;
+	const std::vector<CDMovementAIComponent>& GetEntries() const;
 };

--- a/dDatabase/Tables/CDObjectSkillsTable.cpp
+++ b/dDatabase/Tables/CDObjectSkillsTable.cpp
@@ -1,7 +1,6 @@
 #include "CDObjectSkillsTable.h"
 
-//! Constructor
-CDObjectSkillsTable::CDObjectSkillsTable(void) {
+void CDObjectSkillsTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -33,7 +32,6 @@ CDObjectSkillsTable::CDObjectSkillsTable(void) {
 	tableData.finalize();
 }
 
-//! Queries the table with a custom "where" clause
 std::vector<CDObjectSkills> CDObjectSkillsTable::Query(std::function<bool(CDObjectSkills)> predicate) {
 
 	std::vector<CDObjectSkills> data = cpplinq::from(this->entries)
@@ -43,7 +41,6 @@ std::vector<CDObjectSkills> CDObjectSkillsTable::Query(std::function<bool(CDObje
 	return data;
 }
 
-//! Gets all the entries in the table
-std::vector<CDObjectSkills> CDObjectSkillsTable::GetEntries(void) const {
+const std::vector<CDObjectSkills>& CDObjectSkillsTable::GetEntries() const {
 	return this->entries;
 }

--- a/dDatabase/Tables/CDObjectSkillsTable.h
+++ b/dDatabase/Tables/CDObjectSkillsTable.h
@@ -15,12 +15,12 @@ private:
 	std::vector<CDObjectSkills> entries;
 
 public:
-	CDObjectSkillsTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDObjectSkills> Query(std::function<bool(CDObjectSkills)> predicate);
 
 	// Gets all the entries in the table
-	std::vector<CDObjectSkills> GetEntries(void) const;
+	const std::vector<CDObjectSkills>& GetEntries() const;
 
 };
 

--- a/dDatabase/Tables/CDObjectsTable.cpp
+++ b/dDatabase/Tables/CDObjectsTable.cpp
@@ -1,8 +1,6 @@
 #include "CDObjectsTable.h"
 
-//! Constructor
-CDObjectsTable::CDObjectsTable(void) {
-#ifdef CDCLIENT_CACHE_ALL
+void CDObjectsTable::LoadValuesFromDatabase() {
 	// First, get the size of the table
 	unsigned int size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM Objects");
@@ -20,25 +18,24 @@ CDObjectsTable::CDObjectsTable(void) {
 		CDObjects entry;
 		entry.id = tableData.getIntField("id", -1);
 		entry.name = tableData.getStringField("name", "");
-		entry.placeable = tableData.getIntField("placeable", -1);
+		UNUSED_COLUMN(entry.placeable = tableData.getIntField("placeable", -1);)
 		entry.type = tableData.getStringField("type", "");
-		entry.description = tableData.getStringField("description", "");
-		entry.localize = tableData.getIntField("localize", -1);
-		entry.npcTemplateID = tableData.getIntField("npcTemplateID", -1);
-		entry.displayName = tableData.getStringField("displayName", "");
+		UNUSED_COLUMN(entry.description = tableData.getStringField("description", "");)
+		UNUSED_COLUMN(entry.localize = tableData.getIntField("localize", -1);)
+		UNUSED_COLUMN(entry.npcTemplateID = tableData.getIntField("npcTemplateID", -1);)
+		UNUSED_COLUMN(entry.displayName = tableData.getStringField("displayName", "");)
 		entry.interactionDistance = tableData.getFloatField("interactionDistance", -1.0f);
-		entry.nametag = tableData.getIntField("nametag", -1);
-		entry._internalNotes = tableData.getStringField("_internalNotes", "");
-		entry.locStatus = tableData.getIntField("locStatus", -1);
-		entry.gate_version = tableData.getStringField("gate_version", "");
-		entry.HQ_valid = tableData.getIntField("HQ_valid", -1);
+		UNUSED_COLUMN(entry.nametag = tableData.getIntField("nametag", -1);)
+		UNUSED_COLUMN(entry._internalNotes = tableData.getStringField("_internalNotes", "");)
+		UNUSED_COLUMN(entry.locStatus = tableData.getIntField("locStatus", -1);)
+		UNUSED_COLUMN(entry.gate_version = tableData.getStringField("gate_version", "");)
+		UNUSED_COLUMN(entry.HQ_valid = tableData.getIntField("HQ_valid", -1);)
 
 		this->entries.insert(std::make_pair(entry.id, entry));
 		tableData.nextRow();
 	}
 
 	tableData.finalize();
-#endif
 
 	m_default.id = 0;
 }
@@ -49,12 +46,10 @@ const CDObjects& CDObjectsTable::GetByID(unsigned int LOT) {
 		return it->second;
 	}
 
-#ifndef CDCLIENT_CACHE_ALL
-	std::stringstream query;
+	auto query = CDClientDatabase::CreatePreppedStmt("SELECT * FROM Objects WHERE id = ?;");
+	query.bind(1, static_cast<int32_t>(LOT));
 
-	query << "SELECT * FROM Objects WHERE id = " << std::to_string(LOT);
-
-	auto tableData = CDClientDatabase::ExecuteQuery(query.str());
+	auto tableData = query.execQuery();
 	if (tableData.eof()) {
 		this->entries.insert(std::make_pair(LOT, m_default));
 		return m_default;
@@ -88,7 +83,6 @@ const CDObjects& CDObjectsTable::GetByID(unsigned int LOT) {
 	if (it2 != entries.end()) {
 		return it2->second;
 	}
-#endif
 
 	return m_default;
 }

--- a/dDatabase/Tables/CDObjectsTable.h
+++ b/dDatabase/Tables/CDObjectsTable.h
@@ -26,7 +26,7 @@ private:
 	CDObjects m_default;
 
 public:
-	CDObjectsTable();
+	void LoadValuesFromDatabase();
 	// Gets an entry by ID
 	const CDObjects& GetByID(unsigned int LOT);
 };

--- a/dDatabase/Tables/CDPackageComponentTable.cpp
+++ b/dDatabase/Tables/CDPackageComponentTable.cpp
@@ -1,7 +1,6 @@
 #include "CDPackageComponentTable.h"
 
-//! Constructor
-CDPackageComponentTable::CDPackageComponentTable(void) {
+void CDPackageComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -43,7 +42,7 @@ std::vector<CDPackageComponent> CDPackageComponentTable::Query(std::function<boo
 }
 
 //! Gets all the entries in the table
-std::vector<CDPackageComponent> CDPackageComponentTable::GetEntries(void) const {
+const std::vector<CDPackageComponent>& CDPackageComponentTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDPackageComponentTable.h
+++ b/dDatabase/Tables/CDPackageComponentTable.h
@@ -14,9 +14,9 @@ private:
 	std::vector<CDPackageComponent> entries;
 
 public:
-	CDPackageComponentTable(void);
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDPackageComponent> Query(std::function<bool(CDPackageComponent)> predicate);
 
-	std::vector<CDPackageComponent> GetEntries(void) const;
+	const std::vector<CDPackageComponent>& GetEntries() const;
 };

--- a/dDatabase/Tables/CDPhysicsComponentTable.cpp
+++ b/dDatabase/Tables/CDPhysicsComponentTable.cpp
@@ -1,46 +1,35 @@
 #include "CDPhysicsComponentTable.h"
 
-CDPhysicsComponentTable::CDPhysicsComponentTable(void) {
+void CDPhysicsComponentTable::LoadValuesFromDatabase() {
 	auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM PhysicsComponent");
 	while (!tableData.eof()) {
-		CDPhysicsComponent* entry = new CDPhysicsComponent();
-		entry->id = tableData.getIntField("id", -1);
-		entry->bStatic = tableData.getIntField("static", -1) != 0;
-		entry->physicsAsset = tableData.getStringField("physics_asset", "");
+		CDPhysicsComponent entry;
+		entry.id = tableData.getIntField("id", -1);
+		entry.bStatic = tableData.getIntField("static", -1) != 0;
+		entry.physicsAsset = tableData.getStringField("physics_asset", "");
 		UNUSED(entry->jump = tableData.getIntField("jump", -1) != 0);
 		UNUSED(entry->doublejump = tableData.getIntField("doublejump", -1) != 0);
-		entry->speed = tableData.getFloatField("speed", -1);
+		entry.speed = tableData.getFloatField("speed", -1);
 		UNUSED(entry->rotSpeed = tableData.getFloatField("rotSpeed", -1));
-		entry->playerHeight = tableData.getFloatField("playerHeight");
-		entry->playerRadius = tableData.getFloatField("playerRadius");
-		entry->pcShapeType = tableData.getIntField("pcShapeType");
-		entry->collisionGroup = tableData.getIntField("collisionGroup");
+		entry.playerHeight = tableData.getFloatField("playerHeight");
+		entry.playerRadius = tableData.getFloatField("playerRadius");
+		entry.pcShapeType = tableData.getIntField("pcShapeType");
+		entry.collisionGroup = tableData.getIntField("collisionGroup");
 		UNUSED(entry->airSpeed = tableData.getFloatField("airSpeed"));
 		UNUSED(entry->boundaryAsset = tableData.getStringField("boundaryAsset"));
 		UNUSED(entry->jumpAirSpeed = tableData.getFloatField("jumpAirSpeed"));
 		UNUSED(entry->friction = tableData.getFloatField("friction"));
 		UNUSED(entry->gravityVolumeAsset = tableData.getStringField("gravityVolumeAsset"));
 
-		m_entries.insert(std::make_pair(entry->id, entry));
+		m_entries.insert(std::make_pair(entry.id, entry));
 		tableData.nextRow();
 	}
 
 	tableData.finalize();
 }
 
-CDPhysicsComponentTable::~CDPhysicsComponentTable() {
-	for (auto e : m_entries) {
-		if (e.second) delete e.second;
-	}
-
-	m_entries.clear();
-}
-
 CDPhysicsComponent* CDPhysicsComponentTable::GetByID(unsigned int componentID) {
-	for (auto e : m_entries) {
-		if (e.first == componentID) return e.second;
-	}
-
-	return nullptr;
+	auto itr = m_entries.find(componentID);
+	return itr != m_entries.end() ? &itr->second : nullptr;
 }
 

--- a/dDatabase/Tables/CDPhysicsComponentTable.h
+++ b/dDatabase/Tables/CDPhysicsComponentTable.h
@@ -23,12 +23,11 @@ struct CDPhysicsComponent {
 
 class CDPhysicsComponentTable : public CDTable<CDPhysicsComponentTable> {
 public:
-	CDPhysicsComponentTable();
-	~CDPhysicsComponentTable();
+	void LoadValuesFromDatabase();
 
 	static const std::string GetTableName() { return "PhysicsComponent"; };
 	CDPhysicsComponent* GetByID(unsigned int componentID);
 
 private:
-	std::map<unsigned int, CDPhysicsComponent*> m_entries;
+	std::map<unsigned int, CDPhysicsComponent> m_entries;
 };

--- a/dDatabase/Tables/CDPropertyEntranceComponentTable.cpp
+++ b/dDatabase/Tables/CDPropertyEntranceComponentTable.cpp
@@ -1,7 +1,6 @@
-
 #include "CDPropertyEntranceComponentTable.h"
 
-CDPropertyEntranceComponentTable::CDPropertyEntranceComponentTable() {
+void CDPropertyEntranceComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	size_t size = 0;

--- a/dDatabase/Tables/CDPropertyEntranceComponentTable.h
+++ b/dDatabase/Tables/CDPropertyEntranceComponentTable.h
@@ -11,12 +11,12 @@ struct CDPropertyEntranceComponent {
 
 class CDPropertyEntranceComponentTable : public CDTable<CDPropertyEntranceComponentTable> {
 public:
-	CDPropertyEntranceComponentTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	CDPropertyEntranceComponent GetByID(uint32_t id);
 
 	// Gets all the entries in the table
-	[[nodiscard]] std::vector<CDPropertyEntranceComponent> GetEntries() const { return entries; }
+	[[nodiscard]] const std::vector<CDPropertyEntranceComponent>& GetEntries() const { return entries; }
 private:
 	std::vector<CDPropertyEntranceComponent> entries{};
 	CDPropertyEntranceComponent defaultEntry{};

--- a/dDatabase/Tables/CDPropertyTemplateTable.cpp
+++ b/dDatabase/Tables/CDPropertyTemplateTable.cpp
@@ -1,6 +1,6 @@
 #include "CDPropertyTemplateTable.h"
 
-CDPropertyTemplateTable::CDPropertyTemplateTable() {
+void CDPropertyTemplateTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	size_t size = 0;

--- a/dDatabase/Tables/CDPropertyTemplateTable.h
+++ b/dDatabase/Tables/CDPropertyTemplateTable.h
@@ -10,7 +10,7 @@ struct CDPropertyTemplate {
 
 class CDPropertyTemplateTable : public CDTable<CDPropertyTemplateTable> {
 public:
-	CDPropertyTemplateTable();
+	void LoadValuesFromDatabase();
 
 	static const std::string GetTableName() { return "PropertyTemplate"; };
 	CDPropertyTemplate GetByMapID(uint32_t mapID);

--- a/dDatabase/Tables/CDProximityMonitorComponentTable.cpp
+++ b/dDatabase/Tables/CDProximityMonitorComponentTable.cpp
@@ -1,7 +1,6 @@
 #include "CDProximityMonitorComponentTable.h"
 
-//! Constructor
-CDProximityMonitorComponentTable::CDProximityMonitorComponentTable(void) {
+void CDProximityMonitorComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -33,7 +32,6 @@ CDProximityMonitorComponentTable::CDProximityMonitorComponentTable(void) {
 	tableData.finalize();
 }
 
-//! Queries the table with a custom "where" clause
 std::vector<CDProximityMonitorComponent> CDProximityMonitorComponentTable::Query(std::function<bool(CDProximityMonitorComponent)> predicate) {
 
 	std::vector<CDProximityMonitorComponent> data = cpplinq::from(this->entries)
@@ -43,8 +41,7 @@ std::vector<CDProximityMonitorComponent> CDProximityMonitorComponentTable::Query
 	return data;
 }
 
-//! Gets all the entries in the table
-std::vector<CDProximityMonitorComponent> CDProximityMonitorComponentTable::GetEntries(void) const {
+const std::vector<CDProximityMonitorComponent>& CDProximityMonitorComponentTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDProximityMonitorComponentTable.h
+++ b/dDatabase/Tables/CDProximityMonitorComponentTable.h
@@ -15,9 +15,9 @@ private:
 	std::vector<CDProximityMonitorComponent> entries;
 
 public:
-	CDProximityMonitorComponentTable(void);
+	void LoadValuesFromDatabase();
 	//! Queries the table with a custom "where" clause
 	std::vector<CDProximityMonitorComponent> Query(std::function<bool(CDProximityMonitorComponent)> predicate);
 
-	std::vector<CDProximityMonitorComponent> GetEntries(void) const;
+	const std::vector<CDProximityMonitorComponent>& GetEntries() const;
 };

--- a/dDatabase/Tables/CDRailActivatorComponent.cpp
+++ b/dDatabase/Tables/CDRailActivatorComponent.cpp
@@ -1,7 +1,7 @@
 #include "CDRailActivatorComponent.h"
 #include "GeneralUtils.h"
 
-CDRailActivatorComponentTable::CDRailActivatorComponentTable() {
+void CDRailActivatorComponentTable::LoadValuesFromDatabase() {
 	auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM RailActivatorComponent;");
 	while (!tableData.eof()) {
 		CDRailActivatorComponent entry;
@@ -52,7 +52,7 @@ CDRailActivatorComponent CDRailActivatorComponentTable::GetEntryByID(int32_t id)
 	return {};
 }
 
-std::vector<CDRailActivatorComponent> CDRailActivatorComponentTable::GetEntries() const {
+const std::vector<CDRailActivatorComponent>& CDRailActivatorComponentTable::GetEntries() const {
 	return m_Entries;
 }
 

--- a/dDatabase/Tables/CDRailActivatorComponent.h
+++ b/dDatabase/Tables/CDRailActivatorComponent.h
@@ -22,10 +22,10 @@ struct CDRailActivatorComponent {
 
 class CDRailActivatorComponentTable : public CDTable<CDRailActivatorComponentTable> {
 public:
-	CDRailActivatorComponentTable();
+	void LoadValuesFromDatabase();
 	static const std::string GetTableName() { return "RailActivatorComponent"; };
 	[[nodiscard]] CDRailActivatorComponent GetEntryByID(int32_t id) const;
-	[[nodiscard]] std::vector<CDRailActivatorComponent> GetEntries() const;
+	[[nodiscard]] const std::vector<CDRailActivatorComponent>& GetEntries() const;
 private:
 	static std::pair<uint32_t, std::u16string> EffectPairFromString(std::string& str);
 	std::vector<CDRailActivatorComponent> m_Entries{};

--- a/dDatabase/Tables/CDRarityTableTable.cpp
+++ b/dDatabase/Tables/CDRarityTableTable.cpp
@@ -1,7 +1,6 @@
 #include "CDRarityTableTable.h"
 
-//! Constructor
-CDRarityTableTable::CDRarityTableTable(void) {
+void CDRarityTableTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -44,7 +43,7 @@ std::vector<CDRarityTable> CDRarityTableTable::Query(std::function<bool(CDRarity
 }
 
 //! Gets all the entries in the table
-const std::vector<CDRarityTable>& CDRarityTableTable::GetEntries(void) const {
+const std::vector<CDRarityTable>& CDRarityTableTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDRarityTableTable.cpp
+++ b/dDatabase/Tables/CDRarityTableTable.cpp
@@ -17,33 +17,18 @@ void CDRarityTableTable::LoadValuesFromDatabase() {
 	this->entries.reserve(size);
 
 	// Now get the data
-	auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM RarityTable");
+	auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM RarityTable order by randmax desc;");
 	while (!tableData.eof()) {
+		uint32_t rarityTableIndex = tableData.getIntField("RarityTableIndex", -1);
+
 		CDRarityTable entry;
-		entry.id = tableData.getIntField("id", -1);
 		entry.randmax = tableData.getFloatField("randmax", -1);
 		entry.rarity = tableData.getIntField("rarity", -1);
-		entry.RarityTableIndex = tableData.getIntField("RarityTableIndex", -1);
-
-		this->entries.push_back(entry);
+		entries[rarityTableIndex].push_back(entry);
 		tableData.nextRow();
 	}
-
-	tableData.finalize();
 }
 
-//! Queries the table with a custom "where" clause
-std::vector<CDRarityTable> CDRarityTableTable::Query(std::function<bool(CDRarityTable)> predicate) {
-
-	std::vector<CDRarityTable> data = cpplinq::from(this->entries)
-		>> cpplinq::where(predicate)
-		>> cpplinq::to_vector();
-
-	return data;
+const std::vector<CDRarityTable>& CDRarityTableTable::GetRarityTable(uint32_t id) {
+	return entries[id];
 }
-
-//! Gets all the entries in the table
-const std::vector<CDRarityTable>& CDRarityTableTable::GetEntries() const {
-	return this->entries;
-}
-

--- a/dDatabase/Tables/CDRarityTableTable.h
+++ b/dDatabase/Tables/CDRarityTableTable.h
@@ -31,7 +31,7 @@ private:
 	std::vector<CDRarityTable> entries;
 
 public:
-	CDRarityTableTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDRarityTable> Query(std::function<bool(CDRarityTable)> predicate);
 

--- a/dDatabase/Tables/CDRarityTableTable.h
+++ b/dDatabase/Tables/CDRarityTableTable.h
@@ -4,37 +4,20 @@
 #include "CDTable.h"
 
 struct CDRarityTable {
-	unsigned int id;
 	float randmax;
 	unsigned int rarity;
-	unsigned int RarityTableIndex;
-
-	friend bool operator> (const CDRarityTable& c1, const CDRarityTable& c2) {
-		return c1.rarity > c2.rarity;
-	}
-
-	friend bool operator>= (const CDRarityTable& c1, const CDRarityTable& c2) {
-		return c1.rarity >= c2.rarity;
-	}
-
-	friend bool operator< (const CDRarityTable& c1, const CDRarityTable& c2) {
-		return c1.rarity < c2.rarity;
-	}
-
-	friend bool operator<= (const CDRarityTable& c1, const CDRarityTable& c2) {
-		return c1.rarity <= c2.rarity;
-	}
 };
+
+typedef std::vector<CDRarityTable> RarityTable;
 
 class CDRarityTableTable : public CDTable<CDRarityTableTable> {
 private:
-	std::vector<CDRarityTable> entries;
+	typedef uint32_t RarityTableIndex;
+	std::unordered_map<RarityTableIndex, std::vector<CDRarityTable>> entries;
 
 public:
 	void LoadValuesFromDatabase();
-	// Queries the table with a custom "where" clause
-	std::vector<CDRarityTable> Query(std::function<bool(CDRarityTable)> predicate);
 
-	const std::vector<CDRarityTable>& GetEntries() const;
+	const std::vector<CDRarityTable>& GetRarityTable(uint32_t predicate);
 };
 

--- a/dDatabase/Tables/CDRebuildComponentTable.cpp
+++ b/dDatabase/Tables/CDRebuildComponentTable.cpp
@@ -1,7 +1,6 @@
 #include "CDRebuildComponentTable.h"
 
-//! Constructor
-CDRebuildComponentTable::CDRebuildComponentTable(void) {
+void CDRebuildComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -39,7 +38,6 @@ CDRebuildComponentTable::CDRebuildComponentTable(void) {
 	tableData.finalize();
 }
 
-//! Queries the table with a custom "where" clause
 std::vector<CDRebuildComponent> CDRebuildComponentTable::Query(std::function<bool(CDRebuildComponent)> predicate) {
 
 	std::vector<CDRebuildComponent> data = cpplinq::from(this->entries)
@@ -49,8 +47,7 @@ std::vector<CDRebuildComponent> CDRebuildComponentTable::Query(std::function<boo
 	return data;
 }
 
-//! Gets all the entries in the table
-std::vector<CDRebuildComponent> CDRebuildComponentTable::GetEntries(void) const {
+const std::vector<CDRebuildComponent>& CDRebuildComponentTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDRebuildComponentTable.h
+++ b/dDatabase/Tables/CDRebuildComponentTable.h
@@ -21,10 +21,10 @@ private:
 	std::vector<CDRebuildComponent> entries;
 
 public:
-	CDRebuildComponentTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDRebuildComponent> Query(std::function<bool(CDRebuildComponent)> predicate);
 
-	std::vector<CDRebuildComponent> GetEntries() const;
+	const std::vector<CDRebuildComponent>& GetEntries() const;
 };
 

--- a/dDatabase/Tables/CDRewardsTable.cpp
+++ b/dDatabase/Tables/CDRewardsTable.cpp
@@ -1,35 +1,27 @@
 #include "CDRewardsTable.h"
 
-CDRewardsTable::CDRewardsTable(void) {
+void CDRewardsTable::LoadValuesFromDatabase() {
 	auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM Rewards");
 	while (!tableData.eof()) {
-		CDRewards* entry = new CDRewards();
-		entry->id = tableData.getIntField("id", -1);
-		entry->levelID = tableData.getIntField("LevelID", -1);
-		entry->missionID = tableData.getIntField("MissionID", -1);
-		entry->rewardType = tableData.getIntField("RewardType", -1);
-		entry->value = tableData.getIntField("value", -1);
-		entry->count = tableData.getIntField("count", -1);
+		CDRewards entry;
+		entry.id = tableData.getIntField("id", -1);
+		entry.levelID = tableData.getIntField("LevelID", -1);
+		entry.missionID = tableData.getIntField("MissionID", -1);
+		entry.rewardType = tableData.getIntField("RewardType", -1);
+		entry.value = tableData.getIntField("value", -1);
+		entry.count = tableData.getIntField("count", -1);
 
-		m_entries.insert(std::make_pair(entry->id, entry));
+		m_entries.insert(std::make_pair(entry.id, entry));
 		tableData.nextRow();
 	}
 
 	tableData.finalize();
 }
 
-CDRewardsTable::~CDRewardsTable(void) {
-	for (auto e : m_entries) {
-		if (e.second) delete e.second;
-	}
-
-	m_entries.clear();
-}
-
-std::vector<CDRewards*> CDRewardsTable::GetByLevelID(uint32_t levelID) {
-	std::vector<CDRewards*> result{};
+std::vector<CDRewards> CDRewardsTable::GetByLevelID(uint32_t levelID) {
+	std::vector<CDRewards> result{};
 	for (const auto& e : m_entries) {
-		if (e.second->levelID == levelID) result.push_back(e.second);
+		if (e.second.levelID == levelID) result.push_back(e.second);
 	}
 
 	return result;

--- a/dDatabase/Tables/CDRewardsTable.h
+++ b/dDatabase/Tables/CDRewardsTable.h
@@ -13,12 +13,11 @@ struct CDRewards {
 
 class CDRewardsTable : public CDTable<CDRewardsTable> {
 public:
-	CDRewardsTable();
-	~CDRewardsTable();
+	void LoadValuesFromDatabase();
 
 	static const std::string GetTableName() { return "Rewards"; };
-	std::vector<CDRewards*> GetByLevelID(uint32_t levelID);
+	std::vector<CDRewards> GetByLevelID(uint32_t levelID);
 
 private:
-	std::map<uint32_t, CDRewards*> m_entries;
+	std::map<uint32_t, CDRewards> m_entries;
 };

--- a/dDatabase/Tables/CDScriptComponentTable.cpp
+++ b/dDatabase/Tables/CDScriptComponentTable.cpp
@@ -1,7 +1,6 @@
 #include "CDScriptComponentTable.h"
 
-//! Constructor
-CDScriptComponentTable::CDScriptComponentTable(void) {
+void CDScriptComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;

--- a/dDatabase/Tables/CDScriptComponentTable.h
+++ b/dDatabase/Tables/CDScriptComponentTable.h
@@ -15,7 +15,7 @@ private:
 	CDScriptComponent m_ToReturnWhenNoneFound;
 
 public:
-	CDScriptComponentTable();
+	void LoadValuesFromDatabase();
 	// Gets an entry by scriptID
 	const CDScriptComponent& GetByID(unsigned int id);
 };

--- a/dDatabase/Tables/CDSkillBehaviorTable.cpp
+++ b/dDatabase/Tables/CDSkillBehaviorTable.cpp
@@ -1,8 +1,6 @@
 #include "CDSkillBehaviorTable.h"
-//#include "Logger.hpp"
 
-//! Constructor
-CDSkillBehaviorTable::CDSkillBehaviorTable(void) {
+void CDSkillBehaviorTable::LoadValuesFromDatabase() {
 	m_empty = CDSkillBehavior();
 
 	// First, get the size of the table
@@ -51,13 +49,6 @@ CDSkillBehaviorTable::CDSkillBehaviorTable(void) {
 	tableData.finalize();
 }
 
-//! Queries the table with a custom "where" clause
-std::vector<CDSkillBehavior> CDSkillBehaviorTable::Query(std::function<bool(CDSkillBehavior)> predicate) {
-	std::vector<CDSkillBehavior> data; //So MSVC shuts up
-	return data;
-}
-
-//! Gets an entry by ID
 const CDSkillBehavior& CDSkillBehaviorTable::GetSkillByID(unsigned int skillID) {
 	std::map<unsigned int, CDSkillBehavior>::iterator it = this->entries.find(skillID);
 	if (it != this->entries.end()) {

--- a/dDatabase/Tables/CDSkillBehaviorTable.h
+++ b/dDatabase/Tables/CDSkillBehaviorTable.h
@@ -31,9 +31,7 @@ private:
 	CDSkillBehavior m_empty;
 
 public:
-	CDSkillBehaviorTable();
-	// Queries the table with a custom "where" clause
-	std::vector<CDSkillBehavior> Query(std::function<bool(CDSkillBehavior)> predicate);
+	void LoadValuesFromDatabase();
 
 	// Gets an entry by skillID
 	const CDSkillBehavior& GetSkillByID(unsigned int skillID);

--- a/dDatabase/Tables/CDVendorComponentTable.cpp
+++ b/dDatabase/Tables/CDVendorComponentTable.cpp
@@ -1,7 +1,6 @@
 #include "CDVendorComponentTable.h"
 
-//! Constructor
-CDVendorComponentTable::CDVendorComponentTable(void) {
+void CDVendorComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;
@@ -45,7 +44,7 @@ std::vector<CDVendorComponent> CDVendorComponentTable::Query(std::function<bool(
 }
 
 //! Gets all the entries in the table
-std::vector<CDVendorComponent> CDVendorComponentTable::GetEntries(void) const {
+const std::vector<CDVendorComponent>& CDVendorComponentTable::GetEntries() const {
 	return this->entries;
 }
 

--- a/dDatabase/Tables/CDVendorComponentTable.h
+++ b/dDatabase/Tables/CDVendorComponentTable.h
@@ -16,10 +16,10 @@ private:
 	std::vector<CDVendorComponent> entries;
 
 public:
-	CDVendorComponentTable();
+	void LoadValuesFromDatabase();
 	// Queries the table with a custom "where" clause
 	std::vector<CDVendorComponent> Query(std::function<bool(CDVendorComponent)> predicate);
 
-	std::vector<CDVendorComponent> GetEntries(void) const;
+	const std::vector<CDVendorComponent>& GetEntries(void) const;
 };
 

--- a/dDatabase/Tables/CDZoneTableTable.cpp
+++ b/dDatabase/Tables/CDZoneTableTable.cpp
@@ -1,7 +1,6 @@
 #include "CDZoneTableTable.h"
 
-//! Constructor
-CDZoneTableTable::CDZoneTableTable(void) {
+void CDZoneTableTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
 	unsigned int size = 0;

--- a/dDatabase/Tables/CDZoneTableTable.h
+++ b/dDatabase/Tables/CDZoneTableTable.h
@@ -38,7 +38,7 @@ private:
 	std::map<unsigned int, CDZoneTable> m_Entries;
 
 public:
-	CDZoneTableTable();
+	void LoadValuesFromDatabase();
 
 	// Queries the table with a zoneID to find.
 	const CDZoneTable* Query(unsigned int zoneID);

--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -372,6 +372,7 @@ void Entity::Initialize() {
 					comp->SetIsSmashable(destCompData[0].isSmashable);
 
 					comp->SetLootMatrixID(destCompData[0].LootMatrixIndex);
+					Loot::CacheMatrix(destCompData[0].LootMatrixIndex);
 
 					// Now get currency information
 					uint32_t npcMinLevel = destCompData[0].level;

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -763,18 +763,18 @@ void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType
 
 					auto* member = Game::entityManager->GetEntity(specificOwner);
 
-					if (member) LootGenerator::Instance().DropLoot(member, m_Parent, lootMatrixId, GetMinCoins(), GetMaxCoins());
+					if (member) Loot::DropLoot(member, m_Parent, lootMatrixId, GetMinCoins(), GetMaxCoins());
 				} else {
 					for (const auto memberId : team->members) { // Free for all
 						auto* member = Game::entityManager->GetEntity(memberId);
 
 						if (member == nullptr) continue;
 
-						LootGenerator::Instance().DropLoot(member, m_Parent, lootMatrixId, GetMinCoins(), GetMaxCoins());
+						Loot::DropLoot(member, m_Parent, lootMatrixId, GetMinCoins(), GetMaxCoins());
 					}
 				}
 			} else { // drop loot for non team user
-				LootGenerator::Instance().DropLoot(owner, m_Parent, GetLootMatrixID(), GetMinCoins(), GetMaxCoins());
+				Loot::DropLoot(owner, m_Parent, GetLootMatrixID(), GetMinCoins(), GetMaxCoins());
 			}
 		}
 	} else {
@@ -792,7 +792,7 @@ void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType
 
 				coinsTotal -= coinsToLose;
 
-				LootGenerator::Instance().DropLoot(m_Parent, m_Parent, -1, coinsToLose, coinsToLose);
+				Loot::DropLoot(m_Parent, m_Parent, -1, coinsToLose, coinsToLose);
 				character->SetCoins(coinsTotal, eLootSourceType::PICKUP);
 			}
 		}

--- a/dGame/dComponents/LevelProgressionComponent.cpp
+++ b/dGame/dComponents/LevelProgressionComponent.cpp
@@ -56,19 +56,19 @@ void LevelProgressionComponent::HandleLevelUp() {
 	// Tell the client we beginning to send level rewards.
 	if (rewardingItem) GameMessages::NotifyLevelRewards(m_Parent->GetObjectID(), m_Parent->GetSystemAddress(), m_Level, rewardingItem);
 
-	for (auto* reward : rewards) {
-		switch (reward->rewardType) {
+	for (const auto& reward : rewards) {
+		switch (reward.rewardType) {
 		case 0:
-			inventoryComponent->AddItem(reward->value, reward->count, eLootSourceType::LEVEL_REWARD);
+			inventoryComponent->AddItem(reward.value, reward.count, eLootSourceType::LEVEL_REWARD);
 			break;
 		case 4:
 		{
 			auto* items = inventoryComponent->GetInventory(eInventoryType::ITEMS);
-			items->SetSize(items->GetSize() + reward->value);
+			items->SetSize(items->GetSize() + reward.value);
 		}
 		break;
 		case 9:
-			SetSpeedBase(static_cast<float>(reward->value) );
+			SetSpeedBase(static_cast<float>(reward.value) );
 			controllablePhysicsComponent->SetSpeedMultiplier(GetSpeedBase() / 500.0f);
 			break;
 		case 11:

--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -379,7 +379,7 @@ void RacingControlComponent::HandleMessageBoxResponse(Entity* player, int32_t bu
 		}
 
         const auto score = playersRating * 10 + data->finished;
-		LootGenerator::Instance().GiveActivityLoot(player, m_Parent, m_ActivityID, score);
+		Loot::GiveActivityLoot(player, m_Parent, m_ActivityID, score);
 
 		// Giving rewards
 		GameMessages::SendNotifyRacingClient(

--- a/dGame/dComponents/RebuildComponent.cpp
+++ b/dGame/dComponents/RebuildComponent.cpp
@@ -486,7 +486,7 @@ void RebuildComponent::CompleteRebuild(Entity* user) {
 			auto* missionComponent = builder->GetComponent<MissionComponent>();
 			if (missionComponent) missionComponent->Progress(eMissionTaskType::ACTIVITY, m_ActivityId);
 		}
-		LootGenerator::Instance().DropActivityLoot(builder, m_Parent, m_ActivityId, 1);
+		Loot::DropActivityLoot(builder, m_Parent, m_ActivityId, 1);
 	}
 
 	// Notify scripts

--- a/dGame/dComponents/ScriptedActivityComponent.cpp
+++ b/dGame/dComponents/ScriptedActivityComponent.cpp
@@ -576,7 +576,7 @@ void ActivityInstance::RewardParticipant(Entity* participant) {
 			maxCoins = currencyTable[0].maxvalue;
 		}
 
-		LootGenerator::Instance().DropLoot(participant, m_Parent, activityRewards[0].LootMatrixIndex, minCoins, maxCoins);
+		Loot::DropLoot(participant, m_Parent, activityRewards[0].LootMatrixIndex, minCoins, maxCoins);
 	}
 }
 

--- a/dGame/dComponents/VendorComponent.cpp
+++ b/dGame/dComponents/VendorComponent.cpp
@@ -65,7 +65,7 @@ void VendorComponent::RefreshInventory(bool isCreation) {
 	}
 	m_Inventory.clear();
 	auto* lootMatrixTable = CDClientManager::Instance().GetTable<CDLootMatrixTable>();
-	std::vector<CDLootMatrix> lootMatrices = lootMatrixTable->Query([=](CDLootMatrix entry) { return (entry.LootMatrixIndex == m_LootMatrixID); });
+	const auto& lootMatrices = lootMatrixTable->GetMatrix(m_LootMatrixID);
 
 	if (lootMatrices.empty()) return;
 	// Done with lootMatrix table
@@ -73,8 +73,7 @@ void VendorComponent::RefreshInventory(bool isCreation) {
 	auto* lootTableTable = CDClientManager::Instance().GetTable<CDLootTableTable>();
 
 	for (const auto& lootMatrix : lootMatrices) {
-		int lootTableID = lootMatrix.LootTableIndex;
-		std::vector<CDLootTable> vendorItems = lootTableTable->Query([=](CDLootTable entry) { return (entry.LootTableIndex == lootTableID); });
+		auto vendorItems = lootTableTable->GetTable(lootMatrix.LootTableIndex);
 		if (lootMatrix.maxToDrop == 0 || lootMatrix.minToDrop == 0) {
 			for (CDLootTable item : vendorItems) {
 				m_Inventory.insert({ item.itemid, item.sortPriority });

--- a/dGame/dInventory/Item.cpp
+++ b/dGame/dInventory/Item.cpp
@@ -319,7 +319,7 @@ void Item::UseNonEquip(Item* item) {
 					// Roll the loot for all the packages then see if it all fits.  If it fits, give it to the player, otherwise don't.
 					std::unordered_map<LOT, int32_t> rolledLoot{};
 					for (auto& pack : packages) {
-						auto thisPackage = LootGenerator::Instance().RollLootMatrix(entityParent, pack.LootMatrixIndex);
+						auto thisPackage = Loot::RollLootMatrix(entityParent, pack.LootMatrixIndex);
 						for (auto& loot : thisPackage) {
 							// If we already rolled this lot, add it to the existing one, otherwise create a new entry.
 							auto existingLoot = rolledLoot.find(loot.first);
@@ -331,7 +331,7 @@ void Item::UseNonEquip(Item* item) {
 						}
 					}
 					if (playerInventoryComponent->HasSpaceForLoot(rolledLoot)) {
-						LootGenerator::Instance().GiveLoot(playerInventoryComponent->GetParent(), rolledLoot, eLootSourceType::CONSUMPTION);
+						Loot::GiveLoot(playerInventoryComponent->GetParent(), rolledLoot, eLootSourceType::CONSUMPTION);
 						item->SetCount(item->GetCount() - 1);
 					} else {
 						success = false;

--- a/dGame/dUtilities/Loot.h
+++ b/dGame/dUtilities/Loot.h
@@ -2,61 +2,23 @@
 
 #include "dCommonVars.h"
 #include <unordered_map>
-#include "Singleton.h"
-#include <vector>
 
 class Entity;
 
-struct RarityTableEntry {
-	uint32_t rarity;
-	float randMax;
-};
-
-typedef std::vector<RarityTableEntry> RarityTable;
-
-struct LootMatrixEntry {
-	uint32_t lootTableIndex;
-	uint32_t rarityTableIndex;
-	float percent;
-	uint32_t minDrop;
-	uint32_t maxDrop;
-};
-
-typedef std::vector<LootMatrixEntry> LootMatrix;
-
-struct LootTableEntry {
-	LOT itemID;
-	bool isMissionDrop;
-};
-
-typedef std::vector<LootTableEntry> LootTable;
-
-// used for glue code with Entity and Player classes
 namespace Loot {
 	struct Info {
-		LWOOBJID id;
-		LOT lot;
-		uint32_t count;
+		LWOOBJID id = 0;
+		LOT lot = 0;
+		uint32_t count = 0;
 	};
-}
-
-
-class LootGenerator : public Singleton<LootGenerator> {
-public:
-	LootGenerator();
 
 	std::unordered_map<LOT, int32_t> RollLootMatrix(Entity* player, uint32_t matrixIndex);
 	std::unordered_map<LOT, int32_t> RollLootMatrix(uint32_t matrixIndex);
+	void CacheMatrix(const uint32_t matrixIndex);
 	void GiveLoot(Entity* player, uint32_t matrixIndex, eLootSourceType lootSourceType = eLootSourceType::NONE);
 	void GiveLoot(Entity* player, std::unordered_map<LOT, int32_t>& result, eLootSourceType lootSourceType = eLootSourceType::NONE);
 	void GiveActivityLoot(Entity* player, Entity* source, uint32_t activityID, int32_t rating = 0);
 	void DropLoot(Entity* player, Entity* killedObject, uint32_t matrixIndex, uint32_t minCoins, uint32_t maxCoins);
 	void DropLoot(Entity* player, Entity* killedObject, std::unordered_map<LOT, int32_t>& result, uint32_t minCoins, uint32_t maxCoins);
 	void DropActivityLoot(Entity* player, Entity* source, uint32_t activityID, int32_t rating = 0);
-
-private:
-	std::unordered_map<uint32_t, uint8_t> m_ItemRarities;
-	std::unordered_map<uint32_t, RarityTable> m_RarityTables;
-	std::unordered_map<uint32_t, LootMatrix> m_LootMatrices;
-	std::unordered_map<uint32_t, LootTable> m_LootTables;
 };

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -1790,7 +1790,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 		for (uint32_t i = 0; i < loops; i++) {
 			while (true) {
-				auto lootRoll = LootGenerator::Instance().RollLootMatrix(lootMatrixIndex);
+				auto lootRoll = Loot::RollLootMatrix(lootMatrixIndex);
 				totalRuns += 1;
 				bool doBreak = false;
 				for (const auto& kv : lootRoll) {

--- a/dScripts/02_server/Enemy/General/TreasureChestDragonServer.cpp
+++ b/dScripts/02_server/Enemy/General/TreasureChestDragonServer.cpp
@@ -33,10 +33,10 @@ void TreasureChestDragonServer::OnUse(Entity* self, Entity* user) {
 
 			if (memberObject == nullptr) continue;
 
-			LootGenerator::Instance().DropActivityLoot(memberObject, self, scriptedActivityComponent->GetActivityID(), rating);
+			Loot::DropActivityLoot(memberObject, self, scriptedActivityComponent->GetActivityID(), rating);
 		}
 	} else {
-		LootGenerator::Instance().DropActivityLoot(user, self, scriptedActivityComponent->GetActivityID(), rating);
+		Loot::DropActivityLoot(user, self, scriptedActivityComponent->GetActivityID(), rating);
 	}
 
 	self->Smash(self->GetObjectID());

--- a/dScripts/02_server/Equipment/BootyDigServer.cpp
+++ b/dScripts/02_server/Equipment/BootyDigServer.cpp
@@ -45,7 +45,7 @@ BootyDigServer::OnFireEventServerSide(Entity* self, Entity* sender, std::string 
 				if (renderComponent != nullptr)
 					renderComponent->PlayEffect(7730, u"cast", "bootyshine");
 
-				LootGenerator::Instance().DropLoot(player, self, 231, 75, 75);
+				Loot::DropLoot(player, self, 231, 75, 75);
 			}
 		}
 	} else if (args == "ChestDead") {

--- a/dScripts/02_server/Map/General/BaseInteractDropLootServer.cpp
+++ b/dScripts/02_server/Map/General/BaseInteractDropLootServer.cpp
@@ -22,7 +22,7 @@ void BaseInteractDropLootServer::BaseUse(Entity* self, Entity* user) {
 
 	self->SetNetworkVar(u"bInUse", true);
 
-	LootGenerator::Instance().DropLoot(user, self, lootMatrix, 0, 0);
+	Loot::DropLoot(user, self, lootMatrix, 0, 0);
 
 	self->AddCallbackTimer(cooldownTime, [this, self]() {
 		self->SetNetworkVar(u"bInUse", false);

--- a/dScripts/02_server/Map/General/GrowingFlower.cpp
+++ b/dScripts/02_server/Map/General/GrowingFlower.cpp
@@ -13,7 +13,7 @@ void GrowingFlower::OnSkillEventFired(Entity* self, Entity* target, const std::s
 		const auto mission1 = self->GetVar<int32_t>(u"missionID");
 		const auto mission2 = self->GetVar<int32_t>(u"missionID2");
 
-		LootGenerator::Instance().DropActivityLoot(target, self, self->GetLOT(), 0);
+		Loot::DropActivityLoot(target, self, self->GetLOT(), 0);
 
 		auto* missionComponent = target->GetComponent<MissionComponent>();
 		if (missionComponent != nullptr) {

--- a/dScripts/02_server/Map/General/WishingWellServer.cpp
+++ b/dScripts/02_server/Map/General/WishingWellServer.cpp
@@ -21,7 +21,7 @@ void WishingWellServer::OnUse(Entity* self, Entity* user) {
 		GameMessages::SendPlayNDAudioEmitter(self, user->GetSystemAddress(), audio);
 	}
 
-	LootGenerator::Instance().DropActivityLoot(
+	Loot::DropActivityLoot(
 		user,
 		self,
 		static_cast<uint32_t>(scriptedActivity->GetActivityID()),

--- a/dScripts/02_server/Map/VE/VeMissionConsole.cpp
+++ b/dScripts/02_server/Map/VE/VeMissionConsole.cpp
@@ -6,7 +6,7 @@
 #include "eTerminateType.h"
 
 void VeMissionConsole::OnUse(Entity* self, Entity* user) {
-	LootGenerator::Instance().DropActivityLoot(user, self, 12551);
+	Loot::DropActivityLoot(user, self, 12551);
 
 	auto* inventoryComponent = user->GetComponent<InventoryComponent>();
 	if (inventoryComponent != nullptr) {

--- a/dScripts/02_server/Map/njhub/NjDragonEmblemChestServer.cpp
+++ b/dScripts/02_server/Map/njhub/NjDragonEmblemChestServer.cpp
@@ -14,6 +14,6 @@ void NjDragonEmblemChestServer::OnUse(Entity* self, Entity* user) {
 
 	auto* destroyable = self->GetComponent<DestroyableComponent>();
 	if (destroyable != nullptr) {
-		LootGenerator::Instance().DropLoot(user, self, destroyable->GetLootMatrixID(), 0, 0);
+		Loot::DropLoot(user, self, destroyable->GetLootMatrixID(), 0, 0);
 	}
 }

--- a/dScripts/02_server/Minigame/General/MinigameTreasureChestServer.cpp
+++ b/dScripts/02_server/Minigame/General/MinigameTreasureChestServer.cpp
@@ -27,7 +27,7 @@ void MinigameTreasureChestServer::OnUse(Entity* self, Entity* user) {
 
 				if (self->GetLOT() == frakjawChestId) activityRating = team->members.size();
 
-				LootGenerator::Instance().DropActivityLoot(teamMember, self, sac->GetActivityID(), activityRating);
+				Loot::DropActivityLoot(teamMember, self, sac->GetActivityID(), activityRating);
 			}
 		}
 	} else {
@@ -35,7 +35,7 @@ void MinigameTreasureChestServer::OnUse(Entity* self, Entity* user) {
 
 		if (self->GetLOT() == frakjawChestId) activityRating = 1;
 
-		LootGenerator::Instance().DropActivityLoot(user, self, sac->GetActivityID(), activityRating);
+		Loot::DropActivityLoot(user, self, sac->GetActivityID(), activityRating);
 	}
 
 	sac->PlayerRemove(user->GetObjectID());

--- a/dScripts/ActivityManager.cpp
+++ b/dScripts/ActivityManager.cpp
@@ -71,7 +71,7 @@ void ActivityManager::StopActivity(Entity* self, const LWOOBJID playerID, const 
 		SetActivityValue(self, playerID, 1, value1);
 		SetActivityValue(self, playerID, 2, value2);
 
-		LootGenerator::Instance().GiveActivityLoot(player, self, gameID, CalculateActivityRating(self, playerID));
+		Loot::GiveActivityLoot(player, self, gameID, CalculateActivityRating(self, playerID));
 
 		if (sac != nullptr) {
 			sac->PlayerRemove(player->GetObjectID());

--- a/dScripts/ScriptedPowerupSpawner.cpp
+++ b/dScripts/ScriptedPowerupSpawner.cpp
@@ -29,7 +29,7 @@ void ScriptedPowerupSpawner::OnTimerDone(Entity* self, std::string message) {
 					renderComponent->PlayEffect(0, u"cast", "N_cast");
 				}
 
-				LootGenerator::Instance().DropLoot(owner, self, drops, 0, 0);
+				Loot::DropLoot(owner, self, drops, 0, 0);
 			}
 
 			// Increment the current cycle

--- a/dScripts/ai/AG/AgPicnicBlanket.cpp
+++ b/dScripts/ai/AG/AgPicnicBlanket.cpp
@@ -11,7 +11,7 @@ void AgPicnicBlanket::OnUse(Entity* self, Entity* user) {
 	self->SetVar<bool>(u"active", true);
 
 	auto lootTable = std::unordered_map<LOT, int32_t>{ {935, 3} };
-	LootGenerator::Instance().DropLoot(user, self, lootTable, 0, 0);
+	Loot::DropLoot(user, self, lootTable, 0, 0);
 
 	self->AddCallbackTimer(5.0f, [self]() {
 		self->SetVar<bool>(u"active", false);

--- a/dScripts/ai/MINIGAME/SG_GF/SERVER/SGCannon.cpp
+++ b/dScripts/ai/MINIGAME/SG_GF/SERVER/SGCannon.cpp
@@ -410,7 +410,7 @@ void SGCannon::SpawnNewModel(Entity* self) {
 
 			if (lootMatrix != 0) {
 				std::unordered_map<LOT, int32_t> toDrop = {};
-				toDrop = LootGenerator::Instance().RollLootMatrix(player, lootMatrix);
+				toDrop = Loot::RollLootMatrix(player, lootMatrix);
 
 				for (auto drop : toDrop) {
 					rewardModel->OnFireEventServerSide(self, ModelToBuildEvent, drop.first);
@@ -562,7 +562,7 @@ void SGCannon::StopGame(Entity* self, bool cancel) {
 			missionComponent->Progress(eMissionTaskType::ACTIVITY, m_CannonLot, 0, "", self->GetVar<uint32_t>(TotalScoreVariable));
 		}
 
-		LootGenerator::Instance().GiveActivityLoot(player, self, GetGameID(self), self->GetVar<uint32_t>(TotalScoreVariable));
+		Loot::GiveActivityLoot(player, self, GetGameID(self), self->GetVar<uint32_t>(TotalScoreVariable));
 
 		SaveScore(self, player->GetObjectID(),
 			static_cast<float>(self->GetVar<uint32_t>(TotalScoreVariable)), static_cast<float>(self->GetVar<uint32_t>(MaxStreakVariable)), percentage);

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -212,7 +212,6 @@ int main(int argc, char** argv) {
 
 	ObjectIDManager::Instance()->Initialize();
 	UserManager::Instance()->Initialize();
-	LootGenerator::Instance();
 	Game::chatFilter = new dChatFilter(Game::assetManager->GetResPath().string() + "/chatplus_en_us", bool(std::stoi(Game::config->GetValue("dont_generate_dcf"))));
 
 	Game::server = new dServer(masterIP, ourPort, instanceID, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::World, Game::config, &Game::shouldShutdown, zoneID);


### PR DESCRIPTION
- Remove all excess memory usage
- do not cache components registry
- cache loot matrices on startup of the destroyable component
- convert LootGenerator singleton class to namespace and consolidate Loot namespace definitions
- rework loot cdclient tables to operate closer to how someone would actually use them (basically doing the previous LootGenerator::LootGenerator caching but in those tables)
- Memory usage reduced by 7.5%+ across the board

No actual Loot generation logic was re-written, I strictly focused on removing the double storage.  Same loops, same return storages, same assumptions.  

Tested that a dragon, shooting gallery, vending machine and /rollloot still shows the same metrics as before.  

**Waiting on #1164**
Fixes #274

Because most loot tables and matrices are entities in spawners, smashables or vendors, most of the useful data is cached on world start with very few lookups done post players loading into a world.