### PR TITLE
Fix: Pets can no longer dig treasure without completing Bella Pepper's "Lost Tags" mission

### DIFF
--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -29,6 +29,8 @@
 #include "RenderComponent.h"
 #include "eObjectBits.h"
 #include "eGameMasterLevel.h"
+#include "MissionComponent.h"
+#include "eMissionState.h"
 
 std::unordered_map<LOT, PetComponent::PetPuzzleData> PetComponent::buildCache{};
 std::unordered_map<LWOOBJID, LWOOBJID> PetComponent::currentActivities{};
@@ -439,9 +441,17 @@ void PetComponent::Update(float deltaTime) {
 		}
 	}
 
+	auto* missionComponent = owner->GetComponent<MissionComponent>();
+	if (missionComponent == nullptr) {
+		return;
+	}
+
+	// Determine if "Lost Tags" has been completed and digging has been unlocked
+	const bool digUnlocked = (missionComponent->GetMissionState(842) == eMissionState::COMPLETE);
+
 	Entity* closestTresure = PetDigServer::GetClosestTresure(position);
 
-	if (closestTresure != nullptr) {
+	if (closestTresure != nullptr && digUnlocked) {
 		// Skeleton Dragon Pat special case for bone digging
 		if (closestTresure->GetLOT() == 12192 && m_Parent->GetLOT() != 13067) {
 			goto skipTresure;

--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -29,7 +29,6 @@
 #include "RenderComponent.h"
 #include "eObjectBits.h"
 #include "eGameMasterLevel.h"
-#include "MissionComponent.h"
 #include "eMissionState.h"
 
 std::unordered_map<LOT, PetComponent::PetPuzzleData> PetComponent::buildCache{};
@@ -442,10 +441,10 @@ void PetComponent::Update(float deltaTime) {
 	}
 
 	auto* missionComponent = owner->GetComponent<MissionComponent>();
-	if (missionComponent == nullptr) return;
+	if (!missionComponent) return;
 
-	// Determine if "Lost Tags" has been completed and digging has been unlocked
-	const bool digUnlocked = (missionComponent->GetMissionState(842) == eMissionState::COMPLETE);
+	// Determine if the "Lost Tags" mission has been completed and digging has been unlocked
+	const bool digUnlocked = missionComponent->GetMissionState(842) == eMissionState::COMPLETE;
 
 	Entity* closestTresure = PetDigServer::GetClosestTresure(position);
 

--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -442,9 +442,7 @@ void PetComponent::Update(float deltaTime) {
 	}
 
 	auto* missionComponent = owner->GetComponent<MissionComponent>();
-	if (missionComponent == nullptr) {
-		return;
-	}
+	if (missionComponent == nullptr) return;
 
 	// Determine if "Lost Tags" has been completed and digging has been unlocked
 	const bool digUnlocked = (missionComponent->GetMissionState(842) == eMissionState::COMPLETE);


### PR DESCRIPTION
Fixes #535. Tested by playing character at Pet Cove who had not completed mission, and then switching to another character who had. Pet would not dig up treasure on the first character, but would on the second. Also took the first character to the Advent Gardens pet bouncer dig and found it was unable to dig (which is desired behavior).