### PR TITLE
fix: properly check friend list limits

### DIFF
--- a/dChatServer/PlayerContainer.cpp
+++ b/dChatServer/PlayerContainer.cpp
@@ -14,12 +14,12 @@
 #include "dConfig.h"
 
 PlayerContainer::PlayerContainer() {
-	GeneralUtils::TryParse<uint32_t>(Game::config->GetValue("max_number_of_best_friends"), mMaxNumberOfBestFriends);
-	GeneralUtils::TryParse<uint32_t>(Game::config->GetValue("max_number_of_friends"), mMaxNumberOfFriends);
+	GeneralUtils::TryParse<uint32_t>(Game::config->GetValue("max_number_of_best_friends"), m_MaxNumberOfBestFriends);
+	GeneralUtils::TryParse<uint32_t>(Game::config->GetValue("max_number_of_friends"), m_MaxNumberOfFriends);
 }
 
 PlayerContainer::~PlayerContainer() {
-	mPlayers.clear();
+	m_Players.clear();
 }
 
 TeamData::TeamData() {
@@ -43,9 +43,9 @@ void PlayerContainer::InsertPlayer(Packet* packet) {
 	inStream.Read(data->muteExpire);
 	data->sysAddr = packet->systemAddress;
 
-	mNames[data->playerID] = GeneralUtils::UTF8ToUTF16(data->playerName);
+	m_Names[data->playerID] = GeneralUtils::UTF8ToUTF16(data->playerName);
 
-	mPlayers.insert(std::make_pair(data->playerID, data));
+	m_Players.insert(std::make_pair(data->playerID, data));
 	LOG("Added user: %s (%llu), zone: %i", data->playerName.c_str(), data->playerID, data->zoneID.GetMapID());
 
 	auto* insertLog = Database::CreatePreppedStmt("INSERT INTO activity_log (character_id, activity, time, map_id) VALUES (?, ?, ?, ?);");
@@ -90,7 +90,7 @@ void PlayerContainer::RemovePlayer(Packet* packet) {
 	}
 
 	LOG("Removed user: %llu", playerID);
-	mPlayers.erase(playerID);
+	m_Players.erase(playerID);
 
 	auto* insertLog = Database::CreatePreppedStmt("INSERT INTO activity_log (character_id, activity, time, map_id) VALUES (?, ?, ?, ?);");
 
@@ -193,7 +193,7 @@ TeamData* PlayerContainer::CreateLocalTeam(std::vector<LWOOBJID> members) {
 TeamData* PlayerContainer::CreateTeam(LWOOBJID leader, bool local) {
 	auto* team = new TeamData();
 
-	team->teamID = ++mTeamIDCounter;
+	team->teamID = ++m_TeamIDCounter;
 	team->leaderID = leader;
 	team->local = local;
 
@@ -378,15 +378,15 @@ void PlayerContainer::UpdateTeamsOnWorld(TeamData* team, bool deleteTeam) {
 }
 
 std::u16string PlayerContainer::GetName(LWOOBJID playerID) {
-	const auto& pair = mNames.find(playerID);
+	const auto& pair = m_Names.find(playerID);
 
-	if (pair == mNames.end()) return u"";
+	if (pair == m_Names.end()) return u"";
 
 	return pair->second;
 }
 
 LWOOBJID PlayerContainer::GetId(const std::u16string& playerName) {
-	for (const auto& pair : mNames) {
+	for (const auto& pair : m_Names) {
 		if (pair.second == playerName) {
 			return pair.first;
 		}

--- a/dChatServer/PlayerContainer.cpp
+++ b/dChatServer/PlayerContainer.cpp
@@ -14,6 +14,8 @@
 #include "dConfig.h"
 
 PlayerContainer::PlayerContainer() {
+	GeneralUtils::TryParse<uint32_t>(Game::config->GetValue("max_number_of_best_friends"), maxNumberOfBestFriends);
+	GeneralUtils::TryParse<uint32_t>(Game::config->GetValue("max_number_of_friends"), maxNumberOfFriends);
 }
 
 PlayerContainer::~PlayerContainer() {

--- a/dChatServer/PlayerContainer.cpp
+++ b/dChatServer/PlayerContainer.cpp
@@ -14,8 +14,8 @@
 #include "dConfig.h"
 
 PlayerContainer::PlayerContainer() {
-	GeneralUtils::TryParse<uint32_t>(Game::config->GetValue("max_number_of_best_friends"), maxNumberOfBestFriends);
-	GeneralUtils::TryParse<uint32_t>(Game::config->GetValue("max_number_of_friends"), maxNumberOfFriends);
+	GeneralUtils::TryParse<uint32_t>(Game::config->GetValue("max_number_of_best_friends"), mMaxNumberOfBestFriends);
+	GeneralUtils::TryParse<uint32_t>(Game::config->GetValue("max_number_of_friends"), mMaxNumberOfFriends);
 }
 
 PlayerContainer::~PlayerContainer() {

--- a/dChatServer/PlayerContainer.h
+++ b/dChatServer/PlayerContainer.h
@@ -39,13 +39,13 @@ public:
 	void BroadcastMuteUpdate(LWOOBJID player, time_t time);
 
 	PlayerData* GetPlayerData(const LWOOBJID& playerID) {
-		auto it = mPlayers.find(playerID);
-		if (it != mPlayers.end()) return it->second;
+		auto it = m_Players.find(playerID);
+		if (it != m_Players.end()) return it->second;
 		return nullptr;
 	}
 
 	PlayerData* GetPlayerData(const std::string& playerName) {
-		for (auto player : mPlayers) {
+		for (auto player : m_Players) {
 			if (player.second) {
 				std::string pn = player.second->playerName.c_str();
 				if (pn == playerName) return player.second;
@@ -67,17 +67,17 @@ public:
 	std::u16string GetName(LWOOBJID playerID);
 	LWOOBJID GetId(const std::u16string& playerName);
 	bool GetIsMuted(PlayerData* data);
-	uint32_t GetMaxNumberOfBestFriends() { return mMaxNumberOfBestFriends; }
-	uint32_t GetMaxNumberOfFriends() { return mMaxNumberOfFriends; }
+	uint32_t GetMaxNumberOfBestFriends() { return m_MaxNumberOfBestFriends; }
+	uint32_t GetMaxNumberOfFriends() { return m_MaxNumberOfFriends; }
 
-	std::map<LWOOBJID, PlayerData*>& GetAllPlayerData() { return mPlayers; }
+	std::map<LWOOBJID, PlayerData*>& GetAllPlayerData() { return m_Players; }
 
 private:
-	LWOOBJID mTeamIDCounter = 0;
-	std::map<LWOOBJID, PlayerData*> mPlayers;
+	LWOOBJID m_TeamIDCounter = 0;
+	std::map<LWOOBJID, PlayerData*> m_Players;
 	std::vector<TeamData*> mTeams;
-	std::unordered_map<LWOOBJID, std::u16string> mNames;
-	uint32_t mMaxNumberOfBestFriends = 5;
-	uint32_t mMaxNumberOfFriends = 50;
+	std::unordered_map<LWOOBJID, std::u16string> m_Names;
+	uint32_t m_MaxNumberOfBestFriends = 5;
+	uint32_t m_MaxNumberOfFriends = 50;
 };
 

--- a/dChatServer/PlayerContainer.h
+++ b/dChatServer/PlayerContainer.h
@@ -67,6 +67,8 @@ public:
 	std::u16string GetName(LWOOBJID playerID);
 	LWOOBJID GetId(const std::u16string& playerName);
 	bool GetIsMuted(PlayerData* data);
+	uint32_t GetMaxNumberOfBestFriends() { return mMaxNumberOfBestFriends; }
+	uint32_t GetMaxNumberOfFriends() { return mMaxNumberOfFriends; }
 
 	std::map<LWOOBJID, PlayerData*>& GetAllPlayerData() { return mPlayers; }
 
@@ -75,5 +77,7 @@ private:
 	std::map<LWOOBJID, PlayerData*> mPlayers;
 	std::vector<TeamData*> mTeams;
 	std::unordered_map<LWOOBJID, std::u16string> mNames;
+	uint32_t mMaxNumberOfBestFriends = 5;
+	uint32_t mMaxNumberOfFriends = 50;
 };
 

--- a/resources/chatconfig.ini
+++ b/resources/chatconfig.ini
@@ -1,2 +1,11 @@
 # Port number
 port=2005
+
+# If you would like to increase the maximum number of best friends a player can have on the server
+# Change the value below to what you would like this to be (5 is live accurate)
+max_number_of_best_friends=5
+
+# If you would like to increase the maximum number of friends a player can have on the server
+# Change the value below to what you would like this to be (50 is live accurate)
+# going over 50 will be allowed in some secnarios, but proper handling will require client modding
+max_number_of_friends=50

--- a/resources/worldconfig.ini
+++ b/resources/worldconfig.ini
@@ -40,10 +40,6 @@ classic_survival_scoring=0
 # If this value is 1, pets will consume imagination as they did in live.  if 0 they will not consume imagination at all.
 pets_take_imagination=1
 
-# If you would like to increase the maximum number of best friends a player can have on the server
-# Change the value below to what you would like this to be (5 is live accurate)
-max_number_of_best_friends=5
-
 # Disables loot drops
 disable_drops=0
 


### PR DESCRIPTION
added a config for friend list limit for the brave that want to mod the client to sanely go over 50 
moved the best friend limit config to chatconfig.ini where it should be 
cleanup loading these configs options a bit

Tested that the BFF limit works still and that the new friend limit works as well
fixes #798 