### PR TITLE
fix: Imagination costs that equal your capacity no longer abort quickbuilds unneccessarily

### DIFF
--- a/dGame/dComponents/RebuildComponent.cpp
+++ b/dGame/dComponents/RebuildComponent.cpp
@@ -197,18 +197,17 @@ void RebuildComponent::Update(float deltaTime) {
 			DestroyableComponent* destComp = builder->GetComponent<DestroyableComponent>();
 			if (!destComp) break;
 
-			int newImagination = destComp->GetImagination();
-
 			++m_DrainedImagination;
-			--newImagination;
+			const int32_t imaginationCostRemaining = m_TakeImagination - m_DrainedImagination;
+
+			const int32_t newImagination = destComp->GetImagination() - 1;
 			destComp->SetImagination(newImagination);
 			Game::entityManager->SerializeEntity(builder);
 
-			if (newImagination <= 0) {
+			if (newImagination <= 0 && imaginationCostRemaining > 0) {
 				CancelRebuild(builder, eQuickBuildFailReason::OUT_OF_IMAGINATION, true);
 				break;
 			}
-
 		}
 
 		if (m_Timer >= m_CompleteTime && m_DrainedImagination >= m_TakeImagination) {

--- a/dGame/dComponents/RebuildComponent.h
+++ b/dGame/dComponents/RebuildComponent.h
@@ -285,7 +285,7 @@ private:
 	float m_CompleteTime = 0;
 
 	/**
-	 * The imagination that's deducted when compeleting the rebuild
+	 * The imagination that's deducted when completing the rebuild
 	 */
 	int m_TakeImagination = 0;
 


### PR DESCRIPTION
Fixes #1285 by adding a check to see the remaining quickbuild imagination cost. If the remaining quickbuild imagination cost is not greater than zero, the quickbuild interaction is not cancelled when a player reaches 0 imagination, allowing them to finish the quickbuild correctly.