### PR TITLE
fix: Racing end of race leaderboards now work

### DIFF
--- a/dGame/dComponents/RacingControlComponent.h
+++ b/dGame/dComponents/RacingControlComponent.h
@@ -151,13 +151,6 @@ public:
 	 */
 	RacingPlayerInfo* GetPlayerData(LWOOBJID playerID);
 
-	/**
-	 * Formats a time to a string, currently unused
-	 * @param time the time to format
-	 * @return the time formatted as string
-	 */
-	static std::string FormatTimeString(time_t time);
-
 private:
 
 	/**
@@ -251,4 +244,5 @@ private:
 	 * Value for message box response to know if we are exiting the race via the activity dialogue
 	 */
 	const int32_t m_ActivityExitConfirm = 1;
+	bool m_AllPlayersReady = false;
 };

--- a/dGame/dComponents/VehiclePhysicsComponent.h
+++ b/dGame/dComponents/VehiclePhysicsComponent.h
@@ -6,6 +6,13 @@
 #include "eReplicaComponentType.h"
 
 struct RemoteInputInfo {
+	RemoteInputInfo() {
+		m_RemoteInputX = 0;
+		m_RemoteInputY = 0;
+		m_IsPowersliding = false;
+		m_IsModified = false;
+	}
+
 	void operator=(const RemoteInputInfo& other) {
 		m_RemoteInputX = other.m_RemoteInputX;
 		m_RemoteInputY = other.m_RemoteInputY;


### PR DESCRIPTION
Tested that with two players, both players see the others time at the end of the race and all other metrics are shown correctly.

Technically the `outBitStream->Write(static_cast<uint16_t>(m_RacingPlayers.size()));` should only be written once but how we do it now it is written as we load players in and this is the cheap option compared to the number of bits we are supposed to waste at the end of races

Removed an unused function and linted the file.  Hide whitespace if you don't want to see those changes.