### PR TITLE
feat: Vanity reload and vanity spawners

### DIFF
--- a/dGame/dUtilities/VanityUtilities.cpp
+++ b/dGame/dUtilities/VanityUtilities.cpp
@@ -35,9 +35,8 @@ void VanityUtilities::SpawnVanity() {
 		for (auto& npc : m_NPCs) {
 			if (npc.m_ID == LWOOBJID_EMPTY) continue;
 			if (npc.m_LOT == 176){
-				auto* spawner = Game::zoneManager->GetSpawner(npc.m_ID);
-				if (!spawner) continue;
-				Game::zoneManager->RemoveSpawner(spawner->m_Info.spawnerID);
+				LOG("Removing spawner %llu", npc.m_ID);
+				Game::zoneManager->RemoveSpawner(npc.m_ID);
 			} 
 			auto* entity = Game::entityManager->GetEntity(npc.m_ID);
 			if (!entity) continue;

--- a/dGame/dUtilities/VanityUtilities.cpp
+++ b/dGame/dUtilities/VanityUtilities.cpp
@@ -32,26 +32,21 @@ void VanityUtilities::SpawnVanity() {
 	}
 
 	const uint32_t zoneID = Game::server->GetZoneID();
-	if (!m_NPCs.empty()){
-		for (auto& npc : m_NPCs) {
-			if (npc.m_ID == LWOOBJID_EMPTY) continue;
-			if (npc.m_LOT == 176){
-				Game::zoneManager->RemoveSpawner(npc.m_ID);
-			} else{
-				auto* entity = Game::entityManager->GetEntity(npc.m_ID);
-				if (!entity) continue;
-				entity->Smash(LWOOBJID_EMPTY, eKillType::VIOLENT);
-			}
+
+	for (const auto& npc : m_NPCs) {
+		if (npc.m_ID == LWOOBJID_EMPTY) continue;
+		if (npc.m_LOT == 176){
+			Game::zoneManager->RemoveSpawner(npc.m_ID);
+		} else{
+			auto* entity = Game::entityManager->GetEntity(npc.m_ID);
+			if (!entity) continue;
+			entity->Smash(LWOOBJID_EMPTY, eKillType::VIOLENT);
 		}
-		m_NPCs.clear();
 	}
-	
-	if (!m_Parties.empty()){
-		m_Parties.clear();
-	}
-	if (!m_PartyPhrases.empty()){
-		m_PartyPhrases.clear();
-	}
+
+	m_NPCs.clear();
+	m_Parties.clear();
+	m_PartyPhrases.clear();
 
 	ParseXML((BinaryPathFinder::GetBinaryDir() / "vanity/NPC.xml").string());
 

--- a/dGame/dUtilities/VanityUtilities.cpp
+++ b/dGame/dUtilities/VanityUtilities.cpp
@@ -36,7 +36,6 @@ void VanityUtilities::SpawnVanity() {
 		for (auto& npc : m_NPCs) {
 			if (npc.m_ID == LWOOBJID_EMPTY) continue;
 			if (npc.m_LOT == 176){
-				LOG("Removing spawner %llu", npc.m_ID);
 				Game::zoneManager->RemoveSpawner(npc.m_ID);
 			} else{
 				auto* entity = Game::entityManager->GetEntity(npc.m_ID);
@@ -194,7 +193,6 @@ LWOOBJID VanityUtilities::SpawnSpawner(LOT lot, const NiPoint3& position, const 
 	obj.rotation = rotation;
 	obj.settings = ldf;
 	Level::MakeSpawner(obj);
-	LOG("created spawner %llu", obj.id);
 	return obj.id;
 }
 

--- a/dGame/dUtilities/VanityUtilities.cpp
+++ b/dGame/dUtilities/VanityUtilities.cpp
@@ -37,10 +37,11 @@ void VanityUtilities::SpawnVanity() {
 			if (npc.m_LOT == 176){
 				LOG("Removing spawner %llu", npc.m_ID);
 				Game::zoneManager->RemoveSpawner(npc.m_ID);
-			} 
-			auto* entity = Game::entityManager->GetEntity(npc.m_ID);
-			if (!entity) continue;
-			entity->Smash(LWOOBJID_EMPTY, eKillType::VIOLENT);
+			} else{
+				auto* entity = Game::entityManager->GetEntity(npc.m_ID);
+				if (!entity) continue;
+				entity->Smash(LWOOBJID_EMPTY, eKillType::VIOLENT);
+			}
 		}
 		m_NPCs.clear();
 	}
@@ -139,25 +140,26 @@ void VanityUtilities::SpawnVanity() {
 			auto* spawner = SpawnSpawner(npc.m_LOT, location.m_Position, location.m_Rotation, npc.ldf);
 			if (!spawner) continue;
 			npc.m_ID = spawner->m_Info.spawnerID;
-		}
-		// Spawn the NPC
-		auto* npcEntity = SpawnNPC(npc.m_LOT, npc.m_Name, location.m_Position, location.m_Rotation, npc.m_Equipment, npc.ldf, npc.m_ID);
-		if (!npcEntity) continue;
-		npc.m_ID = npcEntity->GetObjectID();
-		if (!npc.m_Phrases.empty()){
-			npcEntity->SetVar<std::vector<std::string>>(u"chats", npc.m_Phrases);
+		} else {
+			// Spawn the NPC
+			auto* npcEntity = SpawnNPC(npc.m_LOT, npc.m_Name, location.m_Position, location.m_Rotation, npc.m_Equipment, npc.ldf);
+			if (!npcEntity) continue;
+			npc.m_ID = npcEntity->GetObjectID();
+			if (!npc.m_Phrases.empty()){
+				npcEntity->SetVar<std::vector<std::string>>(u"chats", npc.m_Phrases);
 
-			auto* scriptComponent = npcEntity->GetComponent<ScriptComponent>();
+				auto* scriptComponent = npcEntity->GetComponent<ScriptComponent>();
 
-			if (scriptComponent && !npc.m_Script.empty()) {
-				scriptComponent->SetScript(npc.m_Script);
-				scriptComponent->SetSerialized(false);
+				if (scriptComponent && !npc.m_Script.empty()) {
+					scriptComponent->SetScript(npc.m_Script);
+					scriptComponent->SetSerialized(false);
 
-				for (const auto& npc : npc.m_Flags) {
-					npcEntity->SetVar<bool>(GeneralUtils::ASCIIToUTF16(npc.first), npc.second);
+					for (const auto& npc : npc.m_Flags) {
+						npcEntity->SetVar<bool>(GeneralUtils::ASCIIToUTF16(npc.first), npc.second);
+					}
 				}
+				SetupNPCTalk(npcEntity);
 			}
-			SetupNPCTalk(npcEntity);
 		}
 	}
 
@@ -251,13 +253,12 @@ Spawner* VanityUtilities::SpawnSpawner(LOT lot, const NiPoint3& position, const 
 	return spawner;
 }
 
-Entity* VanityUtilities::SpawnNPC(LOT lot, const std::string& name, const NiPoint3& position, const NiQuaternion& rotation, const std::vector<LOT>& inventory, const std::vector<LDFBaseData*>& ldf, const LWOOBJID ID) {
+Entity* VanityUtilities::SpawnNPC(LOT lot, const std::string& name, const NiPoint3& position, const NiQuaternion& rotation, const std::vector<LOT>& inventory, const std::vector<LDFBaseData*>& ldf) {
 	EntityInfo info;
 	info.lot = lot;
 	info.pos = position;
 	info.rot = rotation;
-	if (ID == LWOOBJID_EMPTY) info.spawnerID = Game::entityManager->GetZoneControlEntity()->GetObjectID();
-	else info.spawnerID = ID;
+	info.spawnerID = Game::entityManager->GetZoneControlEntity()->GetObjectID();
 	info.settings = ldf;
 
 	auto* entity = Game::entityManager->CreateEntity(info);

--- a/dGame/dUtilities/VanityUtilities.h
+++ b/dGame/dUtilities/VanityUtilities.h
@@ -42,8 +42,7 @@ public:
 		const NiPoint3& position,
 		const NiQuaternion& rotation,
 		const std::vector<LOT>& inventory,
-		const std::vector<LDFBaseData*>& ldf,
-		const LWOOBJID ID = LWOOBJID_EMPTY
+		const std::vector<LDFBaseData*>& ldf
 	);
 
 	static Spawner* SpawnSpawner(

--- a/dGame/dUtilities/VanityUtilities.h
+++ b/dGame/dUtilities/VanityUtilities.h
@@ -45,7 +45,7 @@ public:
 		const std::vector<LDFBaseData*>& ldf
 	);
 
-	static Spawner* SpawnSpawner(
+	static LWOOBJID SpawnSpawner(
 		LOT lot,
 		const NiPoint3& position,
 		const NiQuaternion& rotation,

--- a/dGame/dUtilities/VanityUtilities.h
+++ b/dGame/dUtilities/VanityUtilities.h
@@ -13,6 +13,7 @@ struct VanityNPCLocation
 
 struct VanityNPC
 {
+	LWOOBJID m_ID = LWOOBJID_EMPTY;
 	std::string m_Name;
 	LOT m_LOT;
 	std::vector<LOT> m_Equipment;
@@ -41,6 +42,14 @@ public:
 		const NiPoint3& position,
 		const NiQuaternion& rotation,
 		const std::vector<LOT>& inventory,
+		const std::vector<LDFBaseData*>& ldf,
+		const LWOOBJID ID = LWOOBJID_EMPTY
+	);
+
+	static Spawner* SpawnSpawner(
+		LOT lot,
+		const NiPoint3& position,
+		const NiQuaternion& rotation,
 		const std::vector<LDFBaseData*>& ldf
 	);
 

--- a/dZoneManager/Level.cpp
+++ b/dZoneManager/Level.cpp
@@ -38,6 +38,76 @@ Level::~Level() {
 	}
 }
 
+void Level::MakeSpawner(SceneObject obj){
+	SpawnerInfo spawnInfo = SpawnerInfo();
+	SpawnerNode* node = new SpawnerNode();
+	spawnInfo.templateID = obj.lot;
+	spawnInfo.spawnerID = obj.id;
+	spawnInfo.templateScale = obj.scale;
+	node->position = obj.position;
+	node->rotation = obj.rotation;
+	node->config = obj.settings;
+	spawnInfo.nodes.push_back(node);
+	for (LDFBaseData* data : obj.settings) {
+	if (data) {
+		if (data->GetKey() == u"spawntemplate") {
+			spawnInfo.templateID = std::stoi(data->GetValueAsString());
+		}
+
+		if (data->GetKey() == u"spawner_node_id") {
+			node->nodeID = std::stoi(data->GetValueAsString());
+		}
+
+		if (data->GetKey() == u"spawner_name") {
+			spawnInfo.name = data->GetValueAsString();
+		}
+
+		if (data->GetKey() == u"max_to_spawn") {
+			spawnInfo.maxToSpawn = std::stoi(data->GetValueAsString());
+		}
+
+		if (data->GetKey() == u"spawner_active_on_load") {
+			spawnInfo.activeOnLoad = std::stoi(data->GetValueAsString());
+		}
+
+		if (data->GetKey() == u"active_on_load") {
+			spawnInfo.activeOnLoad = std::stoi(data->GetValueAsString());
+		}
+
+		if (data->GetKey() == u"respawn") {
+			if (data->GetValueType() == eLDFType::LDF_TYPE_FLOAT) // Floats are in seconds
+			{
+				spawnInfo.respawnTime = std::stof(data->GetValueAsString());
+			} else if (data->GetValueType() == eLDFType::LDF_TYPE_U32) // Ints are in ms?
+			{
+				spawnInfo.respawnTime = std::stoul(data->GetValueAsString()) / 1000;
+			}
+		}
+		if (data->GetKey() == u"spawnsGroupOnSmash") {
+			spawnInfo.spawnsOnSmash = std::stoi(data->GetValueAsString());
+		}
+		if (data->GetKey() == u"spawnNetNameForSpawnGroupOnSmash") {
+			spawnInfo.spawnOnSmashGroupName = data->GetValueAsString();
+		}
+		if (data->GetKey() == u"groupID") { // Load object groups
+			std::string groupStr = data->GetValueAsString();
+			spawnInfo.groups = GeneralUtils::SplitString(groupStr, ';');
+			spawnInfo.groups.erase(spawnInfo.groups.end() - 1);
+		}
+		if (data->GetKey() == u"no_auto_spawn") {
+			spawnInfo.noAutoSpawn = static_cast<LDFData<bool>*>(data)->GetValue();
+		}
+		if (data->GetKey() == u"no_timed_spawn") {
+			spawnInfo.noTimedSpawn = static_cast<LDFData<bool>*>(data)->GetValue();
+		}
+		if (data->GetKey() == u"spawnActivator") {
+			spawnInfo.spawnActivator = static_cast<LDFData<bool>*>(data)->GetValue();
+		}
+	}
+	}
+	Game::zoneManager->MakeSpawner(spawnInfo);
+}
+
 const void Level::PrintAllObjects() {
 	for (std::map<uint32_t, Header>::iterator it = m_ChunkHeaders.begin(); it != m_ChunkHeaders.end(); ++it) {
 		if (it->second.id == Level::ChunkTypeID::SceneObjectData) {
@@ -230,74 +300,7 @@ void Level::ReadSceneObjectDataChunk(std::istream& file, Header& header) {
 		}
 
 		if (obj.lot == 176) { //Spawner
-			SpawnerInfo spawnInfo = SpawnerInfo();
-			SpawnerNode* node = new SpawnerNode();
-			spawnInfo.templateID = obj.lot;
-			spawnInfo.spawnerID = obj.id;
-			spawnInfo.templateScale = obj.scale;
-			node->position = obj.position;
-			node->rotation = obj.rotation;
-			node->config = obj.settings;
-			spawnInfo.nodes.push_back(node);
-			for (LDFBaseData* data : obj.settings) {
-				if (data) {
-					if (data->GetKey() == u"spawntemplate") {
-						spawnInfo.templateID = std::stoi(data->GetValueAsString());
-					}
-
-					if (data->GetKey() == u"spawner_node_id") {
-						node->nodeID = std::stoi(data->GetValueAsString());
-					}
-
-					if (data->GetKey() == u"spawner_name") {
-						spawnInfo.name = data->GetValueAsString();
-					}
-
-					if (data->GetKey() == u"max_to_spawn") {
-						spawnInfo.maxToSpawn = std::stoi(data->GetValueAsString());
-					}
-
-					if (data->GetKey() == u"spawner_active_on_load") {
-						spawnInfo.activeOnLoad = std::stoi(data->GetValueAsString());
-					}
-
-					if (data->GetKey() == u"active_on_load") {
-						spawnInfo.activeOnLoad = std::stoi(data->GetValueAsString());
-					}
-
-					if (data->GetKey() == u"respawn") {
-						if (data->GetValueType() == eLDFType::LDF_TYPE_FLOAT) // Floats are in seconds
-						{
-							spawnInfo.respawnTime = std::stof(data->GetValueAsString());
-						} else if (data->GetValueType() == eLDFType::LDF_TYPE_U32) // Ints are in ms?
-						{
-							spawnInfo.respawnTime = std::stoul(data->GetValueAsString()) / 1000;
-						}
-					}
-					if (data->GetKey() == u"spawnsGroupOnSmash") {
-						spawnInfo.spawnsOnSmash = std::stoi(data->GetValueAsString());
-					}
-					if (data->GetKey() == u"spawnNetNameForSpawnGroupOnSmash") {
-						spawnInfo.spawnOnSmashGroupName = data->GetValueAsString();
-					}
-					if (data->GetKey() == u"groupID") { // Load object groups
-						std::string groupStr = data->GetValueAsString();
-						spawnInfo.groups = GeneralUtils::SplitString(groupStr, ';');
-						spawnInfo.groups.erase(spawnInfo.groups.end() - 1);
-					}
-					if (data->GetKey() == u"no_auto_spawn") {
-						spawnInfo.noAutoSpawn = static_cast<LDFData<bool>*>(data)->GetValue();
-					}
-					if (data->GetKey() == u"no_timed_spawn") {
-						spawnInfo.noTimedSpawn = static_cast<LDFData<bool>*>(data)->GetValue();
-					}
-					if (data->GetKey() == u"spawnActivator") {
-						spawnInfo.spawnActivator = static_cast<LDFData<bool>*>(data)->GetValue();
-					}
-				}
-			}
-			Spawner* spawner = new Spawner(spawnInfo);
-			Game::zoneManager->AddSpawner(obj.id, spawner);
+			MakeSpawner(obj);
 		} else { //Regular object
 			EntityInfo info;
 			info.spawnerID = 0;

--- a/dZoneManager/Level.h
+++ b/dZoneManager/Level.h
@@ -53,6 +53,8 @@ public:
 public:
 	Level(Zone* parentZone, const std::string& filepath);
 	~Level();
+	
+	static void MakeSpawner(SceneObject obj);
 
 	const void PrintAllObjects();
 


### PR DESCRIPTION
This PR properly reload vanity things by destroying them first and clearing out the list before re-reading the xml from disk.
Additionally, support for spawners via vanity is added