### PR TITLE
CheatDetection: Move player access

### DIFF
--- a/dGame/dUtilities/CheatDetection.cpp
+++ b/dGame/dUtilities/CheatDetection.cpp
@@ -55,17 +55,18 @@ void LogAndSaveFailedAntiCheatCheck(const LWOOBJID& id, const SystemAddress& sys
 				player->GetCharacter()->GetName().c_str(), player->GetObjectID(),
 				sysAddr.ToString(),
 				entity->GetCharacter()->GetName().c_str(), entity->GetObjectID());
+			toReport = player->GetParentUser();
 		// In the case that the target entity id did not exist, just log the player info.
 		} else if (player) {
 			Game::logger->Log("CheatDetection", "Player (%s) (%llu) at system address (%s) with sending player (%llu) does not match their own.",
 				player->GetCharacter()->GetName().c_str(), player->GetObjectID(),
 				sysAddr.ToString(), id);
+			toReport = player->GetParentUser();
 		// In the rare case that the player does not exist, just log the system address and who the target id was.
 		} else {
 			Game::logger->Log("CheatDetection", "Player at system address (%s) with sending player (%llu) does not match their own.",
 				sysAddr.ToString(), id);
 		}
-		toReport = player->GetParentUser();
 		break;
 	}
 	case CheckType::User: {


### PR DESCRIPTION
in earlier blocks, we check if player is null before accessing it.  In doing so I neglected to propogate the player access for who to report into said blocks.  This will resolve crashes from null accesses.