### PR TITLE
fix: remove foreign key on name in cheat_detection table

### DIFF
--- a/migrations/dlu/11_fix_cheat_detection_table.sql
+++ b/migrations/dlu/11_fix_cheat_detection_table.sql
@@ -1,0 +1,9 @@
+DROP TABLE IF EXISTS `player_cheat_detections`;
+CREATE TABLE IF NOT EXISTS player_cheat_detections (
+    id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    account_id INT REFERENCES accounts(id),
+    name TEXT NOT NULL,
+    violation_msg TEXT NOT NULL,
+    violation_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP(),
+    violation_system_address TEXT NOT NULL
+);


### PR DESCRIPTION
Drop table incase it exists (which sometimes it doesn't) and then make it again without that foreign key
Tested on 10.11.5-MariaDB

Dropping table since there's little to no chance that data has gotten in it yet, on the chance it even exists