### PR TITLE
chore: Use TryParse for LDF parsing

### DIFF
--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -127,6 +127,11 @@ namespace GeneralUtils {
 	T Parse(const char* value);
 
 	template <>
+	inline bool Parse(const char* value) {
+		return std::stoi(value);
+	}
+
+	template <>
 	inline int32_t Parse(const char* value) {
 		return std::stoi(value);
 	}

--- a/dCommon/LDFFormat.cpp
+++ b/dCommon/LDFFormat.cpp
@@ -61,35 +61,33 @@ LDFBaseData* LDFBaseData::DataFromString(const std::string_view& format) {
 	}
 
 	case LDF_TYPE_S32: {
-		try {
-			int32_t data = static_cast<int32_t>(strtoul(ldfTypeAndValue.second.data(), &storage, 10));
-			returnValue = new LDFData<int32_t>(key, data);
-		} catch (std::exception) {
+		int32_t data;
+		if (!GeneralUtils::TryParse(ldfTypeAndValue.second.data(), data)) {
 			Game::logger->Log("LDFFormat", "Warning: Attempted to process invalid int32 value (%s) from string (%s)", ldfTypeAndValue.second.data(), format.data());
 			return nullptr;
 		}
+		returnValue = new LDFData<int32_t>(key, data);
+
 		break;
 	}
 
 	case LDF_TYPE_FLOAT: {
-		try {
-			float data = strtof(ldfTypeAndValue.second.data(), &storage);
-			returnValue = new LDFData<float>(key, data);
-		} catch (std::exception) {
+		float data;
+		if (!GeneralUtils::TryParse(ldfTypeAndValue.second.data(), data)) {
 			Game::logger->Log("LDFFormat", "Warning: Attempted to process invalid float value (%s) from string (%s)", ldfTypeAndValue.second.data(), format.data());
 			return nullptr;
 		}
+		returnValue = new LDFData<float>(key, data);
 		break;
 	}
 
 	case LDF_TYPE_DOUBLE: {
-		try {
-			double data = strtod(ldfTypeAndValue.second.data(), &storage);
-			returnValue = new LDFData<double>(key, data);
-		} catch (std::exception) {
+		double data;
+		if (!GeneralUtils::TryParse(ldfTypeAndValue.second.data(), data)) {
 			Game::logger->Log("LDFFormat", "Warning: Attempted to process invalid double value (%s) from string (%s)", ldfTypeAndValue.second.data(), format.data());
 			return nullptr;
 		}
+		returnValue = new LDFData<double>(key, data);
 		break;
 	}
 
@@ -102,9 +100,7 @@ LDFBaseData* LDFBaseData::DataFromString(const std::string_view& format) {
 		} else if (ldfTypeAndValue.second == "false") {
 			data = 0;
 		} else {
-			try {
-				data = static_cast<uint32_t>(strtoul(ldfTypeAndValue.second.data(), &storage, 10));
-			} catch (std::exception) {
+			if (!GeneralUtils::TryParse(ldfTypeAndValue.second.data(), data)) {
 				Game::logger->Log("LDFFormat", "Warning: Attempted to process invalid uint32 value (%s) from string (%s)", ldfTypeAndValue.second.data(), format.data());
 				return nullptr;
 			}
@@ -122,9 +118,7 @@ LDFBaseData* LDFBaseData::DataFromString(const std::string_view& format) {
 		} else if (ldfTypeAndValue.second == "false") {
 			data = false;
 		} else {
-			try {
-				data = static_cast<bool>(strtol(ldfTypeAndValue.second.data(), &storage, 10));
-			} catch (std::exception) {
+			if (!GeneralUtils::TryParse(ldfTypeAndValue.second.data(), data)) {
 				Game::logger->Log("LDFFormat", "Warning: Attempted to process invalid bool value (%s) from string (%s)", ldfTypeAndValue.second.data(), format.data());
 				return nullptr;
 			}
@@ -135,24 +129,22 @@ LDFBaseData* LDFBaseData::DataFromString(const std::string_view& format) {
 	}
 
 	case LDF_TYPE_U64: {
-		try {
-			uint64_t data = static_cast<uint64_t>(strtoull(ldfTypeAndValue.second.data(), &storage, 10));
-			returnValue = new LDFData<uint64_t>(key, data);
-		} catch (std::exception) {
+		uint64_t data;
+		if (!GeneralUtils::TryParse(ldfTypeAndValue.second.data(), data)) {
 			Game::logger->Log("LDFFormat", "Warning: Attempted to process invalid uint64 value (%s) from string (%s)", ldfTypeAndValue.second.data(), format.data());
 			return nullptr;
 		}
+		returnValue = new LDFData<uint64_t>(key, data);
 		break;
 	}
 
 	case LDF_TYPE_OBJID: {
-		try {
-			LWOOBJID data = static_cast<LWOOBJID>(strtoll(ldfTypeAndValue.second.data(), &storage, 10));
-			returnValue = new LDFData<LWOOBJID>(key, data);
-		} catch (std::exception) {
+		LWOOBJID data;
+		if (!GeneralUtils::TryParse(ldfTypeAndValue.second.data(), data)) {
 			Game::logger->Log("LDFFormat", "Warning: Attempted to process invalid LWOOBJID value (%s) from string (%s)", ldfTypeAndValue.second.data(), format.data());
 			return nullptr;
 		}
+		returnValue = new LDFData<LWOOBJID>(key, data);
 		break;
 	}
 

--- a/tests/dCommonTests/TestLDFFormat.cpp
+++ b/tests/dCommonTests/TestLDFFormat.cpp
@@ -17,7 +17,7 @@ protected:
 	}
 };
 
-#define LdfUniquePtr std::unique_ptr<LDFBaseData>  
+typedef std::unique_ptr<LDFBaseData> LdfUniquePtr;  
 
 // Suite of tests for parsing LDF values
 


### PR DESCRIPTION
Simplifies the work we are doing by using a common known working and tested function.

Tests still pass and server still reads all ldf data from luz files.