### PR TITLE
fix: WorldServer crash from deleting last character

### DIFF
--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -925,7 +925,7 @@ void HandlePacket(Packet* packet) {
 		//We need to delete the entity first, otherwise the char list could delete it while it exists in the world!
 		if (Game::server->GetZoneID() != 0) {
 			auto user = UserManager::Instance()->GetUser(packet->systemAddress);
-			if (!user) return;
+			if (!user || !user->GetLastUsedChar()) return;
 			Game::entityManager->DestroyEntity(user->GetLastUsedChar()->GetEntity());
 		}
 


### PR DESCRIPTION
When going to character select in a world, then deleting your last character, the world server would crash.

Tested that with this change, the server no longer crashes when deleting your last character after returning to character select