### PR TITLE
fix: tacarc not using offset or checking upper/lower bounds

### DIFF
--- a/dGame/dBehaviors/TacArcBehavior.cpp
+++ b/dGame/dBehaviors/TacArcBehavior.cpp
@@ -104,7 +104,7 @@ void TacArcBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitS
 
 	const auto casterPosition = self->GetPosition();
 
-	auto reference = self->GetPosition(); //+ m_offset;
+	auto reference = self->GetPosition() + m_offset;
 
 	targets.clear();
 
@@ -114,46 +114,34 @@ void TacArcBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitS
 	context->FilterTargets(validTargets, this->m_ignoreFactionList, this->m_includeFactionList, this->m_targetSelf, this->m_targetEnemy, this->m_targetFriend, this->m_targetTeam);
 
 	for (auto validTarget : validTargets) {
-		if (targets.size() >= this->m_maxTargets) {
-			break;
-		}
-
-		if (std::find(targets.begin(), targets.end(), validTarget) != targets.end()) {
-			continue;
-		}
-
+		if (targets.size() >= this->m_maxTargets) break;
+		if (std::find(targets.begin(), targets.end(), validTarget) != targets.end()) continue;
 		if (validTarget->GetIsDead()) continue;
 
-		const auto otherPosition = validTarget->GetPosition();
+		const auto targetPos = validTarget->GetPosition();
 
-		const auto heightDifference = std::abs(otherPosition.y - casterPosition.y);
-
-		/*if (otherPosition.y > reference.y && heightDifference > this->m_upperBound || otherPosition.y < reference.y && heightDifference > this->m_lowerBound)
-		{
+		// make sure we aren't too high or low in comparison to the targer
+		const auto heightDifference = abs(reference.y - targetPos.y);
+		if (targetPos.y > reference.y && heightDifference > this->m_upperBound || targetPos.y < reference.y && heightDifference > this->m_lowerBound)
 			continue;
-		}*/
 
 		const auto forward = self->GetRotation().GetForwardVector();
 
 		// forward is a normalized vector of where the caster is facing.
-		// otherPosition is the position of the target.
+		// targetPos is the position of the target.
 		// reference is the position of the caster.
 		// If we cast a ray forward from the caster, does it come within m_farWidth of the target?
 
-		const auto distance = Vector3::Distance(reference, otherPosition);
+		const auto distance = Vector3::Distance(reference, targetPos);
 
 		if (m_method == 2) {
 			NiPoint3 rayPoint = casterPosition + forward * distance;
-
-			if (m_farWidth > 0 && Vector3::DistanceSquared(rayPoint, otherPosition) > this->m_farWidth * this->m_farWidth) {
+			if (m_farWidth > 0 && Vector3::DistanceSquared(rayPoint, targetPos) > this->m_farWidth * this->m_farWidth)
 				continue;
-			}
 		}
 
-		auto normalized = (reference - otherPosition) / distance;
-
+		auto normalized = (reference - targetPos) / distance;
 		const float degreeAngle = std::abs(Vector3::Angle(forward, normalized) * (180 / 3.14) - 180);
-
 		if (distance >= this->m_minRange && this->m_maxRange >= distance && degreeAngle <= 2 * this->m_angle) {
 			targets.push_back(validTarget);
 		}
@@ -167,33 +155,26 @@ void TacArcBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitS
 		});
 
 	const auto hit = !targets.empty();
-
 	bitStream->Write(hit);
 
 	if (this->m_checkEnv) {
 		const auto blocked = false; // TODO
-
 		bitStream->Write(blocked);
 	}
 
 	if (hit) {
-		if (combatAi != nullptr) {
-			combatAi->LookAt(targets[0]->GetPosition());
-		}
+		if (combatAi) combatAi->LookAt(targets[0]->GetPosition());
 
 		context->foundTarget = true; // We want to continue with this behavior
-
 		const auto count = static_cast<uint32_t>(targets.size());
 
 		bitStream->Write(count);
-
 		for (auto* target : targets) {
 			bitStream->Write(target->GetObjectID());
 		}
 
 		for (auto* target : targets) {
 			branch.target = target->GetObjectID();
-
 			this->m_action->Calculate(context, bitStream, branch);
 		}
 	} else {
@@ -214,8 +195,8 @@ void TacArcBehavior::Load() {
 		GetFloat("offset_z", 0.0f)
 	);
 	this->m_method = GetInt("method", 1);
-	this->m_upperBound = GetFloat("upper_bound", 4.4f);
-	this->m_lowerBound = GetFloat("lower_bound", 0.4f);
+	this->m_upperBound = abs(GetFloat("upper_bound", 4.4f));
+	this->m_lowerBound = abs(GetFloat("lower_bound", 0.4f));
 	this->m_usePickedTarget = GetBoolean("use_picked_target", false);
 	this->m_useTargetPostion = GetBoolean("use_target_position", false);
 	this->m_checkEnv = GetBoolean("check_env", false);

--- a/dGame/dBehaviors/TacArcBehavior.cpp
+++ b/dGame/dBehaviors/TacArcBehavior.cpp
@@ -121,7 +121,7 @@ void TacArcBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bitS
 		const auto targetPos = validTarget->GetPosition();
 
 		// make sure we aren't too high or low in comparison to the targer
-		const auto heightDifference = abs(reference.y - targetPos.y);
+		const auto heightDifference = std::abs(reference.y - targetPos.y);
 		if (targetPos.y > reference.y && heightDifference > this->m_upperBound || targetPos.y < reference.y && heightDifference > this->m_lowerBound)
 			continue;
 
@@ -195,8 +195,8 @@ void TacArcBehavior::Load() {
 		GetFloat("offset_z", 0.0f)
 	);
 	this->m_method = GetInt("method", 1);
-	this->m_upperBound = abs(GetFloat("upper_bound", 4.4f));
-	this->m_lowerBound = abs(GetFloat("lower_bound", 0.4f));
+	this->m_upperBound = std::abs(GetFloat("upper_bound", 4.4f));
+	this->m_lowerBound = std::abs(GetFloat("lower_bound", 0.4f));
 	this->m_usePickedTarget = GetBoolean("use_picked_target", false);
 	this->m_useTargetPostion = GetBoolean("use_target_position", false);
 	this->m_checkEnv = GetBoolean("check_env", false);


### PR DESCRIPTION
Tested in crux that enemies attack normally while on the ground, but skeleton engineers use the knockback attack when up on the tower to knock you off.

tested with other enemies around crux to make sure they felt accurate as well.

Also did some other cleanup to make it more readable

Fixes #956 