### PR TITLE
fix: nexus tower smashable

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -554,6 +554,12 @@ void Entity::Initialize() {
 				Loot::CacheMatrix(activityID);
 			}
 
+			const auto timeBeforeSmash = GetVar<float>(u"tmeSmsh");
+
+			if (timeBeforeSmash > 0) {
+				rebuildComponent->SetTimeBeforeSmash(timeBeforeSmash);
+			}
+
 			const auto compTime = GetVar<float>(u"compTime");
 
 			if (compTime > 0) {


### PR DESCRIPTION
Tested that the crate near the venture league now smashes