### PR TITLE
fix: Script incorrect kill method for exploding asset

### DIFF
--- a/dScripts/02_server/Map/General/ExplodingAsset.cpp
+++ b/dScripts/02_server/Map/General/ExplodingAsset.cpp
@@ -4,6 +4,8 @@
 #include "MissionComponent.h"
 #include "SkillComponent.h"
 #include "eMissionTaskType.h"
+#include "CDClientManager.h"
+#include "CDObjectSkillsTable.h"
 #include "RenderComponent.h"
 
 //TODO: this has to be updated so that you only get killed if you're in a certain radius.
@@ -39,9 +41,11 @@ void ExplodingAsset::OnHit(Entity* self, Entity* attacker) {
 	self->SetOwnerOverride(attacker->GetObjectID());
 
 	GameMessages::SendPlayEmbeddedEffectOnAllClientsNearObject(self, u"camshake", self->GetObjectID(), 16);
+	self->Smash(attacker->GetObjectID());
 
 	auto* skillComponent = self->GetComponent<SkillComponent>();
 	if (skillComponent != nullptr) {
+		// Technically supposed to get first skill in the skill component but only 1 object in the live game used this.
 		skillComponent->CalculateBehavior(147, 4721, LWOOBJID_EMPTY, true);
 	}
 
@@ -65,8 +69,6 @@ void ExplodingAsset::OnHit(Entity* self, Entity* attacker) {
 			}
 		}
 	}
-
-	self->ScheduleKillAfterUpdate();
 }
 
 void ExplodingAsset::OnProximityUpdate(Entity* self, Entity* entering, std::string name, std::string status) {


### PR DESCRIPTION
Tested that the missions Bone to Pick and the daily which uses this still only progress once.  This is because the progression in the script are script progressions and the one for smash missions requires a die, not kill.