### PR TITLE
Scripts: Fix ambiguous base class

### DIFF
--- a/dScripts/02_server/Enemy/General/BaseEnemyApe.h
+++ b/dScripts/02_server/Enemy/General/BaseEnemyApe.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "CppScripts.h"
 
-class BaseEnemyApe : public CppScripts::Script {
+class BaseEnemyApe : virtual public CppScripts::Script {
 public:
 	void OnStartup(Entity* self) override;
 	void OnDie(Entity* self, Entity* killer) override;

--- a/dScripts/02_server/Map/AG_Spider_Queen/ZoneAgSpiderQueen.h
+++ b/dScripts/02_server/Map/AG_Spider_Queen/ZoneAgSpiderQueen.h
@@ -2,7 +2,7 @@
 #include "ActivityManager.h"
 #include "ZoneAgProperty.h"
 
-class ZoneAgSpiderQueen : ZoneAgProperty, ActivityManager {
+class ZoneAgSpiderQueen : public ZoneAgProperty, ActivityManager {
 public:
 	void OnStartup(Entity* self) override;
 	void OnFireEventServerSide(Entity* self, Entity* sender, std::string args, int32_t param1, int32_t param2,

--- a/dScripts/02_server/Map/njhub/NjNPCMissionSpinjitzuServer.h
+++ b/dScripts/02_server/Map/njhub/NjNPCMissionSpinjitzuServer.h
@@ -17,7 +17,7 @@ static std::map<std::u16string, uint32_t> ElementMissions = {
 	{u"fire", 1962},
 };
 
-class NjNPCMissionSpinjitzuServer : public CppScripts::Script {
+class NjNPCMissionSpinjitzuServer : virtual public CppScripts::Script {
 public:
 	void OnMissionDialogueOK(Entity* self, Entity* target, int missionID, eMissionState missionState) override;
 private:

--- a/dScripts/ActivityManager.h
+++ b/dScripts/ActivityManager.h
@@ -8,7 +8,7 @@ struct ActivityTimer {
 	float_t runTime = 0;
 };
 
-class ActivityManager : public CppScripts::Script {
+class ActivityManager : virtual public CppScripts::Script {
 public:
 	static bool IsPlayerInActivity(Entity* self, LWOOBJID playerID);
 	static void UpdatePlayer(Entity* self, LWOOBJID playerID, bool remove = false);

--- a/dScripts/BasePropertyServer.h
+++ b/dScripts/BasePropertyServer.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "CppScripts.h"
 
-class BasePropertyServer : public CppScripts::Script {
+class BasePropertyServer : virtual public CppScripts::Script {
 public:
 
 	virtual void SetGameVariables(Entity* self);

--- a/dScripts/BaseWavesGenericEnemy.h
+++ b/dScripts/BaseWavesGenericEnemy.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "CppScripts.h"
 
-class BaseWavesGenericEnemy : public CppScripts::Script {
+class BaseWavesGenericEnemy : virtual public CppScripts::Script {
 public:
 	void OnStartup(Entity* self) override;
 	void OnDie(Entity* self, Entity* killer) override;

--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -312,22 +312,17 @@
 #include "WildNinjaSensei.h"
 #include "WildNinjaBricks.h"
 
-//Big bad global bc this is a namespace and not a class:
-InvalidScript* invalidToReturn = new InvalidScript();
-std::map<std::string, CppScripts::Script*> m_Scripts;
-
-// yeah sorry darwin ill fix the global later
+namespace {
+	InvalidScript* invalidToReturn = new InvalidScript();
+	std::map<std::string, CppScripts::Script*> m_Scripts;
+};
 
 CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scriptName) {
-	Script* script;
-
 	if (m_Scripts.find(scriptName) != m_Scripts.end()) {
-		script = m_Scripts[scriptName];
-
-		return script;
+		return m_Scripts[scriptName];
 	}
 
-	script = invalidToReturn;
+	Script* script = invalidToReturn;
 
 	//VE / AG:
 	if (scriptName == "scripts\\ai\\AG\\L_AG_SHIP_PLAYER_DEATH_TRIGGER.lua")
@@ -411,7 +406,7 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 	else if (scriptName == "scripts\\02_server\\Map\\AG\\L__AG_MONUMENT_RACE_CANCEL.lua")
 		script = new AgMonumentRaceCancel();
 	else if (scriptName == "scripts\\02_server\\Map\\AG_Spider_Queen\\L_ZONE_AG_SPIDER_QUEEN.lua")
-		script = (ZoneAgProperty*)new ZoneAgSpiderQueen();
+		script = new ZoneAgSpiderQueen();
 	else if (scriptName == "scripts\\02_server\\Map\\AG_Spider_Queen\\L_SPIDER_BOSS_TREASURE_CHEST_SERVER.lua")
 		script = new SpiderBossTreasureChestServer();
 	else if (scriptName == "scripts\\02_server\\Map\\AG\\L_NPC_COWBOY_SERVER.lua")
@@ -475,7 +470,7 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 	else if (scriptName == "scripts\\02_server\\Enemy\\Waves\\L_WAVES_BOSS_HAMMERLING_ENEMY_SERVER.lua")
 		script = new WaveBossHammerling();
 	else if (scriptName == "scripts\\02_server\\Enemy\\Waves\\L_WAVES_BOSS_APE_ENEMY_SERVER.lua")
-		script = (BaseEnemyApe*) new WaveBossApe();
+		script = new WaveBossApe();
 	else if (scriptName == "scripts\\02_server\\Enemy\\Waves\\L_WAVES_BOSS_DARK_SPIDERLING_ENEMY_SERVER.lua")
 		script = new WaveBossSpiderling();
 	else if (scriptName == "scripts\\02_server\\Enemy\\Waves\\L_WAVES_BOSS_HORESEMEN_ENEMY_SERVER.lua")
@@ -636,7 +631,7 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 	else if (scriptName == "scripts\\02_server\\Map\\General\\L_PROP_PLATFORM.lua")
 		script = new PropertyPlatform();
 	else if (scriptName == "scripts\\02_server\\Map\\VE\\L_VE_BRICKSAMPLE_SERVER.lua")
-		return new VeBricksampleServer();
+		script = new VeBricksampleServer();
 	else if (scriptName == "scripts\\02_server\\Map\\General\\L_MAIL_BOX_SERVER.lua")
 		script = new MailBoxServer();
 	else if (scriptName == "scripts\\ai\\ACT\\L_ACT_MINE.lua")
@@ -771,7 +766,7 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 	else if (scriptName == "scripts\\02_server\\Map\\njhub\\L_COLE_NPC.lua")
 		script = new NjColeNPC();
 	else if (scriptName == "scripts\\02_server\\Map\\njhub\\L_JAY_MISSION_ITEMS.lua")
-		script = (NjNPCMissionSpinjitzuServer*) new NjJayMissionItems();
+		script = new NjJayMissionItems();
 	else if (scriptName == "scripts\\02_server\\Map\\njhub\\L_NPC_MISSION_SPINJITZU_SERVER.lua")
 		script = new NjNPCMissionSpinjitzuServer();
 	else if (scriptName == "scripts\\02_server\\Map\\njhub\\L_ENEMY_SKELETON_SPAWNER.lua")
@@ -951,12 +946,4 @@ std::vector<CppScripts::Script*> CppScripts::GetEntityScripts(Entity* entity) {
 		}
 	}
 	return scripts;
-}
-
-CppScripts::Script::Script() {
-
-}
-
-CppScripts::Script::~Script() {
-
 }

--- a/dScripts/CppScripts.h
+++ b/dScripts/CppScripts.h
@@ -29,9 +29,6 @@ namespace CppScripts {
 	 */
 	class Script {
 	public:
-		Script();
-		~Script();
-
 		/**
 		 * Invoked one frame after the script is loaded.
 		 *

--- a/dScripts/NPCAddRemoveItem.h
+++ b/dScripts/NPCAddRemoveItem.h
@@ -10,7 +10,7 @@ struct ItemSetting {
 /**
  * Scripts that allows for the addition and removal of sets of items by an NPC
  */
-class NPCAddRemoveItem : public CppScripts::Script {
+class NPCAddRemoveItem : virtual public CppScripts::Script {
 protected:
 	void OnMissionDialogueOK(Entity* self, Entity* target, int missionID, eMissionState missionState) override;
 	virtual std::map<uint32_t, std::vector<ItemSetting>> GetSettings();


### PR DESCRIPTION
Fixes an issue where we needed a C style cast to save these scripts due the the diamond problem wherein the compiler was unable to determine which CppScripts base class to inherit from with multiple inheritance of the same base class.
Moved globals to unnammed namespace
removed empty script logging as missing

Tested that scripts still compile.
Also cache the script that was being raw returned