### PR TITLE
fix: UB in remote input info

### DIFF
--- a/dGame/dComponents/VehiclePhysicsComponent.h
+++ b/dGame/dComponents/VehiclePhysicsComponent.h
@@ -6,6 +6,13 @@
 #include "eReplicaComponentType.h"
 
 struct RemoteInputInfo {
+	RemoteInputInfo() {
+		m_RemoteInputX = 0;
+		m_RemoteInputY = 0;
+		m_IsPowersliding = false;
+		m_IsModified = false;
+	}
+
 	void operator=(const RemoteInputInfo& other) {
 		m_RemoteInputX = other.m_RemoteInputX;
 		m_RemoteInputY = other.m_RemoteInputY;


### PR DESCRIPTION
Yes i should have made this first
no this wouldnt have happened with rust

I have NO clue why the new AddComponent caused this.  I dug into this for about 10 hours and it was specifically having the PossessableComponent go through the new AddComponent and nothing else.  Using the inline variant resulted in the same effect.  The RemoteInputInfo in the previous case was always initialized to 0 0 0 1, whereas with the new AddComponent for Possessable, it was UB.  

Tested that the client no longer logs HAVOK CRASH ON FRICTION multiple times per frame