### PR TITLE
perf: Add path height correction on world load

### DIFF
--- a/dNavigation/dNavMesh.cpp
+++ b/dNavigation/dNavMesh.cpp
@@ -143,11 +143,13 @@ float dNavMesh::GetHeightAtPoint(const NiPoint3& location, const float halfExten
 	}
 #endif
 	if (toReturn == 0.0f) {
-		toReturn = location.y;
-	// If we were unable to get the poly height, but the query returned a success, just use the height of the nearest point.
-	// This is what seems to happen anyways and it is better than returning zero.
-	} else if (hasPoly == DT_SUCCESS) {
-		toReturn = nearestPoint[1];
+		// If we were unable to get the poly height, but the query returned a success, just use the height of the nearest point.
+		// This is what seems to happen anyways and it is better than returning zero.
+		if (hasPoly == DT_SUCCESS) {
+			toReturn = nearestPoint[1];
+		} else {
+			toReturn = location.y;
+		}
 	}
 	// If we failed to even find a poly, do not change the height since we have no idea what it should be.
 

--- a/dNavigation/dNavMesh.cpp
+++ b/dNavigation/dNavMesh.cpp
@@ -118,7 +118,7 @@ void dNavMesh::LoadNavmesh() {
 	m_NavMesh = mesh;
 }
 
-float dNavMesh::GetHeightAtPoint(const NiPoint3& location) {
+float dNavMesh::GetHeightAtPoint(const NiPoint3& location, const float halfExtentsHeight) const {
 	if (m_NavMesh == nullptr) {
 		return location.y;
 	}
@@ -130,7 +130,7 @@ float dNavMesh::GetHeightAtPoint(const NiPoint3& location) {
 	pos[2] = location.z;
 
 	dtPolyRef nearestRef = 0;
-	float polyPickExt[3] = { 32.0f, 32.0f, 32.0f };
+	float polyPickExt[3] = { 32.0f, halfExtentsHeight, 32.0f };
 	dtQueryFilter filter{};
 
 	m_NavQuery->findNearestPoly(pos, polyPickExt, &filter, &nearestRef, 0);

--- a/dNavigation/dNavMesh.h
+++ b/dNavigation/dNavMesh.h
@@ -15,7 +15,15 @@ public:
 	dNavMesh(uint32_t zoneId);
 	~dNavMesh();
 
-	float GetHeightAtPoint(const NiPoint3& location);
+	/**
+	 * Get the height at a point
+	 * 
+	 * @param location The location to check for height at. This is the center of the search area.
+	 * @param halfExtentsHeight The half extents height of the search area. This is the distance from the center to the top and bottom of the search area.
+	 * The larger the value of halfExtentsHeight is, the larger the performance cost of the query.
+	 * @return float The height at the point. If the point is not on the navmesh, the height of the point is returned.
+	 */
+	float GetHeightAtPoint(const NiPoint3& location, const float halfExtentsHeight = 32.0f) const;
 	std::vector<NiPoint3> GetPath(const NiPoint3& startPos, const NiPoint3& endPos, float speed = 10.0f);
 
 	class dtNavMesh* GetdtNavMesh() { return m_NavMesh; }

--- a/dZoneManager/CMakeLists.txt
+++ b/dZoneManager/CMakeLists.txt
@@ -3,4 +3,5 @@ set(DZONEMANAGER_SOURCES "dZoneManager.cpp"
 	"Spawner.cpp"
 	"Zone.cpp")
 
-add_library(dZoneManager STATIC ${DZONEMANAGER_SOURCES}) 
+add_library(dZoneManager STATIC ${DZONEMANAGER_SOURCES})
+target_link_libraries(dZoneManager dPhysics) 

--- a/dZoneManager/Zone.cpp
+++ b/dZoneManager/Zone.cpp
@@ -549,8 +549,8 @@ void Zone::LoadPath(std::istream& file) {
 		// the waypoint is located near 0 height, 
 		if (path.pathType == PathType::Movement) {
 			if (dpWorld::Instance().IsLoaded()) {
-				// 1000 should be large enough for every world.
-				waypoint.position.y = dpWorld::Instance().GetNavMesh()->GetHeightAtPoint(waypoint.position, 1000.0f);
+				// 2000 should be large enough for every world.
+				waypoint.position.y = dpWorld::Instance().GetNavMesh()->GetHeightAtPoint(waypoint.position, 2000.0f);
 			}
 		}
 		path.pathWaypoints.push_back(waypoint);

--- a/dZoneManager/Zone.cpp
+++ b/dZoneManager/Zone.cpp
@@ -13,6 +13,7 @@
 #include "CDZoneTableTable.h"
 #include "Spawner.h"
 #include "dZoneManager.h"
+#include "dpWorld.h"
 
 #include "eTriggerCommandType.h"
 #include "eTriggerEventType.h"
@@ -544,10 +545,15 @@ void Zone::LoadPath(std::istream& file) {
 			}
 		}
 
+		// We verify the waypoint heights against the navmesh because in many movement paths,
+		// the waypoint is located near 0 height, 
+		if (path.pathType == PathType::Movement) {
+			if (dpWorld::Instance().IsLoaded()) {
+				// 1000 should be large enough for every world.
+				waypoint.position.y = dpWorld::Instance().GetNavMesh()->GetHeightAtPoint(waypoint.position, 1000.0f);
+			}
+		}
 		path.pathWaypoints.push_back(waypoint);
 	}
-
-
-
 	m_Paths.push_back(path);
 }


### PR DESCRIPTION
Because many waypoints for movement place the Y at some height far below the map, we need to correct this height to match that of the navmesh. Doing this at runtime is very expensive as some maps are very tall and so the halfExtents would need to be very large. Doing this at world load is a far more ideal place to take care of this as this only really needs to be done once so that at runtime, more approximate heights can be calculated with the same halfExtents as currently.

Tested that there are no changes aside from the height being changed at world startup.  This may resolve issues with some AI being unable to find a close waypoint on the navmesh due to their waypoint height being far too low for the halfExtents to allow finding of the nearest poly.