### PR TITLE
fix: Add null check for loot drops

### DIFF
--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -1029,7 +1029,7 @@ void GameMessages::SendSetNetworkScriptVar(Entity* entity, const SystemAddress& 
 }
 
 void GameMessages::SendDropClientLoot(Entity* entity, const LWOOBJID& sourceID, LOT item, int currency, NiPoint3 spawnPos, int count) {
-	if (Game::config->GetValue("disable_drops") == "1") {
+	if (Game::config->GetValue("disable_drops") == "1" || !entity) {
 		return;
 	}
 


### PR DESCRIPTION
fixes a crash

crash from being in a team and trying to drop loot to a member of that team no longer crashes