### PR TITLE
perf: Behavior Parameter memory savings

### DIFF
--- a/dDatabase/Tables/CDBehaviorParameterTable.cpp
+++ b/dDatabase/Tables/CDBehaviorParameterTable.cpp
@@ -1,26 +1,30 @@
 #include "CDBehaviorParameterTable.h"
 #include "GeneralUtils.h"
 
-CDBehaviorParameterTable::CDBehaviorParameterTable(void) {
+uint64_t GetHash(const uint32_t behaviorID, const uint32_t parameterID) {
+	uint64_t hash = behaviorID;
+	hash <<= 31U;
+	hash |= parameterID;
+
+	return hash;
+}
+
+CDBehaviorParameterTable::CDBehaviorParameterTable() {
 	auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM BehaviorParameter");
-	uint32_t uniqueParameterId = 0;
-	uint64_t hash = 0;
 	while (!tableData.eof()) {
-		CDBehaviorParameter entry;
-		entry.behaviorID = tableData.getIntField("behaviorID", -1);
+		uint32_t behaviorID = tableData.getIntField("behaviorID", -1);
 		auto candidateStringToAdd = std::string(tableData.getStringField("parameterID", ""));
 		auto parameter = m_ParametersList.find(candidateStringToAdd);
+		uint32_t parameterId;
 		if (parameter != m_ParametersList.end()) {
-			entry.parameterID = parameter;
+			parameterId = parameter->second;
 		} else {
-			entry.parameterID = m_ParametersList.insert(std::make_pair(candidateStringToAdd, uniqueParameterId)).first;
-			uniqueParameterId++;
+			parameterId = m_ParametersList.insert(std::make_pair(candidateStringToAdd, m_ParametersList.size())).first->second;
 		}
-		hash = entry.behaviorID;
-		hash = (hash << 31U) | entry.parameterID->second;
-		entry.value = tableData.getFloatField("value", -1.0f);
+		uint64_t hash = GetHash(behaviorID, parameterId);
+		float value = tableData.getFloatField("value", -1.0f);
 
-		m_Entries.insert(std::make_pair(hash, entry));
+		m_Entries.insert(std::make_pair(hash, value));
 
 		tableData.nextRow();
 	}
@@ -30,27 +34,22 @@ CDBehaviorParameterTable::CDBehaviorParameterTable(void) {
 float CDBehaviorParameterTable::GetValue(const uint32_t behaviorID, const std::string& name, const float defaultValue) {
 	auto parameterID = this->m_ParametersList.find(name);
 	if (parameterID == this->m_ParametersList.end()) return defaultValue;
-
-	uint64_t hash = behaviorID;
-
-	hash = (hash << 31U) | parameterID->second;
+	auto hash = GetHash(behaviorID, parameterID->second);
 
 	// Search for specific parameter
-	const auto& it = m_Entries.find(hash);
-	return it != m_Entries.end() ? it->second.value : defaultValue;
+	auto it = m_Entries.find(hash);
+	return it != m_Entries.end() ? it->second : defaultValue;
 }
 
 std::map<std::string, float> CDBehaviorParameterTable::GetParametersByBehaviorID(uint32_t behaviorID) {
 	uint64_t hashBase = behaviorID;
 	std::map<std::string, float> returnInfo;
-	uint64_t hash;
-	for (auto& parameterCandidate : m_ParametersList) {
-		hash = (hashBase << 31U) | parameterCandidate.second;
+	for (auto& [parameterString, parameterId] : m_ParametersList) {
+		uint64_t hash = GetHash(hashBase, parameterId);
 		auto infoCandidate = m_Entries.find(hash);
 		if (infoCandidate != m_Entries.end()) {
-			returnInfo.insert(std::make_pair(infoCandidate->second.parameterID->first, infoCandidate->second.value));
+			returnInfo.insert(std::make_pair(parameterString, infoCandidate->second));
 		}
 	}
 	return returnInfo;
 }
-

--- a/dDatabase/Tables/CDBehaviorParameterTable.h
+++ b/dDatabase/Tables/CDBehaviorParameterTable.h
@@ -12,7 +12,7 @@ private:
 	std::unordered_map<BehaviorParameterHash, BehaviorParameterValue> m_Entries;
 	std::unordered_map<std::string, uint32_t> m_ParametersList;
 public:
-	CDBehaviorParameterTable::CDBehaviorParameterTable();
+	CDBehaviorParameterTable();
 
 	float GetValue(const uint32_t behaviorID, const std::string& name, const float defaultValue = 0);
 

--- a/dDatabase/Tables/CDBehaviorParameterTable.h
+++ b/dDatabase/Tables/CDBehaviorParameterTable.h
@@ -5,18 +5,15 @@
 #include <unordered_map>
 #include <unordered_set>
 
-struct CDBehaviorParameter {
-	unsigned int behaviorID;											//!< The Behavior ID
-	std::unordered_map<std::string, uint32_t>::iterator parameterID;   	//!< The Parameter ID
-	float value;            											//!< The value of the behavior template
-};
-
 class CDBehaviorParameterTable : public CDTable<CDBehaviorParameterTable> {
 private:
-	std::unordered_map<uint64_t, CDBehaviorParameter> m_Entries;
+	typedef uint64_t BehaviorParameterHash;
+	typedef float BehaviorParameterValue;
+	std::unordered_map<BehaviorParameterHash, BehaviorParameterValue> m_Entries;
 	std::unordered_map<std::string, uint32_t> m_ParametersList;
 public:
-	CDBehaviorParameterTable();
+	CDBehaviorParameterTable::CDBehaviorParameterTable();
+
 	float GetValue(const uint32_t behaviorID, const std::string& name, const float defaultValue = 0);
 
 	std::map<std::string, float> GetParametersByBehaviorID(uint32_t behaviorID);


### PR DESCRIPTION
Yeah it turns out we didnt need many of those parameters to be saved in the map.  Saves 3.5MB statically.  Most of the memory usage from the table comes from the sheer size of it.

Tested that 2243 can still cast its skill and stromlings on crux prime can still attack me.