### PR TITLE
Diagnostics: Fix error file

### DIFF
--- a/dCommon/Diagnostics.cpp
+++ b/dCommon/Diagnostics.cpp
@@ -134,6 +134,10 @@ void CatchUnhandled(int sig) {
 	// Loop through the returned addresses, and get the symbols to be demangled
 	char** strings = backtrace_symbols(array, size);
 
+	FILE* file = fopen(fileName.c_str(), "w+");
+	if (file != NULL) {
+		fprintf(file, "Error: signal %d:\n", sig);
+	}
 	// Print the stack trace
 	for (size_t i = 0; i < size; i++) {
 		// Take a string like './WorldServer(_ZN19SlashCommandHandler17HandleChatCommandERKSbIDsSt11char_traitsIDsESaIDsEEP6EntityRK13SystemAddress+0x6187) [0x55869c44ecf7]'
@@ -155,18 +159,13 @@ void CatchUnhandled(int sig) {
 		}
 
 		LOG("[%02zu] %s", i, functionName.c_str());
+		if (file != NULL) {
+			fprintf(file, "[%02zu] %s\n", i, functionName.c_str());
+		}
 	}
 #  else // defined(__GNUG__)
 	backtrace_symbols_fd(array, size, STDOUT_FILENO);
 #  endif // defined(__GNUG__)
-
-	FILE* file = fopen(fileName.c_str(), "w+");
-	if (file != NULL) {
-		// print out all the frames to stderr
-		fprintf(file, "Error: signal %d:\n", sig);
-		backtrace_symbols_fd(array, size, fileno(file));
-		fclose(file);
-	}
 
 #else // __include_backtrace__
 


### PR DESCRIPTION
Tested that a crash now prints to the error file the demangled names

new logs look like this following
```
Error: signal 11:
[00] CatchUnhandled(int)(+0x2f2) [0x7f29e5fb0f12]
[01] /lib/x86_64-linux-gnu/libpthread.so.0(+0x14420) [0x7f29e5dd1420]
[02] WorldShutdownSequence()(+0x3c) [0x7f29e5fa851c]
[03] /lib/x86_64-linux-gnu/libc.so.6(+0x43090) [0x7f29e56d3090]
[04] /mnt/f/Users/EmosewaMC/Documents/GitHub/DarkflameServerMain/build/WorldServer(+0x4d5524) [0x7f29e62fb524]
[05] CppSQLite3Query::fieldIndex(char const*)(+0x4a) [0x7f29e62f15ca]
[06] CppSQLite3Query::getIntField(char const*, int)(+0x16) [0x7f29e62f1756]
[07] CDBehaviorParameterTable::LoadValuesFromDatabase()(+0xe4) [0x7f29e5fc8e94]
[08] CDClientManager::CDClientManager()(+0x82) [0x7f29e5fbf202]
[09] /mnt/f/Users/EmosewaMC/Documents/GitHub/DarkflameServerMain/build/WorldServer(main+0x1892) [0x7f29e5f9b2e2]
[10] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xf3) [0x7f29e56b4083]
[11] /mnt/f/Users/EmosewaMC/Documents/GitHub/DarkflameServerMain/build/WorldServer(_start+0x2e) [0x7f29e5fa649e]
```