### PR TITLE
fix: Ugc model pickup

### DIFF
--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -431,12 +431,11 @@ void PropertyManagementComponent::DeleteModel(const LWOOBJID id, const int delet
 		return;
 	}
 
-	if (model->GetLOT() == 14) {
+	LOG("delete reason %i", deleteReason);
+	if (model->GetLOT() == 14 && deleteReason == 0) {
 		LOG("User is trying to pick up a BBB model, but this is not implemented, so we return to prevent the user from losing the model");
 
-		if (deleteReason == 0 || deleteReason == 2) {
-			GameMessages::SendUGCEquipPostDeleteBasedOnEditMode(entity->GetObjectID(), entity->GetSystemAddress(), LWOOBJID_EMPTY, 0);
-		}
+		GameMessages::SendUGCEquipPostDeleteBasedOnEditMode(entity->GetObjectID(), entity->GetSystemAddress(), LWOOBJID_EMPTY, 0);
 
 		// Need this to pop the user out of their current state
 		GameMessages::SendPlaceModelResponse(entity->GetObjectID(), entity->GetSystemAddress(), entity->GetPosition(), m_Parent->GetObjectID(), 14, entity->GetRotation());

--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -423,6 +423,27 @@ void PropertyManagementComponent::DeleteModel(const LWOOBJID id, const int delet
 		return;
 	}
 
+	auto* model = Game::entityManager->GetEntity(id);
+
+	if (model == nullptr) {
+		LOG("Failed to find model entity");
+
+		return;
+	}
+
+	if (model->GetLOT() == 14) {
+		LOG("User is trying to pick up a BBB model, but this is not implemented, so we return to prevent the user from losing the model");
+
+		if (deleteReason == 0 || deleteReason == 2) {
+			GameMessages::SendUGCEquipPostDeleteBasedOnEditMode(entity->GetObjectID(), entity->GetSystemAddress(), LWOOBJID_EMPTY, 0);
+		}
+
+		// Need this to pop the user out of their current state
+		GameMessages::SendPlaceModelResponse(entity->GetObjectID(), entity->GetSystemAddress(), entity->GetPosition(), m_Parent->GetObjectID(), 14, entity->GetRotation());
+
+		return;
+	}
+
 	const auto index = models.find(id);
 
 	if (index == models.end()) {
@@ -439,14 +460,6 @@ void PropertyManagementComponent::DeleteModel(const LWOOBJID id, const int delet
 
 	if (spawner == nullptr) {
 		LOG("Failed to find spawner");
-	}
-
-	auto* model = Game::entityManager->GetEntity(id);
-
-	if (model == nullptr) {
-		LOG("Failed to find model entity");
-
-		return;
 	}
 
 	Game::entityManager->DestructEntity(model);

--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -431,7 +431,6 @@ void PropertyManagementComponent::DeleteModel(const LWOOBJID id, const int delet
 		return;
 	}
 
-	LOG("delete reason %i", deleteReason);
 	if (model->GetLOT() == 14 && deleteReason == 0) {
 		LOG("User is trying to pick up a BBB model, but this is not implemented, so we return to prevent the user from losing the model");
 


### PR DESCRIPTION
fix ugc models so they cannot be picked up on the property at all, as opposed to right now when they disappear and the user loses all their work for mis-pressing a button.

Tested that you can still make a new ugc model, place regular models, edit existing ugc models and trying to pick up an existing ugc model does nothing.  The user must manually dismantle the model in edit mode instead.