### PR TITLE
fix: leavezone allowing players to go from Return to the Venture Explorer to Avant Gardens

### DIFF
--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -292,9 +292,7 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		const auto currentZone = Game::zoneManager->GetZone()->GetZoneID().GetMapID();
 		LWOMAPID newZone = 0;
 
-		if (currentZone == 1001) {
-			newZone = 1100; // Send to AG if we're in a Return to Venture Explorer instance
-		} else if (currentZone % 100 == 0) {
+		if (currentZone == 1001 || currentZone % 100 == 0) {
 			ChatPackets::SendSystemMessage(sysAddr, u"You are not in an instanced zone.");
 			return;
 		} else {


### PR DESCRIPTION
Players do not need access to leave Return to the Venture Explorer (rttve) via a slash command.  They can leave through the usual method.

Tested that you cannot leavezone in rttve and you can leave other instanced zones