### PR TITLE
fix: ChatFilter incorrect segment highlighting

### DIFF
--- a/dChatFilter/dChatFilter.cpp
+++ b/dChatFilter/dChatFilter.cpp
@@ -144,7 +144,7 @@ std::vector<std::pair<uint8_t, uint8_t>> dChatFilter::IsSentenceOkay(const std::
 			listOfBadSegments.emplace_back(position, originalSegment.length());
 		}
 
-		position += segment.length() + 1;
+		position += originalSegment.length() + 1;
 	}
 
 	return listOfBadSegments;


### PR DESCRIPTION
Tested that the string pictured here
![image](https://github.com/DarkflameUniverse/DarkflameServer/assets/39972741/cbf81bdd-d93f-4e36-95fe-73bcc0ef3a4d)
no longer has `prime` marked as all red except the ending e, resulting in `prim` being marked as rejected.  This was because we used the regexed string for the length and not the original one.