### PR TITLE
Revert: Fix wisp lee mission

### DIFF
--- a/dGame/dMission/MissionPrerequisites.cpp
+++ b/dGame/dMission/MissionPrerequisites.cpp
@@ -105,9 +105,7 @@ bool PrerequisiteExpression::Execute(const std::unordered_map<uint32_t, Mission*
 
 			if (this->sub != 0) {
 				// Special case for one Wisp Lee repeatable mission.
-				a = mission->GetClientInfo().id == 1883 ?
-					mission->GetMissionState() == static_cast<eMissionState>(this->sub) :
-					mission->GetMissionState() >= static_cast<eMissionState>(this->sub);
+				a = mission->GetMissionState() == static_cast<eMissionState>(this->sub);
 			} else if (mission->IsComplete()) {
 				a = true;
 			}


### PR DESCRIPTION
This reverts commit d7e16ab589697fd1a0a270a02c622b8fa752638f.

Fixes an issue where the incorrect mission is marked as being offerable and this overwrote the original mission offered by wisp lee and forced him to offer a different, unacceptable mission.

Tested that completing the mission twice from a new daily state and a repeatable state both completed the chain correctly.  Unsure what the original bug was, but it does not appear to be present. On top of that, there is no pre-requisite for mission 1883 anywhere in the cdclient, so at best, this check was always false, but the correct behavior is exact equivalence for the mission state.

Fixes #296
