### PR TITLE
fix: Address race condition

### DIFF
--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -116,7 +116,7 @@ int main(int argc, char** argv) {
 
 	uint32_t clientNetVersion = 0;
 	if (!GeneralUtils::TryParse(Game::config->GetValue("client_net_version"), clientNetVersion)) {
-		Game::logger->Log("MasterServer", "Failed to parse (%s) as net version. Cannot start server as no clients could connect.",Game::config->GetValue("client_net_version").c_str());
+		Game::logger->Log("MasterServer", "Failed to parse (%s) as net version. Cannot start server as no clients could connect.", Game::config->GetValue("client_net_version").c_str());
 		Game::logger->Log("MasterServer", "As of version 1.1.1, client_net_version is required to be defined in sharedconfig.ini as opposed to in CMakeVariables.txt as NET_VERSION.");
 		Game::logger->Log("MasterServer", "Rerun cmake to ensure all config values exist. If client_net_version already exists in sharedconfig.ini, please ensure it is a valid number.");
 		Game::logger->Log("MasterServer", "like 171022");
@@ -234,21 +234,21 @@ int main(int argc, char** argv) {
 			std::cout << "Do you want to change the password of that account? [y/n]?";
 			std::string prompt = "";
 			std::cin >> prompt;
-			if (prompt == "y" || prompt == "yes"){
+			if (prompt == "y" || prompt == "yes") {
 				uint32_t accountId = 0;
 				res->next();
 				accountId = res->getUInt(1);
 				if (accountId == 0) return EXIT_FAILURE;
 
 				//Read the password from the console without echoing it.
-				#ifdef __linux__
-						//This function is obsolete, but it only meant to be used by the
-						//sysadmin to create their first account.
-						password = getpass("Enter a password: ");
-				#else
-						std::cout << "Enter a password: ";
-						std::cin >> password;
-				#endif
+#ifdef __linux__
+		//This function is obsolete, but it only meant to be used by the
+		//sysadmin to create their first account.
+				password = getpass("Enter a password: ");
+#else
+				std::cout << "Enter a password: ";
+				std::cin >> password;
+#endif
 
 				// Regenerate hash based on new password
 				char salt[BCRYPT_HASHSIZE];
@@ -271,14 +271,14 @@ int main(int argc, char** argv) {
 		}
 
 		//Read the password from the console without echoing it.
-		#ifdef __linux__
-				//This function is obsolete, but it only meant to be used by the
-				//sysadmin to create their first account.
-				password = getpass("Enter a password: ");
-		#else
-				std::cout << "Enter a password: ";
-				std::cin >> password;
-		#endif
+#ifdef __linux__
+		//This function is obsolete, but it only meant to be used by the
+		//sysadmin to create their first account.
+		password = getpass("Enter a password: ");
+#else
+		std::cout << "Enter a password: ";
+		std::cin >> password;
+#endif
 
 		//Generate new hash for bcrypt
 		char salt[BCRYPT_HASHSIZE];
@@ -295,8 +295,8 @@ int main(int argc, char** argv) {
 			statement->setString(2, std::string(hash, BCRYPT_HASHSIZE).c_str());
 			statement->setInt(3, 9);
 			statement->execute();
-		} catch(sql::SQLException& e) {
-			Game::logger->Log("MasterServer", "A SQL error occurred!:\n %s",  e.what());
+		} catch (sql::SQLException& e) {
+			Game::logger->Log("MasterServer", "A SQL error occurred!:\n %s", e.what());
 			return EXIT_FAILURE;
 		}
 
@@ -581,20 +581,22 @@ void HandlePacket(Packet* packet) {
 			inStream.Read(theirServerType);
 			theirIP = PacketUtils::ReadString(24, packet, false); //24 is the current offset
 
-			if (theirServerType == ServerType::World && !Game::im->IsPortInUse(theirPort)) {
-				Instance* in = new Instance(theirIP, theirPort, theirZoneID, theirInstanceID, 0, 12, 12);
+			if (theirServerType == ServerType::World) {
+				if (!Game::im->IsPortInUse(theirPort)) {
+					Instance* in = new Instance(theirIP, theirPort, theirZoneID, theirInstanceID, 0, 12, 12);
 
-				SystemAddress copy;
-				copy.binaryAddress = packet->systemAddress.binaryAddress;
-				copy.port = packet->systemAddress.port;
+					SystemAddress copy;
+					copy.binaryAddress = packet->systemAddress.binaryAddress;
+					copy.port = packet->systemAddress.port;
 
-				in->SetSysAddr(copy);
-				Game::im->AddInstance(in);
-			} else {
-				auto instance = Game::im->FindInstance(
-					theirZoneID, static_cast<uint16_t>(theirInstanceID));
-				if (instance) {
-					instance->SetSysAddr(packet->systemAddress);
+					in->SetSysAddr(copy);
+					Game::im->AddInstance(in);
+				} else {
+					auto instance = Game::im->FindInstance(
+						theirZoneID, static_cast<uint16_t>(theirInstanceID));
+					if (instance) {
+						instance->SetSysAddr(packet->systemAddress);
+					}
 				}
 			}
 


### PR DESCRIPTION
Fix a race condition that would overwrite the port of zone 0 with the auth server port or a chat server port which would cause a domino effect of desynced server ports

Tested that a sleep(5) in auth still allows a player to connect and login without issues