### PR TITLE
fix: Secure Master packet handling

### DIFF
--- a/dMasterServer/InstanceManager.cpp
+++ b/dMasterServer/InstanceManager.cpp
@@ -180,7 +180,7 @@ void InstanceManager::ReadyInstance(Instance* instance) {
 		const auto& zoneId = instance->GetZoneID();
 
 		Game::logger->Log("InstanceManager", "Responding to pending request %llu -> %i (%i)", request, zoneId.GetMapID(), zoneId.GetCloneID());
-
+		Game::logger->Log("InstanceManager", "%s", request.sysAddr.ToString());
 		MasterPackets::SendZoneTransferResponse(
 			Game::server,
 			request.sysAddr,

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -434,6 +434,7 @@ int main(int argc, char** argv) {
 		for (uint32_t curPacket = 0; curPacket < maxPacketsToProcess && timeSpent < maxPacketProcessingTime; curPacket++) {
 			packet = Game::server->Receive();
 			if (packet) {
+				Game::logger->Log("WorldServer", "packet sysAddr %s", packet->systemAddress.ToString());
 				auto t1 = std::chrono::high_resolution_clock::now();
 				HandlePacket(packet);
 				auto t2 = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
Moves master packets out of the main packet handler and into its own function specifically for master packets to prevent spoofing

Tested that master packets are still routed correctly.