### PR TITLE
fix: MultiZoneEntranceComponent selection windows opening for everyone in the zone

### DIFF
--- a/dGame/dComponents/MultiZoneEntranceComponent.cpp
+++ b/dGame/dComponents/MultiZoneEntranceComponent.cpp
@@ -21,7 +21,7 @@ void MultiZoneEntranceComponent::OnUse(Entity* originator) {
 	if (!rocket) return;
 
 	// the LUP world menu is just the property menu, the client knows how to handle it
-	GameMessages::SendPropertyEntranceBegin(m_Parent->GetObjectID(), m_Parent->GetSystemAddress());
+	GameMessages::SendPropertyEntranceBegin(m_Parent->GetObjectID(), originator->GetSystemAddress());
 }
 
 void MultiZoneEntranceComponent::OnSelectWorld(Entity* originator, uint32_t index) {


### PR DESCRIPTION
fixes #1195
Tested that the menu still works