### PR TITLE
fix: use defaults when getting variables for jetpack behavior

### DIFF
--- a/dGame/dBehaviors/JetPackBehavior.cpp
+++ b/dGame/dBehaviors/JetPackBehavior.cpp
@@ -38,10 +38,12 @@ void JetPackBehavior::Calculate(BehaviorContext* context, RakNet::BitStream* bit
 }
 
 void JetPackBehavior::Load() {
-	this->m_WarningEffectID = GetInt("warning_effect_id");
-	this->m_Airspeed = GetFloat("airspeed");
-	this->m_MaxAirspeed = GetFloat("max_airspeed");
-	this->m_VerticalVelocity = GetFloat("vertical_velocity");
-	this->m_EnableHover = GetBoolean("enable_hover");
-	this->m_BypassChecks = GetBoolean("bypass_checks", true);
+	this->m_WarningEffectID = GetInt("warning_effect_id", -1);
+	this->m_Airspeed = GetFloat("airspeed", 10);
+	this->m_MaxAirspeed = GetFloat("max_airspeed", 15);
+	this->m_VerticalVelocity = GetFloat("vertical_velocity", 1);
+	this->m_EnableHover = GetBoolean("enable_hover", false);
+
+	// TODO: Implement proper jetpack checks, so we can set this default to false
+	this->m_BypassChecks = GetBoolean("bypass_checks", true); 
 }


### PR DESCRIPTION
Tested that the hover jetpack now works and that the normal jetpack still works