### PR TITLE
fix: visiting multiple owned by same person

### DIFF
--- a/dGame/dComponents/PropertyManagementComponent.h
+++ b/dGame/dComponents/PropertyManagementComponent.h
@@ -164,6 +164,8 @@ public:
 
 	LWOCLONEID GetCloneId() { return clone_Id; };
 
+	LWOOBJID GetId() const noexcept { return propertyId; }
+
 private:
 	/**
 	 * This

--- a/dScripts/BasePropertyServer.cpp
+++ b/dScripts/BasePropertyServer.cpp
@@ -101,7 +101,7 @@ void BasePropertyServer::BasePlayerLoaded(Entity* self, Entity* player) {
 				missionComponent->Progress(
 					eMissionTaskType::VISIT_PROPERTY,
 					mapID.GetMapID(),
-					mapID.GetCloneID()
+					PropertyManagementComponent::Instance()->GetId()
 				);
 			}
 		}


### PR DESCRIPTION
will test later, should allow you to get credit for visiting player A's block yard and player A's other properties instead of just 1 of player A's properties.