### PR TITLE
fix: Nexus Tower Combat Challenge exploding dummy

### DIFF
--- a/dScripts/02_server/Map/NT/NtCombatChallengeExplodingDummy.cpp
+++ b/dScripts/02_server/Map/NT/NtCombatChallengeExplodingDummy.cpp
@@ -1,6 +1,7 @@
 #include "NtCombatChallengeExplodingDummy.h"
 #include "EntityManager.h"
 #include "SkillComponent.h"
+#include "DestroyableComponent.h"
 
 void NtCombatChallengeExplodingDummy::OnDie(Entity* self, Entity* killer) {
 	const auto challengeObjectID = self->GetVar<LWOOBJID>(u"challengeObjectID");
@@ -15,6 +16,17 @@ void NtCombatChallengeExplodingDummy::OnDie(Entity* self, Entity* killer) {
 }
 
 void NtCombatChallengeExplodingDummy::OnHitOrHealResult(Entity* self, Entity* attacker, int32_t damage) {
+	auto* destroyableComponent = self->GetComponent<DestroyableComponent>();
+	auto numTimesHit = self->GetVar<int32_t>(u"numTimesHit");
+	if (destroyableComponent && numTimesHit == 0) {
+		self->SetVar<int32_t>(u"numTimesHit", 1);
+		destroyableComponent->SetHealth(destroyableComponent->GetHealth() / 2);
+		return;
+	} else if (numTimesHit == 2) {
+		return;
+	}
+	self->SetVar<int32_t>(u"numTimesHit", 2);
+
 	const auto challengeObjectID = self->GetVar<LWOOBJID>(u"challengeObjectID");
 
 	auto* challengeObject = Game::entityManager->GetEntity(challengeObjectID);
@@ -28,5 +40,6 @@ void NtCombatChallengeExplodingDummy::OnHitOrHealResult(Entity* self, Entity* at
 	if (skillComponent != nullptr) {
 		skillComponent->CalculateBehavior(1338, 30875, attacker->GetObjectID());
 	}
-	self->Kill(attacker);
+	GameMessages::SendPlayEmbeddedEffectOnAllClientsNearObject(self, u"camshake", self->GetObjectID(), 16.0f);
+	self->Smash(attacker->GetObjectID());
 }


### PR DESCRIPTION
Fixes #1263 

Tested that even with uber hammer, only 1 dummy can spawn at a time and Die isnt fired multiple times
Changed behavior to be 2 hits to kill exploding target instead of 1 as this is what the live script did.