### PR TITLE
fix: deleted memory access in Character Select

### DIFF
--- a/dGame/Character.cpp
+++ b/dGame/Character.cpp
@@ -394,12 +394,13 @@ void Character::SetIsNewLogin() {
 
 	auto* currentChild = flags->FirstChildElement();
 	while (currentChild) {
+		auto* nextChild = currentChild->NextSiblingElement();
 		if (currentChild->Attribute("si")) {
 			flags->DeleteChild(currentChild);
 			LOG("Removed isLoggedIn flag from character %i:%s, saving character to database", GetID(), GetName().c_str());
 			WriteToDatabase();
 		}
-		currentChild = currentChild->NextSiblingElement();
+		currentChild = nextChild;
 	}
 }
 


### PR DESCRIPTION
Tested that on windows debug, you no longer crash when logging into a character that was just logged into.