### PR TITLE
fix: Match deallocation for allocators

### DIFF
--- a/dCommon/dClient/AssetManager.h
+++ b/dCommon/dClient/AssetManager.h
@@ -42,7 +42,7 @@ struct AssetMemoryBuffer : std::streambuf {
 	}
 
 	void close() {
-		delete m_Base;
+		free(m_Base);
 	}
 };
 


### PR DESCRIPTION
Currently on line 116 of AssetManager.cpp, we have the following `*data = (char*)malloc(*len);`
however on line 45 of AssetManager.h we have `delete m_Base;` which is not the same allocator as we used to allocate the memory. This PR matches the deallocation to use the correct allocator type.

Tested that valgrind no longer reports errors about mis-matched allocators/free, delete etc.