### PR TITLE
fix: respawn rotation

### DIFF
--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -944,14 +944,7 @@ void GameMessages::SendResurrect(Entity* entity) {
 				destroyableComponent->SetImagination(imaginationToRestore);
 			}
 		}
-		});
-
-
-	auto cont = static_cast<ControllablePhysicsComponent*>(entity->GetComponent(eReplicaComponentType::CONTROLLABLE_PHYSICS));
-	if (cont && entity->GetLOT() == 1) {
-		cont->SetPosition(entity->GetRespawnPosition());
-		cont->SetRotation(entity->GetRespawnRotation());
-	}
+	});
 
 	CBITSTREAM;
 	CMSGHEADER;
@@ -1140,21 +1133,13 @@ void GameMessages::SendPlayerReachedRespawnCheckpoint(Entity* entity, const NiPo
 	bitStream.Write(entity->GetObjectID());
 	bitStream.Write((uint16_t)eGameMessageType::PLAYER_REACHED_RESPAWN_CHECKPOINT);
 
-	bitStream.Write(position.x);
-	bitStream.Write(position.y);
-	bitStream.Write(position.z);
+	bitStream.Write(position);
 
-	auto con = static_cast<ControllablePhysicsComponent*>(entity->GetComponent(eReplicaComponentType::CONTROLLABLE_PHYSICS));
-	if (con) {
-		auto rot = con->GetRotation();
-		bitStream.Write(rot.x);
-		bitStream.Write(rot.y);
-		bitStream.Write(rot.z);
-		bitStream.Write(rot.w);
+	const bool isNotIdentity = rotation != NiQuaternion::IDENTITY;
+	bitStream.Write(isNotIdentity);
+	if (isNotIdentity) {
+		bitStream.Write(rotation);
 	}
-
-	//bitStream.Write(position);
-	//bitStream.Write(rotation);
 
 	SystemAddress sysAddr = entity->GetSystemAddress();
 	SEND_PACKET;

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -1133,12 +1133,18 @@ void GameMessages::SendPlayerReachedRespawnCheckpoint(Entity* entity, const NiPo
 	bitStream.Write(entity->GetObjectID());
 	bitStream.Write((uint16_t)eGameMessageType::PLAYER_REACHED_RESPAWN_CHECKPOINT);
 
-	bitStream.Write(position);
+	bitStream.Write(position.x);
+	bitStream.Write(position.y);
+	bitStream.Write(position.z);
 
 	const bool isNotIdentity = rotation != NiQuaternion::IDENTITY;
 	bitStream.Write(isNotIdentity);
+	
 	if (isNotIdentity) {
-		bitStream.Write(rotation);
+		bitStream.Write(rotation.w);
+		bitStream.Write(rotation.x);
+		bitStream.Write(rotation.y);
+		bitStream.Write(rotation.z);
 	}
 
 	SystemAddress sysAddr = entity->GetSystemAddress();


### PR DESCRIPTION
Fixed off-by-one error in the PlayerReachedRespawnCheckpoint GM bitstream (thanks aron) and removed some unnecessary code that set player rotation and position (which was promptly overwritten by the client anyway).