### PR TITLE
fix: Using 'leave-zone' in Return to the Venture Explorer allows players to return to the original Venture Explorer map

### DIFF
--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -291,7 +291,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 	if (chatCommand == "leave-zone" || chatCommand == "leavezone") {
 		const auto currentZone = Game::zoneManager->GetZone()->GetZoneID().GetMapID();
 		const auto VeZoneBugEnabled = Game::config->GetValue("enable_venture_explorer_bug");
-		LWOMAPID newZone;
+		LWOMAPID newZone = 0;
 
 		if (currentZone == 1001 && VeZoneBugEnabled != "1") {
 			newZone = 1100; // Send to AG if we're in a Return to Venture Explorer instance

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -290,10 +290,10 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 	if (chatCommand == "leave-zone" || chatCommand == "leavezone") {
 		const auto currentZone = Game::zoneManager->GetZone()->GetZoneID().GetMapID();
-		const auto VeZoneBugEnabled = Game::config->GetValue("enable_venture_explorer_bug");
+		const auto veZoneBugEnabled = Game::config->GetValue("enable_venture_explorer_bug");
 		LWOMAPID newZone = 0;
 
-		if (currentZone == 1001 && VeZoneBugEnabled != "1") {
+		if (currentZone == 1001 && veZoneBugEnabled != "1") {
 			newZone = 1100; // Send to AG if we're in a Return to Venture Explorer instance
 		} else if (currentZone % 100 == 0) {
 			ChatPackets::SendSystemMessage(sysAddr, u"You are not in an instanced zone.");

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -290,10 +290,9 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 
 	if (chatCommand == "leave-zone" || chatCommand == "leavezone") {
 		const auto currentZone = Game::zoneManager->GetZone()->GetZoneID().GetMapID();
-		const auto veZoneBugEnabled = Game::config->GetValue("enable_venture_explorer_bug");
 		LWOMAPID newZone = 0;
 
-		if (currentZone == 1001 && veZoneBugEnabled != "1") {
+		if (currentZone == 1001) {
 			newZone = 1100; // Send to AG if we're in a Return to Venture Explorer instance
 		} else if (currentZone % 100 == 0) {
 			ChatPackets::SendSystemMessage(sysAddr, u"You are not in an instanced zone.");

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -288,11 +288,14 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		return;
 	}
 
-	if (chatCommand == "leave-zone") {
+	if (chatCommand == "leave-zone" || chatCommand == "leavezone") {
 		const auto currentZone = Game::zoneManager->GetZone()->GetZoneID().GetMapID();
+		const auto VeZoneBugEnabled = Game::config->GetValue("enable_venture_explorer_bug");
+		LWOMAPID newZone;
 
-		LWOMAPID newZone = 0;
-		if (currentZone % 100 == 0) {
+		if (currentZone == 1001 && VeZoneBugEnabled != "1") {
+			newZone = 1100; // Send to AG if we're in a Return to Venture Explorer instance
+		} else if (currentZone % 100 == 0) {
 			ChatPackets::SendSystemMessage(sysAddr, u"You are not in an instanced zone.");
 			return;
 		} else {

--- a/resources/worldconfig.ini
+++ b/resources/worldconfig.ini
@@ -76,3 +76,6 @@ help_4_description=Visit Discussions on the DarkflameServer GitHub page<br/>to a
 
 # Toggleable quality of life feature to allow users to skip most cinematics. 
 allow_players_to_skip_cinematics=0
+
+# Enable bug allowing players to use the leave-zone command in Return to the Venture Explorer in order to return to the original Venture Explorer map
+enable_venture_explorer_bug=0

--- a/resources/worldconfig.ini
+++ b/resources/worldconfig.ini
@@ -76,6 +76,3 @@ help_4_description=Visit Discussions on the DarkflameServer GitHub page<br/>to a
 
 # Toggleable quality of life feature to allow users to skip most cinematics. 
 allow_players_to_skip_cinematics=0
-
-# Enable bug allowing players to use the leave-zone command in Return to the Venture Explorer in order to return to the original Venture Explorer map
-enable_venture_explorer_bug=0


### PR DESCRIPTION
Since fixing this bug makes me feel a little like the fun police, I also added a config option to allow a server owner to intentionally retain this bug if they so choose.