### PR TITLE
fix: Default team loot to ffa

### DIFF
--- a/dChatServer/PlayerContainer.cpp
+++ b/dChatServer/PlayerContainer.cpp
@@ -11,12 +11,17 @@
 #include "eConnectionType.h"
 #include "eChatInternalMessageType.h"
 #include "ChatPackets.h"
+#include "dConfig.h"
 
 PlayerContainer::PlayerContainer() {
 }
 
 PlayerContainer::~PlayerContainer() {
 	mPlayers.clear();
+}
+
+TeamData::TeamData() {
+	lootFlag = Game::config->GetValue("default_team_loot") == "0" ? 0 : 1;
 }
 
 void PlayerContainer::InsertPlayer(Packet* packet) {

--- a/dChatServer/PlayerContainer.h
+++ b/dChatServer/PlayerContainer.h
@@ -18,6 +18,7 @@ struct PlayerData {
 };
 
 struct TeamData {
+	TeamData();
 	LWOOBJID teamID = LWOOBJID_EMPTY; // Internal use
 	LWOOBJID leaderID = LWOOBJID_EMPTY;
 	std::vector<LWOOBJID> memberIDs{};

--- a/dGame/TeamManager.cpp
+++ b/dGame/TeamManager.cpp
@@ -1,7 +1,13 @@
 #include "TeamManager.h"
 #include "EntityManager.h"
+#include "Game.h"
+#include "dConfig.h"
 
 TeamManager* TeamManager::m_Address = nullptr; //For singleton method
+
+Team::Team() {
+	lootOption = Game::config->GetValue("default_team_loot") == "0" ? 0 : 1;
+}
 
 TeamManager::TeamManager() {
 }

--- a/dGame/TeamManager.h
+++ b/dGame/TeamManager.h
@@ -2,16 +2,15 @@
 
 #include "Entity.h"
 
-struct Team
-{
+struct Team {
+	Team();
 	LWOOBJID teamID = LWOOBJID_EMPTY;
 	char lootOption = 0;
 	std::vector<LWOOBJID> members{};
 	char lootRound = 0;
 };
 
-class TeamManager
-{
+class TeamManager {
 public:
 	static TeamManager* Instance() {
 		if (!m_Address) {

--- a/resources/sharedconfig.ini
+++ b/resources/sharedconfig.ini
@@ -43,3 +43,7 @@ maximum_mtu_size=1228
 # This cannot just be any arbitrary number.  This has to match the same value that is in your client.
 # If you do not know what this value is, default it to 171022.
 client_net_version=171022
+
+# Turn to 0 to default teams to use the live accurate Shared Loot (0) by default as opposed to Free for All (1)
+# This is used in both Chat and World servers.
+default_team_loot=1


### PR DESCRIPTION
new feature to default teams to ffa as 99.999% of the time you use this anyways.  Config option added to use live accurate default shared loot should you want that.

Tested that when default_team_loot is 0, shared loot is used by default and when default_team_loot is 1, free for all loot is used by default.