### PR TITLE
fix: read and store the zone transition width properly

### DIFF
--- a/dZoneManager/Zone.cpp
+++ b/dZoneManager/Zone.cpp
@@ -349,7 +349,7 @@ void Zone::LoadSceneTransition(std::istream& file) {
 		uint8_t length;
 		BinaryIO::BinaryRead(file, length);
 		sceneTrans.name = BinaryIO::ReadString(file, length);
-		file.ignore(4);
+		BinaryIO::BinaryRead(file, sceneTrans.width);
 	}
 
 	//BR�THER MAY I HAVE SOME L��PS?

--- a/dZoneManager/Zone.h
+++ b/dZoneManager/Zone.h
@@ -30,6 +30,7 @@ struct SceneTransitionInfo {
 struct SceneTransition {
 	std::string name;
 	std::vector<SceneTransitionInfo> points;
+	float width;
 };
 
 struct MovingPlatformPathWaypoint {


### PR DESCRIPTION
tested that nothing broke