### PR TITLE
fix: remove cancelOnLogout handling

### DIFF
--- a/dGame/dComponents/BuffComponent.cpp
+++ b/dGame/dComponents/BuffComponent.cpp
@@ -398,7 +398,8 @@ void BuffComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
 
 	for (const auto& [id, buff] : m_Buffs) {
 		auto* buffEntry = doc->NewElement("b");
-		if (buff.cancelOnZone || buff.cancelOnLogout) continue;
+		// TODO: change this if to if (buff.cancelOnZone || buff.cancelOnLogout) handling at some point.  No current way to differentiate between zone transfer and logout.
+		if (buff.cancelOnZone) continue;
 
 		buffEntry->SetAttribute("id", id);
 		buffEntry->SetAttribute("t", buff.time);


### PR DESCRIPTION
fixes #1353 

Tested that the imagination backpack holds its charge through world transfers now, however we now no longer handle logouts as per before the commit that added the handling.  A ticket will be created on merge to reflect the new work.
