### PR TITLE
fix: general crashes

### DIFF
--- a/dGame/User.cpp
+++ b/dGame/User.cpp
@@ -110,3 +110,7 @@ void User::UserOutOfSync() {
 		Game::server->Disconnect(this->m_SystemAddress, eServerDisconnectIdentifiers::PLAY_SCHEDULE_TIME_DONE);
 	}
 }
+
+void User::UpdateBestFriendValue(const std::string_view playerName, const bool newValue) {
+	m_IsBestFriendMap[playerName.data()] = newValue;
+}

--- a/dGame/User.h
+++ b/dGame/User.h
@@ -43,8 +43,8 @@ public:
 	bool GetLastChatMessageApproved() { return m_LastChatMessageApproved; }
 	void SetLastChatMessageApproved(bool approved) { m_LastChatMessageApproved = approved; }
 
-	std::unordered_map<std::string, bool> GetIsBestFriendMap() { return m_IsBestFriendMap; }
-	void SetIsBestFriendMap(std::unordered_map<std::string, bool> mapToSet) { m_IsBestFriendMap = mapToSet; }
+	const std::unordered_map<std::string, bool>& GetIsBestFriendMap() { return m_IsBestFriendMap; }
+	void UpdateBestFriendValue(const std::string_view playerName, const bool newValue);
 
 	bool GetIsMuted() const;
 

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -5578,7 +5578,7 @@ void GameMessages::HandleModularBuildFinish(RakNet::BitStream* inStream, Entity*
 
 			std::unique_ptr<sql::PreparedStatement> stmt(Database::Get()->CreatePreppedStmt("INSERT INTO ugc_modular_build (ugc_id, ldf_config, character_id) VALUES (?,?,?)"));
 			stmt->setUInt64(1, newIdBig);
-			stmt->setString(2, GeneralUtils::UTF16ToWTF8(modules));
+			stmt->setString(2, GeneralUtils::UTF16ToWTF8(modules).c_str());
 			auto* pCharacter = character->GetCharacter();
 			pCharacter ? stmt->setUInt(3, pCharacter->GetID()) : stmt->setNull(3, sql::DataType::BIGINT);
 			stmt->execute();

--- a/dNet/ClientPackets.cpp
+++ b/dNet/ClientPackets.cpp
@@ -359,8 +359,8 @@ void ClientPackets::HandleChatModerationRequest(const SystemAddress& sysAddr, Pa
 				idOfReceiver = characterIdFetch->id;
 			}
 		}
-
-		if (user->GetIsBestFriendMap().find(receiver) == user->GetIsBestFriendMap().end() && idOfReceiver != LWOOBJID_EMPTY) {
+		const auto& bffMap = user->GetIsBestFriendMap();
+		if (bffMap.find(receiver) == bffMap.end() && idOfReceiver != LWOOBJID_EMPTY) {
 			auto bffInfo = Database::Get()->GetBestFriendStatus(entity->GetObjectID(), idOfReceiver);
 
 			if (bffInfo) {
@@ -368,11 +368,9 @@ void ClientPackets::HandleChatModerationRequest(const SystemAddress& sysAddr, Pa
 			}
 
 			if (isBestFriend) {
-				auto tmpBestFriendMap = user->GetIsBestFriendMap();
-				tmpBestFriendMap[receiver] = true;
-				user->SetIsBestFriendMap(tmpBestFriendMap);
+				user->UpdateBestFriendValue(receiver, true);
 			}
-		} else if (user->GetIsBestFriendMap().find(receiver) != user->GetIsBestFriendMap().end()) {
+		} else if (bffMap.find(receiver) != bffMap.end()) {
 			isBestFriend = true;
 		}
 	}

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -18,6 +18,7 @@
 #include "PerformanceManager.h"
 #include "Diagnostics.h"
 #include "BinaryPathFinder.h"
+#include "dPlatforms.h"
 
 //RakNet includes:
 #include "RakNetDefines.h"
@@ -1284,11 +1285,13 @@ void WorldShutdownProcess(uint32_t zoneId) {
 }
 
 void WorldShutdownSequence() {
-	if (Game::shouldShutdown || worldShutdownSequenceComplete) {
+	Game::shouldShutdown = true;
+#ifndef DARKFLAME_PLATFORM_WIN32
+	if (Game::shouldShutdown || worldShutdownSequenceComplete)
+#endif
+	{
 		return;
 	}
-
-	Game::shouldShutdown = true;
 
 	LOG("Zone (%i) instance (%i) shutting down outside of main loop!", Game::server->GetZoneID(), instanceID);
 	WorldShutdownProcess(Game::server->GetZoneID());
@@ -1302,11 +1305,17 @@ void FinalizeShutdown() {
 	Metrics::Clear();
 	Database::Destroy("WorldServer");
 	if (Game::chatFilter) delete Game::chatFilter;
+	Game::chatFilter = nullptr;
 	if (Game::zoneManager) delete Game::zoneManager;
+	Game::zoneManager = nullptr;
 	if (Game::server) delete Game::server;
+	Game::server = nullptr;
 	if (Game::config) delete Game::config;
+	Game::config = nullptr;
 	if (Game::entityManager) delete Game::entityManager;
+	Game::entityManager = nullptr;
 	if (Game::logger) delete Game::logger;
+	Game::logger = nullptr;
 
 	worldShutdownSequenceComplete = true;
 

--- a/dZoneManager/dZoneManager.cpp
+++ b/dZoneManager/dZoneManager.cpp
@@ -79,8 +79,6 @@ dZoneManager::~dZoneManager() {
 			delete p.second;
 			p.second = nullptr;
 		}
-
-		m_Spawners.erase(p.first);
 	}
 	if (m_WorldConfig) delete m_WorldConfig;
 }


### PR DESCRIPTION
fix crash with chat filter
fix ldf_config being empty in database on windows debug
fix windows crashes on shutdown
fix zonemanager crash on shutdown

Tested that the ldf_config column has data in it in the database now on windows debug
tested that you cannot crash the server as per #1335 
tested that no more crashes happen on world shutdown with players in the world on windows

fixes #1335 
fixes #1244 
