### PR TITLE
fix: Animated deaths not playing

### DIFF
--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -72,6 +72,7 @@ DestroyableComponent::DestroyableComponent(Entity* parent) : Component(parent) {
 	m_ImmuneToImaginationLossCount = 0;
 	m_ImmuneToQuickbuildInterruptCount = 0;
 	m_ImmuneToPullToPointCount = 0;
+	m_DeathBehavior = -1;
 }
 
 DestroyableComponent::~DestroyableComponent() {

--- a/dGame/dComponents/DestroyableComponent.h
+++ b/dGame/dComponents/DestroyableComponent.h
@@ -416,6 +416,9 @@ public:
 	const bool GetImmuneToQuickbuildInterrupt() {return m_ImmuneToQuickbuildInterruptCount > 0;};
 	const bool GetImmuneToPullToPoint() {return m_ImmuneToPullToPointCount > 0;};
 
+	int32_t GetDeathBehavior() const { return m_DeathBehavior; }
+	void SetDeathBehavior(int32_t value) { m_DeathBehavior = value; }
+
 	/**
 	 * Utility to reset all stats to the default stats based on items and completed missions
 	 */
@@ -597,6 +600,11 @@ private:
 	uint32_t m_ImmuneToImaginationLossCount;
 	uint32_t m_ImmuneToQuickbuildInterruptCount;
 	uint32_t m_ImmuneToPullToPointCount;
+
+	/**
+	 * Death behavior type.  If 0, the client plays a death animation as opposed to a smash animation.
+	 */
+	int32_t m_DeathBehavior;
 };
 
 #endif // DESTROYABLECOMPONENT_H

--- a/dScripts/ai/PROPERTY/AgPropguards.cpp
+++ b/dScripts/ai/PROPERTY/AgPropguards.cpp
@@ -18,7 +18,7 @@ void AgPropguards::OnMissionDialogueOK(Entity* self, Entity* target, int mission
 		&& !character->GetPlayerFlag(flag)) {
 		// If the player just started the mission, play a cinematic highlighting the target
 		GameMessages::SendPlayCinematic(target->GetObjectID(), u"MissionCam", target->GetSystemAddress());
-	} else if (missionState == eMissionState::COMPLETE_READY_TO_COMPLETE) {
+	} else if (missionState == eMissionState::READY_TO_COMPLETE) {
 		// Makes the guard disappear once the mission has been completed
 		const auto zoneControlID = Game::entityManager->GetZoneControlEntity()->GetObjectID();
 		GameMessages::SendNotifyClientObject(zoneControlID, u"GuardChat", 0, 0, self->GetObjectID(),


### PR DESCRIPTION
Fixes #1222

addresses an issue where the death behavior of a destructible component was not being respected and enemies with destroyable components that had special death animations were not able to play the animation on death.  This pr adds in the hardcoded constant the client uses for the same metric of 12 seconds.

Tested that claiming Nimbus Rock and completing the property guards mission allows him to vacuum away and then network the destruction packet 12 seconds later.