### PR TITLE
chore: miscellaneous code, formatting, and syntax cleanup

### DIFF
--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -242,6 +242,7 @@ namespace GeneralUtils {
 	template <typename T>
 	inline constexpr typename std::underlying_type<T>::type CastUnderlyingType(const T& entry) {
 		static_assert(std::is_enum<T>::value, "Not an enum");
+
 		return static_cast<typename std::underlying_type<T>::type>(entry);
 	}
 
@@ -256,6 +257,7 @@ namespace GeneralUtils {
 	inline T GenerateRandomNumber() {
 		// Make sure it is a numeric type
 		static_assert(std::is_arithmetic<T>::value, "Not an arithmetic type");
+
 		return GenerateRandomNumber<T>(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
 	}
 }

--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -239,11 +239,11 @@ namespace GeneralUtils {
 	 * @param entry Enum entry to cast
 	 * @returns The enum entry's value in its underlying type
 	*/
-	template <typename T>
-	inline constexpr typename std::underlying_type<T>::type CastUnderlyingType(const T& entry) {
-		static_assert(std::is_enum<T>::value, "Not an enum");
+	template <typename eType>
+	inline constexpr typename std::underlying_type_t<eType> CastUnderlyingType(const eType entry) {
+		static_assert(std::is_enum_v<eType>, "Not an enum");
 
-		return static_cast<typename std::underlying_type<T>::type>(entry);
+		return static_cast<typename std::underlying_type_t<eType>>(entry);
 	}
 
 	// on Windows we need to undef these or else they conflict with our numeric limits calls

--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -234,18 +234,28 @@ namespace GeneralUtils {
 		return T();
 	}
 
-// on Windows we need to undef these or else they conflict with our numeric limits calls
-// DEVELOPERS DEVELOPERS DEVELOPERS DEVELOPERS DEVELOPERS DEVELOPERS DEVELOPERS DEVELOPERS
-#ifdef _WIN32
-#undef min
-#undef max
-#endif
+	/**
+	 * Casts the value of an enum entry to its underlying type
+	 * @param entry Enum entry to cast
+	 * @returns The enum entry's value in its underlying type
+	*/
+	template <typename T>
+	inline constexpr typename std::underlying_type<T>::type CastUnderlyingType(const T& entry) {
+		return static_cast<typename std::underlying_type<T>::type>(entry);
+	}
+
+	// on Windows we need to undef these or else they conflict with our numeric limits calls
+	// DEVELOPERS DEVELOPERS DEVELOPERS DEVELOPERS DEVELOPERS DEVELOPERS DEVELOPERS DEVELOPERS
+	#ifdef _WIN32
+	#undef min
+	#undef max
+	#endif
 
 	template <typename T>
 	inline T GenerateRandomNumber() {
 		// Make sure it is a numeric type
 		static_assert(std::is_arithmetic<T>::value, "Not an arithmetic type");
-		
+
 		return GenerateRandomNumber<T>(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
 	}
 }

--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -241,6 +241,7 @@ namespace GeneralUtils {
 	*/
 	template <typename T>
 	inline constexpr typename std::underlying_type<T>::type CastUnderlyingType(const T& entry) {
+		static_assert(std::is_enum<T>::value, "Not an enum");
 		return static_cast<typename std::underlying_type<T>::type>(entry);
 	}
 
@@ -255,7 +256,6 @@ namespace GeneralUtils {
 	inline T GenerateRandomNumber() {
 		// Make sure it is a numeric type
 		static_assert(std::is_arithmetic<T>::value, "Not an arithmetic type");
-
 		return GenerateRandomNumber<T>(std::numeric_limits<T>::min(), std::numeric_limits<T>::max());
 	}
 }

--- a/dCommon/dEnums/StringifiedEnum.h
+++ b/dCommon/dEnums/StringifiedEnum.h
@@ -6,15 +6,9 @@
 
 namespace StringifiedEnum {
 	template<typename T>
-	constexpr std::string_view ToString(const T& e) {
-		// Check type
-		static_assert(std::is_enum<T>::value, "Not an enum");
+	const std::string_view ToString(const T e) {
+		static_assert(std::is_enum_v<T>, "Not an enum"); // Check type
 
-		if (__builtin_constant_p(e)) {
-			return magic_enum::enum_name<T>(e).empty() ? "UNKNOWN" : magic_enum::enum_name<T>(e);
-		}
-
-		// Otherwise, evaluate in real-time
 		constexpr auto sv = &magic_enum::enum_entries<T>();
 		std::string_view output;
 

--- a/dCommon/dEnums/StringifiedEnum.h
+++ b/dCommon/dEnums/StringifiedEnum.h
@@ -6,20 +6,24 @@
 
 namespace StringifiedEnum {
 	template<typename T>
-	const std::string_view ToString(const T e) {
+	constexpr std::string_view ToString(const T& e) {
+		// Evaluate as constexpr if possible
+		if (__builtin_constant_p(e)) {
+			return magic_enum::enum_name<T>(e).empty() ? "UNKNOWN" : magic_enum::enum_name<T>(e);
+		}
+
+		// Otherwise, evaluate in real-time
 		constexpr auto sv = &magic_enum::enum_entries<T>();
 		std::string_view output;
 
 		const auto it = std::lower_bound(
 			sv->begin(), sv->end(), e,
-			[&](const std::pair<T, std::string_view>& lhs, const T rhs)
-			{ return lhs.first < rhs; }
+			[&](const std::pair<T, std::string_view>& lhs, const T rhs) { return lhs.first < rhs; }
 		);
 
 		if (it != sv->end() && it->first == e) {
 			output = it->second;
-		}
-		else {
+		} else {
 			output = "UNKNOWN";
 		}
 		return output;

--- a/dCommon/dEnums/StringifiedEnum.h
+++ b/dCommon/dEnums/StringifiedEnum.h
@@ -7,7 +7,9 @@
 namespace StringifiedEnum {
 	template<typename T>
 	constexpr std::string_view ToString(const T& e) {
-		// Evaluate as constexpr if possible
+		// Check type
+		static_assert(std::is_enum<T>::value, "Not an enum");
+
 		if (__builtin_constant_p(e)) {
 			return magic_enum::enum_name<T>(e).empty() ? "UNKNOWN" : magic_enum::enum_name<T>(e);
 		}

--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -336,7 +336,7 @@ void Entity::Initialize() {
 
 	CDDestructibleComponentTable* destCompTable = CDClientManager::Instance().GetTable<CDDestructibleComponentTable>();
 	std::vector<CDDestructibleComponent> destCompData = destCompTable->Query([=](CDDestructibleComponent entry) { return (entry.id == componentID); });
-  
+
 	bool isSmashable = GetVarAs<int32_t>(u"is_smashable") != 0;
 	if (buffComponentID > 0 || collectibleComponentID > 0 || isSmashable) {
 		DestroyableComponent* comp = AddComponent<DestroyableComponent>();
@@ -543,8 +543,7 @@ void Entity::Initialize() {
 
 				// Known bug with moving platform in FV that casues it to build at the end instead of the start.
 				// This extends the smash time so players can ride up the lift.
-				if (m_TemplateID == 9483)
-				{
+				if (m_TemplateID == 9483) {
 					rebuildComponent->SetResetTime(rebuildComponent->GetResetTime() + 25);
 				}
 			}

--- a/dGame/dBehaviors/BasicAttackBehavior.cpp
+++ b/dGame/dBehaviors/BasicAttackBehavior.cpp
@@ -22,7 +22,6 @@ void BasicAttackBehavior::Handle(BehaviorContext* context, RakNet::BitStream* bi
 			if (entity->IsPlayer() && !this->m_DontApplyImmune) {
 				const float immunityTime = Game::zoneManager->GetWorldConfig()->globalImmunityTime;
 				destroyableComponent->SetDamageCooldownTimer(immunityTime);
-				LOG_DEBUG("Target targetEntity %llu took damage, setting damage cooldown timer to %f s", branch.target, immunityTime);
 			}
 		}
 
@@ -189,7 +188,6 @@ void BasicAttackBehavior::DoBehaviorCalculation(BehaviorContext* context, RakNet
 	}
 
 	const float immunityTime = Game::zoneManager->GetWorldConfig()->globalImmunityTime;
-	LOG_DEBUG("Damage cooldown timer currently %f s", destroyableComponent->GetDamageCooldownTimer());
 
 	const bool isImmune = (destroyableComponent->IsImmune()) || (destroyableComponent->IsCooldownImmune());
 
@@ -220,7 +218,6 @@ void BasicAttackBehavior::DoBehaviorCalculation(BehaviorContext* context, RakNet
 	//Handle player damage cooldown
 	if (isSuccess && targetEntity->IsPlayer() && !this->m_DontApplyImmune) {
 		destroyableComponent->SetDamageCooldownTimer(immunityTime);
-		LOG_DEBUG("Target targetEntity %llu took damage, setting damage cooldown timer to %f s", branch.target, immunityTime);
 	}
 
 	eBasicAttackSuccessTypes successState = eBasicAttackSuccessTypes::FAILIMMUNE;

--- a/dGame/dBehaviors/BasicAttackBehavior.cpp
+++ b/dGame/dBehaviors/BasicAttackBehavior.cpp
@@ -187,10 +187,7 @@ void BasicAttackBehavior::DoBehaviorCalculation(BehaviorContext* context, RakNet
 		return;
 	}
 
-	const float immunityTime = Game::zoneManager->GetWorldConfig()->globalImmunityTime;
-
-	const bool isImmune = (destroyableComponent->IsImmune()) || (destroyableComponent->IsCooldownImmune());
-
+	const bool isImmune = destroyableComponent->IsImmune() || destroyableComponent->IsCooldownImmune();
 	bitStream->Write(isImmune);
 
 	if (isImmune) {
@@ -217,7 +214,7 @@ void BasicAttackBehavior::DoBehaviorCalculation(BehaviorContext* context, RakNet
 
 	//Handle player damage cooldown
 	if (isSuccess && targetEntity->IsPlayer() && !this->m_DontApplyImmune) {
-		destroyableComponent->SetDamageCooldownTimer(immunityTime);
+		destroyableComponent->SetDamageCooldownTimer(Game::zoneManager->GetWorldConfig()->globalImmunityTime);
 	}
 
 	eBasicAttackSuccessTypes successState = eBasicAttackSuccessTypes::FAILIMMUNE;

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -557,7 +557,7 @@ void DestroyableComponent::Damage(uint32_t damage, const LWOOBJID source, uint32
 	}
 
 	if (IsImmune() || IsCooldownImmune()) {
-		LOG_DEBUG("Target targetEntity %llu is immune!", m_Parent->GetObjectID()); //Immune is succesfully proc'd
+		LOG_DEBUG("Target targetEntity %llu is immune!", m_Parent->GetObjectID());
 		return;
 	}
 

--- a/dGame/dComponents/RebuildComponent.cpp
+++ b/dGame/dComponents/RebuildComponent.cpp
@@ -198,9 +198,9 @@ void RebuildComponent::Update(float deltaTime) {
 			if (!destComp) break;
 
 			++m_DrainedImagination;
-			const int32_t imaginationCostRemaining = m_TakeImagination - m_DrainedImagination;
+			const auto imaginationCostRemaining = m_TakeImagination - m_DrainedImagination;
 
-			const int32_t newImagination = destComp->GetImagination() - 1;
+			const auto newImagination = destComp->GetImagination() - 1;
 			destComp->SetImagination(newImagination);
 			Game::entityManager->SerializeEntity(builder);
 

--- a/dGame/dComponents/RebuildComponent.cpp
+++ b/dGame/dComponents/RebuildComponent.cpp
@@ -198,9 +198,9 @@ void RebuildComponent::Update(float deltaTime) {
 			if (!destComp) break;
 
 			++m_DrainedImagination;
-			const auto imaginationCostRemaining = m_TakeImagination - m_DrainedImagination;
+			const int32_t imaginationCostRemaining = m_TakeImagination - m_DrainedImagination;
 
-			const auto newImagination = destComp->GetImagination() - 1;
+			const int32_t newImagination = destComp->GetImagination() - 1;
 			destComp->SetImagination(newImagination);
 			Game::entityManager->SerializeEntity(builder);
 

--- a/dGame/dGameMessages/GameMessageHandler.cpp
+++ b/dGame/dGameMessages/GameMessageHandler.cpp
@@ -53,7 +53,7 @@ void GameMessageHandler::HandleMessage(RakNet::BitStream* inStream, const System
 		return;
 	}
 
-	if (messageID != eGameMessageType::READY_FOR_UPDATES) LOG_DEBUG("Received GM with ID and name: %4i, %s", messageID,  StringifiedEnum::ToString(messageID).data());
+	if (messageID != eGameMessageType::READY_FOR_UPDATES) LOG_DEBUG("Received GM with ID and name: %4i, %s", messageID, StringifiedEnum::ToString(messageID).data());
 
 	switch (messageID) {
 
@@ -694,7 +694,7 @@ void GameMessageHandler::HandleMessage(RakNet::BitStream* inStream, const System
 		GameMessages::SendVendorStatusUpdate(entity, sysAddr, true);
 		break;
 	default:
-		LOG_DEBUG("Received Unknown GM with ID: %4i, %s", messageID,  StringifiedEnum::ToString(messageID).data());
+		LOG_DEBUG("Received Unknown GM with ID: %4i, %s", messageID, StringifiedEnum::ToString(messageID).data());
 		break;
 	}
 }

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -111,7 +111,7 @@ void GameMessages::SendFireEventClientSide(const LWOOBJID& objectID, const Syste
 	uint32_t argSize = args.size();
 	bitStream.Write(argSize);
 	for (uint32_t k = 0; k < argSize; k++) {
-		bitStream.Write(static_cast<uint16_t>(args[k]));
+		bitStream.Write<uint16_t>(args[k]);
 	}
 	bitStream.Write(object);
 	bitStream.Write0();
@@ -221,13 +221,13 @@ void GameMessages::SendInvalidZoneTransferList(Entity* entity, const SystemAddre
 	uint32_t CustomerFeedbackURLLength = feedbackURL.size();
 	bitStream.Write(CustomerFeedbackURLLength);
 	for (uint32_t k = 0; k < CustomerFeedbackURLLength; k++) {
-		bitStream.Write(static_cast<uint16_t>(feedbackURL[k]));
+		bitStream.Write<uint16_t>(feedbackURL[k]);
 	}
 
 	uint32_t InvalidMapTransferListLength = invalidMapTransferList.size();
 	bitStream.Write(InvalidMapTransferListLength);
 	for (uint32_t k = 0; k < InvalidMapTransferListLength; k++) {
-		bitStream.Write(static_cast<uint16_t>(invalidMapTransferList[k]));
+		bitStream.Write<uint16_t>(invalidMapTransferList[k]);
 	}
 
 	bitStream.Write(feedbackOnExit);
@@ -325,10 +325,10 @@ void GameMessages::SendPlayNDAudioEmitter(Entity* entity, const SystemAddress& s
 	uint32_t length = audioGUID.size();
 	bitStream.Write(length);
 	for (uint32_t k = 0; k < length; k++) {
-		bitStream.Write(static_cast<char>(audioGUID[k]));
+		bitStream.Write<char>(audioGUID[k]);
 	}
 
-	bitStream.Write(static_cast<uint32_t>(0));
+	bitStream.Write<uint32_t>(0);
 	bitStream.Write0();
 	bitStream.Write0();
 
@@ -472,9 +472,9 @@ void GameMessages::SendAddItemToInventoryClientSync(Entity* entity, const System
 	bitStream.Write<uint32_t>(extraInfo.name.size());
 	if (extraInfo.name.size() > 0) {
 		for (uint32_t i = 0; i < extraInfo.name.size(); ++i) {
-			bitStream.Write(static_cast<uint16_t>(extraInfo.name[i]));
+			bitStream.Write<uint16_t>(extraInfo.name[i]);
 		}
-		bitStream.Write(static_cast<uint16_t>(0x00));
+		bitStream.Write<uint16_t>(0x00);
 	}
 
 	bitStream.Write(item->GetLot());
@@ -617,7 +617,7 @@ void GameMessages::SendUIMessageServerToSingleClient(Entity* entity, const Syste
 	bitStream.Write(strMessageNameLength);
 
 	for (uint32_t k = 0; k < strMessageNameLength; k++) {
-		bitStream.Write(static_cast<char>(message[k]));
+		bitStream.Write<char>(message[k]);
 	}
 
 	SEND_PACKET;
@@ -636,7 +636,7 @@ void GameMessages::SendUIMessageServerToAllClients(const std::string& message, A
 	bitStream.Write(strMessageNameLength);
 
 	for (uint32_t k = 0; k < strMessageNameLength; k++) {
-		bitStream.Write(static_cast<char>(message[k]));
+		bitStream.Write<char>(message[k]);
 	}
 
 	SEND_PACKET_BROADCAST;
@@ -649,9 +649,9 @@ void GameMessages::SendPlayEmbeddedEffectOnAllClientsNearObject(Entity* entity, 
 	bitStream.Write(entity->GetObjectID());
 	bitStream.Write(eGameMessageType::PLAY_EMBEDDED_EFFECT_ON_ALL_CLIENTS_NEAR_OBJECT);
 
-	bitStream.Write(static_cast<uint32_t>(effectName.length()));
+	bitStream.Write<uint32_t>(effectName.length());
 	for (uint32_t k = 0; k < effectName.length(); k++) {
-		bitStream.Write(static_cast<uint16_t>(effectName[k]));
+		bitStream.Write<uint16_t>(effectName[k]);
 	}
 	bitStream.Write(fromObjectID);
 	bitStream.Write(radius);
@@ -722,16 +722,16 @@ void GameMessages::SendBroadcastTextToChatbox(Entity* entity, const SystemAddres
 	attribs.name = attrs;
 	attribs.length = attrs.size();
 
-	bitStream.Write(static_cast<uint32_t>(attribs.length));
+	bitStream.Write<uint32_t>(attribs.length);
 	for (uint32_t i = 0; i < attribs.length; ++i) {
-		bitStream.Write(static_cast<uint16_t>(attribs.name[i]));
+		bitStream.Write<uint16_t>(attribs.name[i]);
 	}
-	bitStream.Write(static_cast<uint16_t>(0x00)); // Null Terminator
+	bitStream.Write<uint16_t>(0x00); // Null Terminator
 
 	uint32_t wsTextLength = wsText.size();
 	bitStream.Write(wsTextLength);
 	for (uint32_t k = 0; k < wsTextLength; k++) {
-		bitStream.Write(static_cast<uint16_t>(wsText[k]));
+		bitStream.Write<uint16_t>(wsText[k]);
 	}
 
 	SEND_PACKET_BROADCAST;
@@ -853,7 +853,7 @@ void GameMessages::SendDie(Entity* entity, const LWOOBJID& killerID, const LWOOB
 	uint32_t deathTypeLength = deathType.size();
 	bitStream.Write(deathTypeLength);
 	for (uint32_t k = 0; k < deathTypeLength; k++) {
-		bitStream.Write(static_cast<uint16_t>(deathType[k]));
+		bitStream.Write<uint16_t>(deathType[k]);
 	}
 
 	bitStream.Write(directionRelative_AngleXZ);
@@ -984,7 +984,7 @@ void GameMessages::SendStop2DAmbientSound(Entity* entity, bool force, std::strin
 	bitStream.Write(audioGUIDSize);
 
 	for (uint32_t k = 0; k < audioGUIDSize; k++) {
-		bitStream.Write(static_cast<char>(audioGUID[k]));
+		bitStream.Write<char>(audioGUID[k]);
 	}
 
 	bitStream.Write(result);
@@ -1004,7 +1004,7 @@ void GameMessages::SendPlay2DAmbientSound(Entity* entity, std::string audioGUID,
 
 	bitStream.Write(audioGUIDSize);
 	for (uint32_t k = 0; k < audioGUIDSize; k++) {
-		bitStream.Write(static_cast<char>(audioGUID[k]));
+		bitStream.Write<char>(audioGUID[k]);
 	}
 	bitStream.Write(result);
 
@@ -1026,9 +1026,9 @@ void GameMessages::SendSetNetworkScriptVar(Entity* entity, const SystemAddress& 
 
 	bitStream.Write(dataSize);
 	for (auto value : u16Data) {
-		bitStream.Write(static_cast<uint16_t>(value));
+		bitStream.Write<uint16_t>(value);
 	}
-	if (dataSize > 0) bitStream.Write(static_cast<uint16_t>(0));
+	if (dataSize > 0) bitStream.Write<uint16_t>(0);
 
 	if (sysAddr == UNASSIGNED_SYSTEM_ADDRESS) SEND_PACKET_BROADCAST;
 	SEND_PACKET;
@@ -1344,8 +1344,8 @@ void GameMessages::SendRemoveItemFromInventory(Entity* entity, const SystemAddre
 	bitStream.Write(eInvType);
 	bitStream.Write1();
 	bitStream.Write(eLootTypeSource);
-	bitStream.Write(static_cast<uint32_t>(0)); //extra info
-	//bitStream.Write(static_cast<uint16_t>(0)); //extra info
+	bitStream.Write<uint32_t>(0); //extra info
+	//bitStream.Write<uint16_t>(0); //extra info
 	bitStream.Write(forceDeletion);
 	bitStream.Write0();
 	bitStream.Write1();
@@ -1468,11 +1468,11 @@ void GameMessages::SendMatchUpdate(Entity* entity, const SystemAddress& sysAddr,
 
 	bitStream.Write(entity->GetObjectID());
 	bitStream.Write(eGameMessageType::MATCH_UPDATE);
-	bitStream.Write(static_cast<uint32_t>(data.size()));
+	bitStream.Write<uint32_t>(data.size());
 	for (char character : data) {
-		bitStream.Write(static_cast<uint16_t>(character));
+		bitStream.Write<uint16_t>(character);
 	}
-	if (data.size() > 0) bitStream.Write(static_cast<uint16_t>(0));
+	if (data.size() > 0) bitStream.Write<uint16_t>(0);
 	bitStream.Write(type);
 
 	SEND_PACKET;
@@ -1742,7 +1742,7 @@ void GameMessages::SendSetRailMovement(const LWOOBJID& objectID, bool pathGoForw
 
 	bitStream.Write(pathGoForward);
 
-	bitStream.Write(static_cast<uint32_t>(pathName.size()));
+	bitStream.Write<uint32_t>(pathName.size());
 	for (auto character : pathName) {
 		bitStream.Write<uint16_t>(character);
 	}
@@ -1781,14 +1781,14 @@ void GameMessages::SendStartRailMovement(const LWOOBJID& objectID, std::u16strin
 	bitStream.Write(cameraLocked);
 	bitStream.Write(collisionEnabled);
 
-	bitStream.Write(static_cast<uint32_t>(loopSound.size()));
+	bitStream.Write<uint32_t>(loopSound.size());
 	for (auto character : loopSound) {
 		bitStream.Write<uint16_t>(character);
 	}
 
 	bitStream.Write(goForward);
 
-	bitStream.Write(static_cast<uint32_t>(pathName.size()));
+	bitStream.Write<uint32_t>(pathName.size());
 	for (auto character : pathName) {
 		bitStream.Write<uint16_t>(character);
 	}
@@ -1811,12 +1811,12 @@ void GameMessages::SendStartRailMovement(const LWOOBJID& objectID, std::u16strin
 		bitStream.Write<LWOOBJID>(railActivatorObjectID);
 	}
 
-	bitStream.Write(static_cast<uint32_t>(startSound.size()));
+	bitStream.Write<uint32_t>(startSound.size());
 	for (auto character : startSound) {
 		bitStream.Write<uint16_t>(character);
 	}
 
-	bitStream.Write(static_cast<uint32_t>(stopSound.size()));
+	bitStream.Write<uint32_t>(stopSound.size());
 	for (auto character : stopSound) {
 		bitStream.Write<uint16_t>(character);
 	}
@@ -1834,7 +1834,7 @@ void GameMessages::SendNotifyClientObject(const LWOOBJID& objectID, std::u16stri
 	bitStream.Write(objectID);
 	bitStream.Write(eGameMessageType::NOTIFY_CLIENT_OBJECT);
 
-	bitStream.Write(static_cast<uint32_t>(name.size()));
+	bitStream.Write<uint32_t>(name.size());
 	for (auto character : name) {
 		bitStream.Write<uint16_t>(character);
 	}
@@ -1845,7 +1845,7 @@ void GameMessages::SendNotifyClientObject(const LWOOBJID& objectID, std::u16stri
 
 	bitStream.Write(paramObj);
 
-	bitStream.Write(static_cast<uint32_t>(paramStr.size()));
+	bitStream.Write<uint32_t>(paramStr.size());
 	for (auto character : paramStr) {
 		bitStream.Write(character);
 	}
@@ -1863,7 +1863,7 @@ void GameMessages::SendNotifyClientZoneObject(const LWOOBJID& objectID, const st
 	bitStream.Write(objectID);
 	bitStream.Write(eGameMessageType::NOTIFY_CLIENT_ZONE_OBJECT);
 
-	bitStream.Write(static_cast<uint32_t>(name.size()));
+	bitStream.Write<uint32_t>(name.size());
 	for (const auto& character : name) {
 		bitStream.Write<uint16_t>(character);
 	}
@@ -1872,7 +1872,7 @@ void GameMessages::SendNotifyClientZoneObject(const LWOOBJID& objectID, const st
 	bitStream.Write(param2);
 	bitStream.Write(paramObj);
 
-	bitStream.Write(static_cast<uint32_t>(paramStr.size()));
+	bitStream.Write<uint32_t>(paramStr.size());
 	for (const auto& character : paramStr) {
 		bitStream.Write(character);
 	}
@@ -1889,9 +1889,9 @@ void GameMessages::SendNotifyClientFailedPrecondition(LWOOBJID objectId, const S
 	bitStream.Write(objectId);
 	bitStream.Write(eGameMessageType::NOTIFY_CLIENT_FAILED_PRECONDITION);
 
-	bitStream.Write(static_cast<uint32_t>(failedReason.size()));
+	bitStream.Write<uint32_t>(failedReason.size());
 	for (uint16_t character : failedReason) {
-		bitStream.Write(static_cast<uint16_t>(character));
+		bitStream.Write<uint16_t>(character);
 	}
 
 	bitStream.Write(preconditionID);
@@ -2015,7 +2015,7 @@ void GameMessages::SendLockNodeRotation(Entity* entity, std::string nodeName) {
 	bitStream.Write(entity->GetObjectID());
 	bitStream.Write(eGameMessageType::LOCK_NODE_ROTATION);
 
-	bitStream.Write(static_cast<uint32_t>(nodeName.size()));
+	bitStream.Write<uint32_t>(nodeName.size());
 	for (char character : nodeName) {
 		bitStream.Write(character);
 	}
@@ -2050,7 +2050,7 @@ void GameMessages::SendGetModelsOnProperty(LWOOBJID objectId, std::map<LWOOBJID,
 	bitStream.Write(objectId);
 	bitStream.Write(eGameMessageType::GET_MODELS_ON_PROPERTY);
 
-	bitStream.Write(static_cast<uint32_t>(models.size()));
+	bitStream.Write<uint32_t>(models.size());
 
 	for (const auto& pair : models) {
 		bitStream.Write(pair.first);
@@ -2432,7 +2432,7 @@ void GameMessages::HandleBBBLoadItemRequest(RakNet::BitStream* inStream, Entity*
 void GameMessages::SendBlueprintLoadItemResponse(const SystemAddress& sysAddr, bool success, LWOOBJID oldItemId, LWOOBJID newItemId) {
 	CBITSTREAM;
 	BitStreamUtils::WriteHeader(bitStream, eConnectionType::CLIENT, eClientMessageType::BLUEPRINT_LOAD_RESPONSE_ITEMID);
-	bitStream.Write(static_cast<uint8_t>(success));
+	bitStream.Write<uint8_t>(success);
 	bitStream.Write<LWOOBJID>(oldItemId);
 	bitStream.Write<LWOOBJID>(newItemId);
 	SEND_PACKET;
@@ -3057,7 +3057,7 @@ void GameMessages::SendNotifyObject(LWOOBJID objectId, LWOOBJID objIDSender, std
 	bitStream.Write(eGameMessageType::NOTIFY_OBJECT);
 
 	bitStream.Write(objIDSender);
-	bitStream.Write(static_cast<uint32_t>(name.size()));
+	bitStream.Write<uint32_t>(name.size());
 	for (const auto character : name) {
 		bitStream.Write(character);
 	}
@@ -3114,7 +3114,7 @@ void GameMessages::SendServerTradeInvite(LWOOBJID objectId, bool bNeedInvitePopU
 
 	bitStream.Write(bNeedInvitePopUp);
 	bitStream.Write(i64Requestor);
-	bitStream.Write(static_cast<uint32_t>(wsName.size()));
+	bitStream.Write<uint32_t>(wsName.size());
 	for (const auto character : wsName) {
 		bitStream.Write(character);
 	}
@@ -3132,7 +3132,7 @@ void GameMessages::SendServerTradeInitialReply(LWOOBJID objectId, LWOOBJID i64In
 
 	bitStream.Write(i64Invitee);
 	bitStream.Write(resultType);
-	bitStream.Write(static_cast<uint32_t>(wsName.size()));
+	bitStream.Write<uint32_t>(wsName.size());
 	for (const auto character : wsName) {
 		bitStream.Write(character);
 	}
@@ -3150,7 +3150,7 @@ void GameMessages::SendServerTradeFinalReply(LWOOBJID objectId, bool bResult, LW
 
 	bitStream.Write(bResult);
 	bitStream.Write(i64Invitee);
-	bitStream.Write(static_cast<uint32_t>(wsName.size()));
+	bitStream.Write<uint32_t>(wsName.size());
 	for (const auto character : wsName) {
 		bitStream.Write(character);
 	}
@@ -3192,7 +3192,7 @@ void GameMessages::SendServerTradeUpdate(LWOOBJID objectId, uint64_t coins, cons
 
 	bitStream.Write(false);
 	bitStream.Write(coins);
-	bitStream.Write(static_cast<uint32_t>(items.size()));
+	bitStream.Write<uint32_t>(items.size());
 
 	for (const auto& item : items) {
 		bitStream.Write(item.itemId);
@@ -3401,7 +3401,7 @@ void GameMessages::SendNotifyPetTamingPuzzleSelected(LWOOBJID objectId, const st
 	bitStream.Write(objectId);
 	bitStream.Write(eGameMessageType::NOTIFY_TAMING_PUZZLE_SELECTED);
 
-	bitStream.Write(static_cast<uint32_t>(bricks.size()));
+	bitStream.Write<uint32_t>(bricks.size());
 	for (const auto& brick : bricks) {
 		bitStream.Write(brick.designerID);
 		bitStream.Write(brick.materialID);
@@ -3450,7 +3450,7 @@ void GameMessages::SendAddPetToPlayer(LWOOBJID objectId, int32_t iElementalType,
 	bitStream.Write(eGameMessageType::ADD_PET_TO_PLAYER);
 
 	bitStream.Write(iElementalType);
-	bitStream.Write(static_cast<uint32_t>(name.size()));
+	bitStream.Write<uint32_t>(name.size());
 	for (const auto character : name) {
 		bitStream.Write(character);
 	}
@@ -3584,7 +3584,7 @@ void GameMessages::SendSetPetName(LWOOBJID objectId, std::u16string name, LWOOBJ
 	bitStream.Write(objectId);
 	bitStream.Write(eGameMessageType::SET_PET_NAME);
 
-	bitStream.Write(static_cast<uint32_t>(name.size()));
+	bitStream.Write<uint32_t>(name.size());
 	for (const auto character : name) {
 		bitStream.Write(character);
 	}
@@ -3623,12 +3623,12 @@ void GameMessages::SendPetNameChanged(LWOOBJID objectId, int32_t moderationStatu
 
 	bitStream.Write(moderationStatus);
 
-	bitStream.Write(static_cast<uint32_t>(name.size()));
+	bitStream.Write<uint32_t>(name.size());
 	for (const auto character : name) {
 		bitStream.Write(character);
 	}
 
-	bitStream.Write(static_cast<uint32_t>(ownerName.size()));
+	bitStream.Write<uint32_t>(ownerName.size());
 	for (const auto character : ownerName) {
 		bitStream.Write(character);
 	}
@@ -3906,19 +3906,19 @@ void GameMessages::SendDisplayMessageBox(LWOOBJID objectId, bool bShow, LWOOBJID
 	bitStream.Write(bShow);
 	bitStream.Write(callbackClient);
 
-	bitStream.Write(static_cast<uint32_t>(identifier.size()));
+	bitStream.Write<uint32_t>(identifier.size());
 	for (const auto character : identifier) {
 		bitStream.Write(character);
 	}
 
 	bitStream.Write(imageID);
 
-	bitStream.Write(static_cast<uint32_t>(text.size()));
+	bitStream.Write<uint32_t>(text.size());
 	for (const auto character : text) {
 		bitStream.Write(character);
 	}
 
-	bitStream.Write(static_cast<uint32_t>(userData.size()));
+	bitStream.Write<uint32_t>(userData.size());
 	for (const auto character : userData) {
 		bitStream.Write(character);
 	}
@@ -3935,7 +3935,7 @@ void GameMessages::SendDisplayChatBubble(LWOOBJID objectId, const std::u16string
 	bitStream.Write(objectId);
 	bitStream.Write(eGameMessageType::DISPLAY_CHAT_BUBBLE);
 
-	bitStream.Write(static_cast<uint32_t>(text.size()));
+	bitStream.Write<uint32_t>(text.size());
 	for (const auto character : text) {
 		bitStream.Write(character);
 	}
@@ -4243,7 +4243,7 @@ void GameMessages::SendModuleAssemblyDBDataForClient(LWOOBJID objectId, LWOOBJID
 
 	bitStream.Write(assemblyID);
 
-	bitStream.Write(static_cast<uint32_t>(data.size()));
+	bitStream.Write<uint32_t>(data.size());
 	for (auto character : data) {
 		bitStream.Write(character);
 	}
@@ -4388,7 +4388,7 @@ void GameMessages::SendNotifyRacingClient(LWOOBJID objectId, int32_t eventType, 
 
 	bitStream.Write(paramObj);
 
-	bitStream.Write(static_cast<uint32_t>(paramStr.size()));
+	bitStream.Write<uint32_t>(paramStr.size());
 	for (auto character : paramStr) {
 		bitStream.Write(character);
 	}
@@ -4583,7 +4583,7 @@ void GameMessages::SendShowActivityCountdown(LWOOBJID objectId, bool bPlayAdditi
 
 	bitStream.Write(bPlayCountdownSound);
 
-	bitStream.Write(static_cast<uint32_t>(sndName.size()));
+	bitStream.Write<uint32_t>(sndName.size());
 	for (auto character : sndName) {
 		bitStream.Write(character);
 	}

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -318,7 +318,7 @@ void GameMessages::SendPlayNDAudioEmitter(Entity* entity, const SystemAddress& s
 	CMSGHEADER;
 
 	bitStream.Write(entity->GetObjectID());
-	bitStream.Write((uint16_t)eGameMessageType::PLAY_ND_AUDIO_EMITTER);
+	bitStream.Write(eGameMessageType::PLAY_ND_AUDIO_EMITTER);
 	bitStream.Write0();
 	bitStream.Write0();
 
@@ -328,7 +328,7 @@ void GameMessages::SendPlayNDAudioEmitter(Entity* entity, const SystemAddress& s
 		bitStream.Write(static_cast<char>(audioGUID[k]));
 	}
 
-	bitStream.Write(uint32_t(0));
+	bitStream.Write(static_cast<uint32_t>(0));
 	bitStream.Write0();
 	bitStream.Write0();
 
@@ -375,7 +375,7 @@ void GameMessages::SendPlatformResync(Entity* entity, const SystemAddress& sysAd
 	}
 
 	bitStream.Write(entity->GetObjectID());
-	bitStream.Write((uint16_t)eGameMessageType::PLATFORM_RESYNC);
+	bitStream.Write(eGameMessageType::PLATFORM_RESYNC);
 
 	bool bReverse = false;
 	int eCommand = 0;
@@ -432,7 +432,7 @@ void GameMessages::SendChatModeUpdate(const LWOOBJID& objectID, eGameMasterLevel
 	CBITSTREAM;
 	CMSGHEADER;
 	bitStream.Write(objectID);
-	bitStream.Write((uint16_t)eGameMessageType::UPDATE_CHAT_MODE);
+	bitStream.Write(eGameMessageType::UPDATE_CHAT_MODE);
 	bitStream.Write(level);
 	SEND_PACKET_BROADCAST;
 }
@@ -441,7 +441,7 @@ void GameMessages::SendGMLevelBroadcast(const LWOOBJID& objectID, eGameMasterLev
 	CBITSTREAM;
 	CMSGHEADER;
 	bitStream.Write(objectID);
-	bitStream.Write((uint16_t)eGameMessageType::SET_GM_LEVEL);
+	bitStream.Write(eGameMessageType::SET_GM_LEVEL);
 	bitStream.Write1();
 	bitStream.Write(level);
 	SEND_PACKET_BROADCAST;
@@ -511,7 +511,7 @@ void GameMessages::SendNotifyClientFlagChange(const LWOOBJID& objectID, uint32_t
 	CMSGHEADER;
 
 	bitStream.Write(objectID);
-	bitStream.Write((uint16_t)eGameMessageType::NOTIFY_CLIENT_FLAG_CHANGE);
+	bitStream.Write(eGameMessageType::NOTIFY_CLIENT_FLAG_CHANGE);
 	bitStream.Write(bFlag);
 	bitStream.Write(iFlagID);
 
@@ -523,7 +523,7 @@ void GameMessages::SendChangeObjectWorldState(const LWOOBJID& objectID, eObjectW
 	CMSGHEADER;
 
 	bitStream.Write(objectID);
-	bitStream.Write((uint16_t)eGameMessageType::CHANGE_OBJECT_WORLD_STATE);
+	bitStream.Write(eGameMessageType::CHANGE_OBJECT_WORLD_STATE);
 	bitStream.Write(state);
 
 	if (sysAddr == UNASSIGNED_SYSTEM_ADDRESS) SEND_PACKET_BROADCAST
@@ -578,7 +578,7 @@ void GameMessages::SendNotifyMissionTask(Entity* entity, const SystemAddress& sy
 	CMSGHEADER;
 
 	bitStream.Write(entity->GetObjectID());
-	bitStream.Write((uint16_t)eGameMessageType::NOTIFY_MISSION_TASK);
+	bitStream.Write(eGameMessageType::NOTIFY_MISSION_TASK);
 
 	bitStream.Write(missionID);
 	bitStream.Write(taskMask);
@@ -596,7 +596,7 @@ void GameMessages::SendModifyLEGOScore(Entity* entity, const SystemAddress& sysA
 	CMSGHEADER;
 
 	bitStream.Write(entity->GetObjectID());
-	bitStream.Write((uint16_t)eGameMessageType::MODIFY_LEGO_SCORE);
+	bitStream.Write(eGameMessageType::MODIFY_LEGO_SCORE);
 	bitStream.Write(score);
 
 	bitStream.Write(sourceType != eLootSourceType::NONE);
@@ -610,7 +610,7 @@ void GameMessages::SendUIMessageServerToSingleClient(Entity* entity, const Syste
 	CMSGHEADER;
 
 	bitStream.Write(entity->GetObjectID());
-	bitStream.Write((uint16_t)eGameMessageType::UI_MESSAGE_SERVER_TO_SINGLE_CLIENT);
+	bitStream.Write(eGameMessageType::UI_MESSAGE_SERVER_TO_SINGLE_CLIENT);
 
 	bitStream.Write<AMFBaseValue&>(args);
 	uint32_t strMessageNameLength = message.size();
@@ -629,7 +629,7 @@ void GameMessages::SendUIMessageServerToAllClients(const std::string& message, A
 
 	LWOOBJID empty = 0;
 	bitStream.Write(empty);
-	bitStream.Write((uint16_t)eGameMessageType::UI_MESSAGE_SERVER_TO_ALL_CLIENTS);
+	bitStream.Write(eGameMessageType::UI_MESSAGE_SERVER_TO_ALL_CLIENTS);
 
 	bitStream.Write<AMFBaseValue&>(args);
 	uint32_t strMessageNameLength = message.size();
@@ -647,7 +647,7 @@ void GameMessages::SendPlayEmbeddedEffectOnAllClientsNearObject(Entity* entity, 
 	CMSGHEADER;
 
 	bitStream.Write(entity->GetObjectID());
-	bitStream.Write((uint16_t)eGameMessageType::PLAY_EMBEDDED_EFFECT_ON_ALL_CLIENTS_NEAR_OBJECT);
+	bitStream.Write(eGameMessageType::PLAY_EMBEDDED_EFFECT_ON_ALL_CLIENTS_NEAR_OBJECT);
 
 	bitStream.Write(static_cast<uint32_t>(effectName.length()));
 	for (uint32_t k = 0; k < effectName.length(); k++) {
@@ -668,7 +668,7 @@ void GameMessages::SendPlayFXEffect(const LWOOBJID& entity, int32_t effectID, co
 	CMSGHEADER;
 
 	bitStream.Write(entity);
-	bitStream.Write((uint16_t)eGameMessageType::PLAY_FX_EFFECT);
+	bitStream.Write(eGameMessageType::PLAY_FX_EFFECT);
 
 	bitStream.Write(effectID != -1);
 	if (effectID != -1) bitStream.Write(effectID);
@@ -716,7 +716,7 @@ void GameMessages::SendBroadcastTextToChatbox(Entity* entity, const SystemAddres
 	CMSGHEADER;
 
 	bitStream.Write(entity->GetObjectID());
-	bitStream.Write((uint16_t)eGameMessageType::BROADCAST_TEXT_TO_CHATBOX);
+	bitStream.Write(eGameMessageType::BROADCAST_TEXT_TO_CHATBOX);
 
 	LWONameValue attribs;
 	attribs.name = attrs;
@@ -772,7 +772,7 @@ void GameMessages::SendRebuildNotifyState(Entity* entity, eRebuildState prevStat
 	CMSGHEADER;
 
 	bitStream.Write(entity->GetObjectID());
-	bitStream.Write((uint16_t)eGameMessageType::REBUILD_NOTIFY_STATE);
+	bitStream.Write(eGameMessageType::REBUILD_NOTIFY_STATE);
 
 	bitStream.Write(prevState);
 	bitStream.Write(state);
@@ -786,7 +786,7 @@ void GameMessages::SendEnableRebuild(Entity* entity, bool enable, bool fail, boo
 	CMSGHEADER;
 
 	bitStream.Write(entity->GetObjectID());
-	bitStream.Write((uint16_t)eGameMessageType::ENABLE_REBUILD);
+	bitStream.Write(eGameMessageType::ENABLE_REBUILD);
 
 	bitStream.Write(enable);
 	bitStream.Write(fail);
@@ -806,7 +806,7 @@ void GameMessages::SendTerminateInteraction(const LWOOBJID& objectID, eTerminate
 	CMSGHEADER;
 
 	bitStream.Write(objectID);
-	bitStream.Write((uint16_t)eGameMessageType::TERMINATE_INTERACTION);
+	bitStream.Write(eGameMessageType::TERMINATE_INTERACTION);
 
 	bitStream.Write(terminator);
 	bitStream.Write(type);
@@ -842,7 +842,7 @@ void GameMessages::SendDie(Entity* entity, const LWOOBJID& killerID, const LWOOB
 
 	bitStream.Write(entity->GetObjectID());
 
-	bitStream.Write((uint16_t)eGameMessageType::DIE);
+	bitStream.Write(eGameMessageType::DIE);
 
 	bitStream.Write(bClientDeath);
 	bitStream.Write(bSpawnLoot);
@@ -976,7 +976,7 @@ void GameMessages::SendStop2DAmbientSound(Entity* entity, bool force, std::strin
 	CMSGHEADER;
 
 	bitStream.Write(entity->GetObjectID());
-	bitStream.Write((uint16_t)eGameMessageType::STOP2_D_AMBIENT_SOUND);
+	bitStream.Write(eGameMessageType::STOP2_D_AMBIENT_SOUND);
 
 	uint32_t audioGUIDSize = audioGUID.size();
 
@@ -999,8 +999,7 @@ void GameMessages::SendPlay2DAmbientSound(Entity* entity, std::string audioGUID,
 	CMSGHEADER;
 
 	bitStream.Write(entity->GetObjectID());
-	bitStream.Write((uint16_t)eGameMessageType::PLAY2_D_AMBIENT_SOUND);
-
+	bitStream.Write(eGameMessageType::PLAY2_D_AMBIENT_SOUND);
 	uint32_t audioGUIDSize = audioGUID.size();
 
 	bitStream.Write(audioGUIDSize);
@@ -1018,7 +1017,7 @@ void GameMessages::SendSetNetworkScriptVar(Entity* entity, const SystemAddress& 
 	CMSGHEADER;
 
 	bitStream.Write(entity->GetObjectID());
-	bitStream.Write((uint16_t)eGameMessageType::SCRIPT_NETWORK_VAR_UPDATE);
+	bitStream.Write(eGameMessageType::SCRIPT_NETWORK_VAR_UPDATE);
 
 	// FIXME: this is a bad place to need to do a conversion because we have no clue whether data is utf8 or plain ascii
 	// an this has performance implications
@@ -1027,9 +1026,9 @@ void GameMessages::SendSetNetworkScriptVar(Entity* entity, const SystemAddress& 
 
 	bitStream.Write(dataSize);
 	for (auto value : u16Data) {
-		bitStream.Write(uint16_t(value));
+		bitStream.Write(static_cast<uint16_t>(value));
 	}
-	if (dataSize > 0) bitStream.Write(uint16_t(0));
+	if (dataSize > 0) bitStream.Write(static_cast<uint16_t>(0));
 
 	if (sysAddr == UNASSIGNED_SYSTEM_ADDRESS) SEND_PACKET_BROADCAST;
 	SEND_PACKET;
@@ -1144,16 +1143,16 @@ void GameMessages::SendPlayerReachedRespawnCheckpoint(Entity* entity, const NiPo
 	CMSGHEADER;
 
 	bitStream.Write(entity->GetObjectID());
-	bitStream.Write((uint16_t)eGameMessageType::PLAYER_REACHED_RESPAWN_CHECKPOINT);
+	bitStream.Write(eGameMessageType::PLAYER_REACHED_RESPAWN_CHECKPOINT);
 
 	bitStream.Write(position.x);
 	bitStream.Write(position.y);
 	bitStream.Write(position.z);
 
-	const bool isNotIdentity = rotation != NiQuaternion::IDENTITY;
-	bitStream.Write(isNotIdentity);
-	
-	if (isNotIdentity) {
+	const bool bIsNotIdentity = rotation != NiQuaternion::IDENTITY;
+	bitStream.Write(bIsNotIdentity);
+
+	if (bIsNotIdentity) {
 		bitStream.Write(rotation.w);
 		bitStream.Write(rotation.x);
 		bitStream.Write(rotation.y);
@@ -1176,7 +1175,7 @@ void GameMessages::SendAddSkill(Entity* entity, TSkillID skillID, BehaviorSlot s
 	CMSGHEADER;
 
 	bitStream.Write(entity->GetObjectID());
-	bitStream.Write((uint16_t)eGameMessageType::ADD_SKILL);
+	bitStream.Write(eGameMessageType::ADD_SKILL);
 
 	bitStream.Write(AICombatWeight != 0);
 	if (AICombatWeight != 0) bitStream.Write(AICombatWeight);
@@ -1469,11 +1468,11 @@ void GameMessages::SendMatchUpdate(Entity* entity, const SystemAddress& sysAddr,
 
 	bitStream.Write(entity->GetObjectID());
 	bitStream.Write(eGameMessageType::MATCH_UPDATE);
-	bitStream.Write(uint32_t(data.size()));
+	bitStream.Write(static_cast<uint32_t>(data.size()));
 	for (char character : data) {
-		bitStream.Write(uint16_t(character));
+		bitStream.Write(static_cast<uint16_t>(character));
 	}
-	if (data.size() > 0) bitStream.Write(uint16_t(0));
+	if (data.size() > 0) bitStream.Write(static_cast<uint16_t>(0));
 	bitStream.Write(type);
 
 	SEND_PACKET;
@@ -1557,7 +1556,7 @@ void GameMessages::NotifyLevelRewards(LWOOBJID objectID, const SystemAddress& sy
 	CMSGHEADER;
 
 	bitStream.Write(objectID);
-	bitStream.Write((uint16_t)eGameMessageType::NOTIFY_LEVEL_REWARDS);
+	bitStream.Write(eGameMessageType::NOTIFY_LEVEL_REWARDS);
 
 	bitStream.Write(level);
 	bitStream.Write(sending_rewards);
@@ -1743,7 +1742,7 @@ void GameMessages::SendSetRailMovement(const LWOOBJID& objectID, bool pathGoForw
 
 	bitStream.Write(pathGoForward);
 
-	bitStream.Write(uint32_t(pathName.size()));
+	bitStream.Write(static_cast<uint32_t>(pathName.size()));
 	for (auto character : pathName) {
 		bitStream.Write<uint16_t>(character);
 	}
@@ -1782,14 +1781,14 @@ void GameMessages::SendStartRailMovement(const LWOOBJID& objectID, std::u16strin
 	bitStream.Write(cameraLocked);
 	bitStream.Write(collisionEnabled);
 
-	bitStream.Write(uint32_t(loopSound.size()));
+	bitStream.Write(static_cast<uint32_t>(loopSound.size()));
 	for (auto character : loopSound) {
 		bitStream.Write<uint16_t>(character);
 	}
 
 	bitStream.Write(goForward);
 
-	bitStream.Write(uint32_t(pathName.size()));
+	bitStream.Write(static_cast<uint32_t>(pathName.size()));
 	for (auto character : pathName) {
 		bitStream.Write<uint16_t>(character);
 	}
@@ -1812,12 +1811,12 @@ void GameMessages::SendStartRailMovement(const LWOOBJID& objectID, std::u16strin
 		bitStream.Write<LWOOBJID>(railActivatorObjectID);
 	}
 
-	bitStream.Write(uint32_t(startSound.size()));
+	bitStream.Write(static_cast<uint32_t>(startSound.size()));
 	for (auto character : startSound) {
 		bitStream.Write<uint16_t>(character);
 	}
 
-	bitStream.Write(uint32_t(stopSound.size()));
+	bitStream.Write(static_cast<uint32_t>(stopSound.size()));
 	for (auto character : stopSound) {
 		bitStream.Write<uint16_t>(character);
 	}
@@ -1835,7 +1834,7 @@ void GameMessages::SendNotifyClientObject(const LWOOBJID& objectID, std::u16stri
 	bitStream.Write(objectID);
 	bitStream.Write(eGameMessageType::NOTIFY_CLIENT_OBJECT);
 
-	bitStream.Write(uint32_t(name.size()));
+	bitStream.Write(static_cast<uint32_t>(name.size()));
 	for (auto character : name) {
 		bitStream.Write<uint16_t>(character);
 	}
@@ -1846,7 +1845,7 @@ void GameMessages::SendNotifyClientObject(const LWOOBJID& objectID, std::u16stri
 
 	bitStream.Write(paramObj);
 
-	bitStream.Write(uint32_t(paramStr.size()));
+	bitStream.Write(static_cast<uint32_t>(paramStr.size()));
 	for (auto character : paramStr) {
 		bitStream.Write(character);
 	}
@@ -1864,7 +1863,7 @@ void GameMessages::SendNotifyClientZoneObject(const LWOOBJID& objectID, const st
 	bitStream.Write(objectID);
 	bitStream.Write(eGameMessageType::NOTIFY_CLIENT_ZONE_OBJECT);
 
-	bitStream.Write(uint32_t(name.size()));
+	bitStream.Write(static_cast<uint32_t>(name.size()));
 	for (const auto& character : name) {
 		bitStream.Write<uint16_t>(character);
 	}
@@ -1873,7 +1872,7 @@ void GameMessages::SendNotifyClientZoneObject(const LWOOBJID& objectID, const st
 	bitStream.Write(param2);
 	bitStream.Write(paramObj);
 
-	bitStream.Write(uint32_t(paramStr.size()));
+	bitStream.Write(static_cast<uint32_t>(paramStr.size()));
 	for (const auto& character : paramStr) {
 		bitStream.Write(character);
 	}
@@ -1890,9 +1889,9 @@ void GameMessages::SendNotifyClientFailedPrecondition(LWOOBJID objectId, const S
 	bitStream.Write(objectId);
 	bitStream.Write(eGameMessageType::NOTIFY_CLIENT_FAILED_PRECONDITION);
 
-	bitStream.Write(uint32_t(failedReason.size()));
+	bitStream.Write(static_cast<uint32_t>(failedReason.size()));
 	for (uint16_t character : failedReason) {
-		bitStream.Write(uint16_t(character));
+		bitStream.Write(static_cast<uint16_t>(character));
 	}
 
 	bitStream.Write(preconditionID);
@@ -2016,7 +2015,7 @@ void GameMessages::SendLockNodeRotation(Entity* entity, std::string nodeName) {
 	bitStream.Write(entity->GetObjectID());
 	bitStream.Write(eGameMessageType::LOCK_NODE_ROTATION);
 
-	bitStream.Write(uint32_t(nodeName.size()));
+	bitStream.Write(static_cast<uint32_t>(nodeName.size()));
 	for (char character : nodeName) {
 		bitStream.Write(character);
 	}
@@ -4127,8 +4126,7 @@ void GameMessages::HandleRequestDie(RakNet::BitStream* inStream, Entity* entity,
 		}
 
 		racingControlComponent->OnRequestDie(entity);
-	}
-	else {
+	} else {
 		auto* destroyableComponent = entity->GetComponent<DestroyableComponent>();
 
 		if (!destroyableComponent) return;
@@ -5601,7 +5599,7 @@ void GameMessages::HandleModularBuildFinish(RakNet::BitStream* inStream, Entity*
 			if (entity->GetLOT() != 9980 || Game::server->GetZoneID() != 1200) {
 				if (missionComponent != nullptr) {
 					missionComponent->Progress(eMissionTaskType::SCRIPT, entity->GetLOT(), entity->GetObjectID());
-					if (count >= 7 && everyPieceSwapped) missionComponent->Progress(eMissionTaskType::RACING, LWOOBJID_EMPTY, (LWOOBJID)eRacingTaskParam::MODULAR_BUILDING);
+					if (count >= 7 && everyPieceSwapped) missionComponent->Progress(eMissionTaskType::RACING, LWOOBJID_EMPTY, static_cast<LWOOBJID>(eRacingTaskParam::MODULAR_BUILDING));
 				}
 			}
 

--- a/dNet/MasterPackets.cpp
+++ b/dNet/MasterPackets.cpp
@@ -31,7 +31,7 @@ void MasterPackets::SendZoneTransferRequest(dServer* server, uint64_t requestID,
 	BitStreamUtils::WriteHeader(bitStream, eConnectionType::MASTER, eMasterMessageType::REQUEST_ZONE_TRANSFER);
 
 	bitStream.Write(requestID);
-	bitStream.Write(static_cast<uint8_t>(mythranShift));
+	bitStream.Write<uint8_t>(mythranShift);
 	bitStream.Write(zoneID);
 	bitStream.Write(cloneID);
 
@@ -58,7 +58,7 @@ void MasterPackets::SendZoneRequestPrivate(dServer* server, uint64_t requestID, 
 	BitStreamUtils::WriteHeader(bitStream, eConnectionType::MASTER, eMasterMessageType::REQUEST_PRIVATE_ZONE);
 
 	bitStream.Write(requestID);
-	bitStream.Write(static_cast<uint8_t>(mythranShift));
+	bitStream.Write<uint8_t>(mythranShift);
 
 	bitStream.Write<uint32_t>(password.size());
 	for (auto character : password) {
@@ -83,11 +83,11 @@ void MasterPackets::SendZoneTransferResponse(dServer* server, const SystemAddres
 	BitStreamUtils::WriteHeader(bitStream, eConnectionType::MASTER, eMasterMessageType::REQUEST_ZONE_TRANSFER_RESPONSE);
 
 	bitStream.Write(requestID);
-	bitStream.Write(static_cast<uint8_t>(mythranShift));
+	bitStream.Write<uint8_t>(mythranShift);
 	bitStream.Write(zoneID);
 	bitStream.Write(zoneInstance);
 	bitStream.Write(zoneClone);
-	bitStream.Write(static_cast<uint16_t>(serverPort));
+	bitStream.Write<uint16_t>(serverPort);
 	bitStream.Write(LUString(serverIP, static_cast<uint32_t>(serverIP.size() + 1)));
 
 	server->Send(&bitStream, sysAddr, false);

--- a/dNet/WorldPackets.cpp
+++ b/dNet/WorldPackets.cpp
@@ -21,19 +21,19 @@ void WorldPackets::SendLoadStaticZone(const SystemAddress& sysAddr, float x, flo
 	BitStreamUtils::WriteHeader(bitStream, eConnectionType::CLIENT, eClientMessageType::LOAD_STATIC_ZONE);
 
 	auto zone = Game::zoneManager->GetZone()->GetZoneID();
-	bitStream.Write(static_cast<uint16_t>(zone.GetMapID()));
-	bitStream.Write(static_cast<uint16_t>(zone.GetInstanceID()));
-	//bitStream.Write(static_cast<uint32_t>(zone.GetCloneID()));
+	bitStream.Write<uint16_t>(zone.GetMapID());
+	bitStream.Write<uint16_t>(zone.GetInstanceID());
+	//bitStream.Write<uint32_t>(zone.GetCloneID());
 	bitStream.Write(0);
 
 	bitStream.Write(checksum);
-	bitStream.Write(static_cast<uint16_t>(0));     // ??
+	bitStream.Write<uint16_t>(0);     // ??
 
 	bitStream.Write(x);
 	bitStream.Write(y);
 	bitStream.Write(z);
 
-	bitStream.Write(static_cast<uint32_t>(0));     // Change this to eventually use 4 on activity worlds
+	bitStream.Write<uint32_t>(0);     // Change this to eventually use 4 on activity worlds
 
 	SEND_PACKET;
 }
@@ -45,18 +45,18 @@ void WorldPackets::SendCharacterList(const SystemAddress& sysAddr, User* user) {
 	BitStreamUtils::WriteHeader(bitStream, eConnectionType::CLIENT, eClientMessageType::CHARACTER_LIST_RESPONSE);
 
 	std::vector<Character*> characters = user->GetCharacters();
-	bitStream.Write(static_cast<uint8_t>(characters.size()));
-	bitStream.Write(static_cast<uint8_t>(0)); //character index in front, just picking 0
+	bitStream.Write<uint8_t>(characters.size());
+	bitStream.Write<uint8_t>(0); //character index in front, just picking 0
 
 	for (uint32_t i = 0; i < characters.size(); ++i) {
 		bitStream.Write(characters[i]->GetObjectID());
-		bitStream.Write(static_cast<uint32_t>(0));
+		bitStream.Write<uint32_t>(0);
 
 		bitStream.Write(LUWString(characters[i]->GetName()));
 		bitStream.Write(LUWString(characters[i]->GetUnapprovedName()));
 
-		bitStream.Write(static_cast<uint8_t>(characters[i]->GetNameRejected()));
-		bitStream.Write(static_cast<uint8_t>(false));
+		bitStream.Write<uint8_t>(characters[i]->GetNameRejected());
+		bitStream.Write<uint8_t>(false);
 
 		bitStream.Write(LUString("", 10));
 
@@ -70,16 +70,16 @@ void WorldPackets::SendCharacterList(const SystemAddress& sysAddr, User* user) {
 		bitStream.Write(characters[i]->GetEyebrows());
 		bitStream.Write(characters[i]->GetEyes());
 		bitStream.Write(characters[i]->GetMouth());
-		bitStream.Write(static_cast<uint32_t>(0));
+		bitStream.Write<uint32_t>(0);
 
-		bitStream.Write(static_cast<uint16_t>(characters[i]->GetZoneID()));
-		bitStream.Write(static_cast<uint16_t>(characters[i]->GetZoneInstance()));
+		bitStream.Write<uint16_t>(characters[i]->GetZoneID());
+		bitStream.Write<uint16_t>(characters[i]->GetZoneInstance());
 		bitStream.Write(characters[i]->GetZoneClone());
 
 		bitStream.Write(characters[i]->GetLastLogin());
 
 		const auto& equippedItems = characters[i]->GetEquippedItems();
-		bitStream.Write(static_cast<uint16_t>(equippedItems.size()));
+		bitStream.Write<uint16_t>(equippedItems.size());
 
 		for (uint32_t j = 0; j < equippedItems.size(); ++j) {
 			bitStream.Write(equippedItems[j]);
@@ -106,7 +106,7 @@ void WorldPackets::SendCharacterRenameResponse(const SystemAddress& sysAddr, eRe
 void WorldPackets::SendCharacterDeleteResponse(const SystemAddress& sysAddr, bool response) {
 	RakNet::BitStream bitStream;
 	BitStreamUtils::WriteHeader(bitStream, eConnectionType::CLIENT, eClientMessageType::DELETE_CHARACTER_RESPONSE);
-	bitStream.Write(static_cast<uint8_t>(response));
+	bitStream.Write<uint8_t>(response);
 	SEND_PACKET;
 }
 
@@ -115,8 +115,8 @@ void WorldPackets::SendTransferToWorld(const SystemAddress& sysAddr, const std::
 	BitStreamUtils::WriteHeader(bitStream, eConnectionType::CLIENT, eClientMessageType::TRANSFER_TO_WORLD);
 
 	bitStream.Write(LUString(serverIP));
-	bitStream.Write(static_cast<uint16_t>(serverPort));
-	bitStream.Write(static_cast<uint8_t>(mythranShift));
+	bitStream.Write<uint16_t>(serverPort);
+	bitStream.Write<uint8_t>(mythranShift);
 
 	SEND_PACKET;
 }
@@ -124,7 +124,7 @@ void WorldPackets::SendTransferToWorld(const SystemAddress& sysAddr, const std::
 void WorldPackets::SendServerState(const SystemAddress& sysAddr) {
 	RakNet::BitStream bitStream;
 	BitStreamUtils::WriteHeader(bitStream, eConnectionType::CLIENT, eClientMessageType::SERVER_STATES);
-	bitStream.Write(static_cast<uint8_t>(1)); //If the server is receiving this request, it probably is ready anyway.
+	bitStream.Write<uint8_t>(1); //If the server is receiving this request, it probably is ready anyway.
 	SEND_PACKET;
 }
 
@@ -204,8 +204,8 @@ void WorldPackets::SendChatModerationResponse(const SystemAddress& sysAddr, bool
 	bitStream.Write<uint8_t>(unacceptedItems.empty()); // Is sentence ok?
 	bitStream.Write<uint16_t>(0x16); // Source ID, unknown
 
-	bitStream.Write(static_cast<uint8_t>(requestID)); // request ID
-	bitStream.Write(static_cast<char>(0)); // chat mode
+	bitStream.Write<uint8_t>(requestID); // request ID
+	bitStream.Write<char>(0); // chat mode
 
 	bitStream.Write(LUWString(receiver, 42)); // receiver name
 

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -217,7 +217,7 @@ int main(int argc, char** argv) {
 	uint32_t chatPort = 1501;
 	if (Game::config->GetValue("chat_server_port") != "") chatPort = std::atoi(Game::config->GetValue("chat_server_port").c_str());
 
-	auto chatSock = SocketDescriptor(uint16_t(ourPort + 2), 0);
+	auto chatSock = SocketDescriptor(static_cast<uint16_t>(ourPort + 2), 0);
 	Game::chatServer = RakNetworkFactory::GetRakPeerInterface();
 	Game::chatServer->Startup(1, 30, &chatSock, 1);
 	Game::chatServer->Connect(masterIP.c_str(), chatPort, "3.25 ND1", 8);
@@ -1246,7 +1246,7 @@ void HandlePacket(Packet* packet) {
 
 	default:
 		const auto messageId = *reinterpret_cast<eWorldMessageType*>(&packet->data[3]);
-		const std::string_view messageIdString =  StringifiedEnum::ToString(messageId);
+		const std::string_view messageIdString = StringifiedEnum::ToString(messageId);
 		LOG("Unknown world packet received: %4i, %s", messageId, messageIdString.data());
 	}
 }

--- a/tests/dCommonTests/CMakeLists.txt
+++ b/tests/dCommonTests/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(DCOMMONTEST_SOURCES
 	"AMFDeserializeTests.cpp"
 	"Amf3Tests.cpp"
+	"CastUnderlyingTypeTests.cpp"
 	"HeaderSkipTest.cpp"
 	"TestCDFeatureGatingTable.cpp"
 	"TestLDFFormat.cpp"

--- a/tests/dCommonTests/CastUnderlyingTypeTests.cpp
+++ b/tests/dCommonTests/CastUnderlyingTypeTests.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+
+#include "GeneralUtils.h"
+
+#include "eGameMasterLevel.h"
+#include "eGameMessageType.h"
+#include "eWorldMessageType.h"
+
+#define ASSERT_TYPE_EQ(TYPE, ENUM)\
+	ASSERT_TRUE(typeid(TYPE) == typeid(GeneralUtils::CastUnderlyingType(static_cast<ENUM>(0))));
+
+#define ASSERT_TYPE_NE(TYPE, ENUM)\
+	ASSERT_FALSE(typeid(TYPE) == typeid(GeneralUtils::CastUnderlyingType(static_cast<ENUM>(0))));
+	
+// Verify that the underlying enum types are being cast correctly
+TEST(CastUnderlyingTypeTests, VerifyCastUnderlyingType) {
+	ASSERT_TYPE_EQ(uint8_t, eGameMasterLevel);
+	ASSERT_TYPE_EQ(uint16_t, eGameMessageType);
+	ASSERT_TYPE_EQ(uint32_t, eWorldMessageType)
+
+	ASSERT_TYPE_NE(void, eGameMasterLevel);
+	ASSERT_TYPE_NE(void, eGameMessageType);
+	ASSERT_TYPE_NE(void, eWorldMessageType)
+}

--- a/tests/dCommonTests/dEnumsTests/MagicEnumTests.cpp
+++ b/tests/dCommonTests/dEnumsTests/MagicEnumTests.cpp
@@ -20,7 +20,7 @@
 // Test World Message Enum Reflection
 TEST(MagicEnumTest, eWorldMessageTypeTest) {
 	Game::logger = new Logger("./MagicEnumTest_eWorldMessageTypeTest.log", true, true);
-	
+
 	ENUM_EQ(eWorldMessageType, 1, VALIDATION);
 	ENUM_EQ(eWorldMessageType, 2, CHARACTER_LIST_REQUEST);
 	ENUM_EQ(eWorldMessageType, 3, CHARACTER_CREATE_REQUEST);
@@ -74,9 +74,9 @@ TEST(MagicEnumTest, eWorldMessageTypeTest) {
 
 // Test Game Message Enum Reflection
 TEST(MagicEnumTest, eGameMessageTypeTest) {
-	
+
 	Game::logger = new Logger("./MagicEnumTest_eGameMessageTypeTest.log", true, true);
-	
+
 	// Only doing the first and last 10 for the sake of my sanity
 	ENUM_EQ(eGameMessageType, 0, GET_POSITION);
 	ENUM_EQ(eGameMessageType, 1, GET_ROTATION);
@@ -139,4 +139,25 @@ TEST(MagicEnumTest, ArraysAreSorted) {
 	ASSERT_EARRAY_SORTED(gmArray);
 
 	delete Game::logger;
+}
+
+#define IS_CONSTEXPR2(...) std::integral_constant<bool, __builtin_constant_p(([] () { __VA_ARGS__; } (), 0))>::value
+
+/* Test that the StringifiedEnum::ToString() function is evaluated as a constexpr when possible
+ * As the 'static_asserts' will generate compiler errors, this test simply checks if it is ran
+ * The main purpose of including it at all is to have a logical place to store this code 
+ */
+TEST(MagicEnumTest, ConstexprEvaluation) {
+	volatile bool isCompiled = false; // Trying to keep the compiler from optimizing away this variable, but it's otherwise a dummy
+
+	constexpr eWorldMessageType wmVal = eWorldMessageType::CANCEL_MAP_QUEUE;
+	static_assert(StringifiedEnum::ToString(wmVal)=="CANCEL_MAP_QUEUE");
+	static_assert(StringifiedEnum::ToString(eWorldMessageType::CANCEL_MAP_QUEUE)=="CANCEL_MAP_QUEUE");
+
+	constexpr eGameMessageType gmVal = eGameMessageType::ACTIVATE_BRICK_MODE;
+	static_assert(StringifiedEnum::ToString(gmVal)=="ACTIVATE_BRICK_MODE");
+	static_assert(StringifiedEnum::ToString(eGameMessageType::ACTIVATE_BRICK_MODE)=="ACTIVATE_BRICK_MODE");
+
+	isCompiled = true;
+	ASSERT_TRUE(isCompiled);
 }

--- a/tests/dCommonTests/dEnumsTests/MagicEnumTests.cpp
+++ b/tests/dCommonTests/dEnumsTests/MagicEnumTests.cpp
@@ -140,24 +140,3 @@ TEST(MagicEnumTest, ArraysAreSorted) {
 
 	delete Game::logger;
 }
-
-#define IS_CONSTEXPR2(...) std::integral_constant<bool, __builtin_constant_p(([] () { __VA_ARGS__; } (), 0))>::value
-
-/* Test that the StringifiedEnum::ToString() function is evaluated as a constexpr when possible
- * As the 'static_asserts' will generate compiler errors, this test simply checks if it is ran
- * The main purpose of including it at all is to have a logical place to store this code 
- */
-TEST(MagicEnumTest, ConstexprEvaluation) {
-	volatile bool isCompiled = false; // Trying to keep the compiler from optimizing away this variable, but it's otherwise a dummy
-
-	constexpr eWorldMessageType wmVal = eWorldMessageType::CANCEL_MAP_QUEUE;
-	static_assert(StringifiedEnum::ToString(wmVal)=="CANCEL_MAP_QUEUE");
-	static_assert(StringifiedEnum::ToString(eWorldMessageType::CANCEL_MAP_QUEUE)=="CANCEL_MAP_QUEUE");
-
-	constexpr eGameMessageType gmVal = eGameMessageType::ACTIVATE_BRICK_MODE;
-	static_assert(StringifiedEnum::ToString(gmVal)=="ACTIVATE_BRICK_MODE");
-	static_assert(StringifiedEnum::ToString(eGameMessageType::ACTIVATE_BRICK_MODE)=="ACTIVATE_BRICK_MODE");
-
-	isCompiled = true;
-	ASSERT_TRUE(isCompiled);
-}


### PR DESCRIPTION
This is kind of a grab-bag of miscellaneous changes I've wanted to do. Most of them do not affect functionality, except for one fairly large change which I will elaborate on below.

I've altered the StringifiedEnum::ToString() function to attempt to evaluate as a constexpr. However, doing this requires the use of a poorly-documented compiler flag and might break things. Part of why I'm making this PR is to check how the other compiler builds handle it. If y'all want that stripped out and/or it breaks things, I can do so. Otherwise, everything in here should be pretty non-controversial.

EDIT: Ended up dropping that particular change due to compiler portability issues, as seen in commit 57e274d below. The performance benefit was pretty much purely hypothetical anyway: I couldn't even measure it.