### PR TITLE
Fix: Log Output WorldServer "Server is listening on "IP""

### DIFF
--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -209,7 +209,7 @@ int main(int argc, char** argv) {
 	UserManager::Instance()->Initialize();
 	Game::chatFilter = new dChatFilter(Game::assetManager->GetResPath().string() + "/chatplus_en_us", bool(std::stoi(Game::config->GetValue("dont_generate_dcf"))));
 
-	Game::server = new dServer(masterIP, ourPort, instanceID, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::World, Game::config, &Game::shouldShutdown, zoneID);
+	Game::server = new dServer(Game::config->GetValue("external_ip"), ourPort, instanceID, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::World, Game::config, &Game::shouldShutdown, zoneID);
 
 	//Connect to the chat server:
 	uint32_t chatPort = 1501;


### PR DESCRIPTION
Fixes the Log Output for Server is listening on "IP" from many 0`s to the IP set in sharedconfig.ini

before:

![Screenshot 2023-12-01 081807](https://github.com/DarkflameUniverse/DarkflameServer/assets/79744524/84619661-8399-41f6-8a79-9d57e210cf52)

after:

![Screenshot 2023-12-01 082114](https://github.com/DarkflameUniverse/DarkflameServer/assets/79744524/3fc509ee-b683-4ed5-b72e-bbe52012db4e)
