### PR TITLE
fix: Models leak

### DIFF
--- a/dGame/dInventory/Item.cpp
+++ b/dGame/dInventory/Item.cpp
@@ -433,7 +433,7 @@ void Item::DisassembleModel() {
 		return;
 	}
 
-	auto* doc = new tinyxml2::XMLDocument();
+	std::unique_ptr<tinyxml2::XMLDocument> doc(new tinyxml2::XMLDocument());
 
 	if (!doc) {
 		return;


### PR DESCRIPTION
Fix a massive memory leak by deleting the doc after we are done using it.  Tested that the memory does not leak in the megabytes everytime you dismantle a model to bricks.