### PR TITLE
fix: dangling pointer in mission when saving character data

### DIFF
--- a/dGame/dMission/Mission.cpp
+++ b/dGame/dMission/Mission.cpp
@@ -42,9 +42,10 @@ Mission::Mission(MissionComponent* missionComponent, const uint32_t missionId) {
 
 	auto* missionsTable = CDClientManager::Instance().GetTable<CDMissionsTable>();
 
-	info = missionsTable->GetPtrByMissionID(missionId);
+	auto* mis = missionsTable->GetPtrByMissionID(missionId);
+	info = *mis;
 
-	if (info == &CDMissionsTable::Default) {
+	if (mis == &CDMissionsTable::Default) {
 		Game::logger->Log("Missions", "Failed to find mission (%i)!", missionId);
 
 		return;
@@ -137,7 +138,7 @@ void Mission::UpdateXml(tinyxml2::XMLElement* element) {
 
 	element->DeleteChildren();
 
-	element->SetAttribute("id", static_cast<unsigned int>(info->id));
+	element->SetAttribute("id", static_cast<unsigned int>(info.id));
 
 	if (m_Completions > 0) {
 		element->SetAttribute("cct", static_cast<unsigned int>(m_Completions));
@@ -212,11 +213,11 @@ User* Mission::GetUser() const {
 }
 
 uint32_t Mission::GetMissionId() const {
-	return info->id;
+	return info.id;
 }
 
 const CDMissions& Mission::GetClientInfo() const {
-	return *info;
+	return info;
 }
 
 uint32_t Mission::GetCompletions() const {
@@ -240,15 +241,15 @@ eMissionState Mission::GetMissionState() const {
 }
 
 bool Mission::IsAchievement() const {
-	return !info->isMission;
+	return !info.isMission;
 }
 
 bool Mission::IsMission() const {
-	return info->isMission;
+	return info.isMission;
 }
 
 bool Mission::IsRepeatable() const {
-	return info->repeatable;
+	return info.repeatable;
 }
 
 bool Mission::IsComplete() const {
@@ -284,7 +285,7 @@ void Mission::MakeAvalible() {
 }
 
 void Mission::Accept() {
-	SetMissionTypeState(eMissionLockState::NEW, info->defined_type, info->defined_subtype);
+	SetMissionTypeState(eMissionLockState::NEW, info.defined_type, info.defined_subtype);
 
 	SetMissionState(m_Completions > 0 ? eMissionState::COMPLETE_ACTIVE : eMissionState::ACTIVE);
 
@@ -321,16 +322,16 @@ void Mission::Complete(const bool yieldRewards) {
 
 	auto* characterComponent = entity->GetComponent<CharacterComponent>();
 	if (characterComponent != nullptr) {
-		characterComponent->TrackMissionCompletion(!info->isMission);
+		characterComponent->TrackMissionCompletion(!info.isMission);
 	}
 
 	auto* missionComponent = entity->GetComponent<MissionComponent>();
 
-	missionComponent->Progress(eMissionTaskType::META, info->id);
+	missionComponent->Progress(eMissionTaskType::META, info.id);
 
-	missionComponent->Progress(eMissionTaskType::RACING, info->id, (LWOOBJID)eRacingTaskParam::COMPLETE_ANY_RACING_TASK);
+	missionComponent->Progress(eMissionTaskType::RACING, info.id, (LWOOBJID)eRacingTaskParam::COMPLETE_ANY_RACING_TASK);
 
-	missionComponent->Progress(eMissionTaskType::RACING, info->id, (LWOOBJID)eRacingTaskParam::COMPLETE_TRACK_TASKS);
+	missionComponent->Progress(eMissionTaskType::RACING, info.id, (LWOOBJID)eRacingTaskParam::COMPLETE_TRACK_TASKS);
 
 	auto* missionEmailTable = CDClientManager::Instance().GetTable<CDMissionEmailTable>();
 
@@ -441,24 +442,24 @@ void Mission::YieldRewards() {
 	}
 
 	int32_t coinsToSend = 0;
-	if (info->LegoScore > 0) {
-		eLootSourceType lootSource = info->isMission ? eLootSourceType::MISSION : eLootSourceType::ACHIEVEMENT;
+	if (info.LegoScore > 0) {
+		eLootSourceType lootSource = info.isMission ? eLootSourceType::MISSION : eLootSourceType::ACHIEVEMENT;
 		if (levelComponent->GetLevel() >= Game::zoneManager->GetWorldConfig()->levelCap) {
 			// Since the character is at the level cap we reward them with coins instead of UScore.
-			coinsToSend += info->LegoScore * Game::zoneManager->GetWorldConfig()->levelCapCurrencyConversion;
+			coinsToSend += info.LegoScore * Game::zoneManager->GetWorldConfig()->levelCapCurrencyConversion;
 		} else {
-			characterComponent->SetUScore(characterComponent->GetUScore() + info->LegoScore);
-			GameMessages::SendModifyLEGOScore(entity, entity->GetSystemAddress(), info->LegoScore, lootSource);
+			characterComponent->SetUScore(characterComponent->GetUScore() + info.LegoScore);
+			GameMessages::SendModifyLEGOScore(entity, entity->GetSystemAddress(), info.LegoScore, lootSource);
 		}
 	}
 
 	if (m_Completions > 0) {
 		std::vector<std::pair<LOT, uint32_t>> items;
 
-		items.emplace_back(info->reward_item1_repeatable, info->reward_item1_repeat_count);
-		items.emplace_back(info->reward_item2_repeatable, info->reward_item2_repeat_count);
-		items.emplace_back(info->reward_item3_repeatable, info->reward_item3_repeat_count);
-		items.emplace_back(info->reward_item4_repeatable, info->reward_item4_repeat_count);
+		items.emplace_back(info.reward_item1_repeatable, info.reward_item1_repeat_count);
+		items.emplace_back(info.reward_item2_repeatable, info.reward_item2_repeat_count);
+		items.emplace_back(info.reward_item3_repeatable, info.reward_item3_repeat_count);
+		items.emplace_back(info.reward_item4_repeatable, info.reward_item4_repeat_count);
 
 		for (const auto& pair : items) {
 			// Some missions reward zero of an item and so they must be allowed through this clause,
@@ -478,9 +479,9 @@ void Mission::YieldRewards() {
 			inventoryComponent->AddItem(pair.first, count, IsMission() ? eLootSourceType::MISSION : eLootSourceType::ACHIEVEMENT);
 		}
 
-		if (info->reward_currency_repeatable > 0 || coinsToSend > 0) {
-			eLootSourceType lootSource = info->isMission ? eLootSourceType::MISSION : eLootSourceType::ACHIEVEMENT;
-			character->SetCoins(character->GetCoins() + info->reward_currency_repeatable + coinsToSend, lootSource);
+		if (info.reward_currency_repeatable > 0 || coinsToSend > 0) {
+			eLootSourceType lootSource = info.isMission ? eLootSourceType::MISSION : eLootSourceType::ACHIEVEMENT;
+			character->SetCoins(character->GetCoins() + info.reward_currency_repeatable + coinsToSend, lootSource);
 		}
 
 		return;
@@ -488,10 +489,10 @@ void Mission::YieldRewards() {
 
 	std::vector<std::pair<LOT, int32_t>> items;
 
-	items.emplace_back(info->reward_item1, info->reward_item1_count);
-	items.emplace_back(info->reward_item2, info->reward_item2_count);
-	items.emplace_back(info->reward_item3, info->reward_item3_count);
-	items.emplace_back(info->reward_item4, info->reward_item4_count);
+	items.emplace_back(info.reward_item1, info.reward_item1_count);
+	items.emplace_back(info.reward_item2, info.reward_item2_count);
+	items.emplace_back(info.reward_item3, info.reward_item3_count);
+	items.emplace_back(info.reward_item4, info.reward_item4_count);
 
 	for (const auto& pair : items) {
 		// Some missions reward zero of an item and so they must be allowed through this clause,
@@ -511,58 +512,58 @@ void Mission::YieldRewards() {
 		inventoryComponent->AddItem(pair.first, count, IsMission() ? eLootSourceType::MISSION : eLootSourceType::ACHIEVEMENT);
 	}
 
-	if (info->reward_currency > 0 || coinsToSend > 0) {
-		eLootSourceType lootSource = info->isMission ? eLootSourceType::MISSION : eLootSourceType::ACHIEVEMENT;
-		character->SetCoins(character->GetCoins() + info->reward_currency + coinsToSend, lootSource);
+	if (info.reward_currency > 0 || coinsToSend > 0) {
+		eLootSourceType lootSource = info.isMission ? eLootSourceType::MISSION : eLootSourceType::ACHIEVEMENT;
+		character->SetCoins(character->GetCoins() + info.reward_currency + coinsToSend, lootSource);
 	}
 
-	if (info->reward_maxinventory > 0) {
+	if (info.reward_maxinventory > 0) {
 		auto* inventory = inventoryComponent->GetInventory(ITEMS);
 
-		inventory->SetSize(inventory->GetSize() + info->reward_maxinventory);
+		inventory->SetSize(inventory->GetSize() + info.reward_maxinventory);
 	}
 
-	if (info->reward_bankinventory > 0) {
+	if (info.reward_bankinventory > 0) {
 		auto* inventory = inventoryComponent->GetInventory(eInventoryType::VAULT_ITEMS);
 		auto modelInventory = inventoryComponent->GetInventory(eInventoryType::VAULT_MODELS);
 
-		inventory->SetSize(inventory->GetSize() + info->reward_bankinventory);
-		modelInventory->SetSize(modelInventory->GetSize() + info->reward_bankinventory);
+		inventory->SetSize(inventory->GetSize() + info.reward_bankinventory);
+		modelInventory->SetSize(modelInventory->GetSize() + info.reward_bankinventory);
 	}
 
-	if (info->reward_reputation > 0) {
-		missionComponent->Progress(eMissionTaskType::EARN_REPUTATION, 0, 0L, "", info->reward_reputation);
+	if (info.reward_reputation > 0) {
+		missionComponent->Progress(eMissionTaskType::EARN_REPUTATION, 0, 0L, "", info.reward_reputation);
 		auto character = entity->GetComponent<CharacterComponent>();
 		if (character) {
-			character->SetReputation(character->GetReputation() + info->reward_reputation);
+			character->SetReputation(character->GetReputation() + info.reward_reputation);
 			GameMessages::SendUpdateReputation(entity->GetObjectID(), character->GetReputation(), entity->GetSystemAddress());
 		}
 	}
 
-	if (info->reward_maxhealth > 0) {
-		destroyableComponent->SetMaxHealth(destroyableComponent->GetMaxHealth() + static_cast<float>(info->reward_maxhealth), true);
+	if (info.reward_maxhealth > 0) {
+		destroyableComponent->SetMaxHealth(destroyableComponent->GetMaxHealth() + static_cast<float>(info.reward_maxhealth), true);
 	}
 
-	if (info->reward_maximagination > 0) {
-		destroyableComponent->SetMaxImagination(destroyableComponent->GetMaxImagination() + static_cast<float>(info->reward_maximagination), true);
+	if (info.reward_maximagination > 0) {
+		destroyableComponent->SetMaxImagination(destroyableComponent->GetMaxImagination() + static_cast<float>(info.reward_maximagination), true);
 	}
 
 	Game::entityManager->SerializeEntity(entity);
 
-	if (info->reward_emote > 0) {
-		character->UnlockEmote(info->reward_emote);
+	if (info.reward_emote > 0) {
+		character->UnlockEmote(info.reward_emote);
 	}
 
-	if (info->reward_emote2 > 0) {
-		character->UnlockEmote(info->reward_emote2);
+	if (info.reward_emote2 > 0) {
+		character->UnlockEmote(info.reward_emote2);
 	}
 
-	if (info->reward_emote3 > 0) {
-		character->UnlockEmote(info->reward_emote3);
+	if (info.reward_emote3 > 0) {
+		character->UnlockEmote(info.reward_emote3);
 	}
 
-	if (info->reward_emote4 > 0) {
-		character->UnlockEmote(info->reward_emote4);
+	if (info.reward_emote4 > 0) {
+		character->UnlockEmote(info.reward_emote4);
 	}
 }
 
@@ -599,7 +600,7 @@ void Mission::SetMissionState(const eMissionState state, const bool sendingRewar
 		return;
 	}
 
-	GameMessages::SendNotifyMission(entity, entity->GetParentUser()->GetSystemAddress(), info->id, static_cast<int>(state), sendingRewards);
+	GameMessages::SendNotifyMission(entity, entity->GetParentUser()->GetSystemAddress(), info.id, static_cast<int>(state), sendingRewards);
 }
 
 void Mission::SetMissionTypeState(eMissionLockState state, const std::string& type, const std::string& subType) {

--- a/dGame/dMission/Mission.h
+++ b/dGame/dMission/Mission.h
@@ -245,7 +245,7 @@ private:
 	/**
 	 * The database information that corresponds to this mission
 	 */
-	const CDMissions* info;
+	CDMissions info;
 
 	/**
 	 * The current state this mission is in


### PR DESCRIPTION
Fixes an issue where characters would lose mission progress due to a dangling pointer in mission data.
This was proven by adding a logging message to the destructor of all CD tables which revealed that when crashing, the tables and all their data are destroyed _first_ and then character data is saved.  This causes all missions to enter a state where their pointers are dangling and character data will enter an invalid state.

This is a quick patch to get character save data stable and remove the dangling pointer.

Tested that previously, I would lose my mission progress with 3 clients in world `1251 1` every time on multiple characters and after the patch I would never lose save data.

Image of save data with fragmented memory, as you can see, the missionID is a completely invalid number
![image](https://github.com/DarkflameUniverse/DarkflameServer/assets/39972741/7b310166-c86a-434d-92b5-654beb355001)
