### PR TITLE
fix: backwards name check

### DIFF
--- a/dGame/UserManager.cpp
+++ b/dGame/UserManager.cpp
@@ -405,7 +405,7 @@ void UserManager::RenameCharacter(const SystemAddress& sysAddr, Packet* packet) 
 			return;
 		}
 
-		if (Database::Get()->GetCharacterInfo(newName)) {
+		if (!Database::Get()->GetCharacterInfo(newName)) {
 			if (IsNamePreapproved(newName)) {
 				Database::Get()->SetCharacterName(charID, newName);
 				LOG("Character %s now known as %s", character->GetName().c_str(), newName.c_str());


### PR DESCRIPTION
Untested.  Should fix not being able to rename a character at character create