### PR TITLE
fix: Ugc Add subkey for rockets and cars

### DIFF
--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -5625,10 +5625,18 @@ void GameMessages::HandleModularBuildFinish(RakNet::BitStream* inStream, Entity*
 		std::vector<LDFBaseData*> config;
 		config.push_back(moduleAssembly);
 
+		LWOOBJID newIdBig;
+		// Make sure a subkey isnt already in use.  Persistent Ids do not make sense here since this only needs to be unique for
+		// this character. Because of that, we just generate a random id and check for a collision.
+		do {
+			newIdBig = ObjectIDManager::Instance()->GenerateRandomObjectID();
+			GeneralUtils::SetBit(newIdBig, eObjectBits::CHARACTER);
+		} while (inv->FindItemBySubKey(newIdBig));
+
 		if (count == 3) {
-			inv->AddItem(6416, 1, eLootSourceType::QUICKBUILD, eInventoryType::MODELS, config);
+			inv->AddItem(6416, 1, eLootSourceType::QUICKBUILD, eInventoryType::MODELS, config, LWOOBJID_EMPTY, true, false, newIdBig);
 		} else if (count == 7) {
-			inv->AddItem(8092, 1, eLootSourceType::QUICKBUILD, eInventoryType::MODELS, config);
+			inv->AddItem(8092, 1, eLootSourceType::QUICKBUILD, eInventoryType::MODELS, config, LWOOBJID_EMPTY, true, false, newIdBig);
 		}
 
 		auto* missionComponent = character->GetComponent<MissionComponent>();


### PR DESCRIPTION
Enables cars and rockets to actually be able to load images for their preview icons in the inventory.  _does not handle image generation.  This will need to be handled by the end user or a 3rd party._

Tested that, if a user has followed the guide and turned UGCUSE3DSERVICES from 1 to 0, the do not get booted to login for having a rocket or a car with a subkey in their inventory; in this case, the rocket or car will never try to load an image and will always use the default.

If however, UGCUSE3DSERVICES is set to 1, the following behavior is correct as per the live client (and a sample from an old client with a rocket image).
Tested that, given a subkey of `1152921508901867691`, the client expects a file called UserMade/691/01152921508901867691.dds in the UserMade folder and when a dds is placed in the folder with that name and path, the client properly renders the rocket/car with said image. (file format is last 3 digits of the subkey as the folder number and then subkey.dds).
Even if this file exists, but UGCUSE3DSERVICES is set to 0, then no images will ever be loaded, even if they exist and are correct.
