### PR TITLE
fix: more than 1 zone control object causing issues with scripted minigames

### DIFF
--- a/dZoneManager/Level.cpp
+++ b/dZoneManager/Level.cpp
@@ -269,13 +269,13 @@ void Level::ReadSceneObjectDataChunk(std::istream& file, Header& header) {
 				else if (gating.featureName == Game::config->GetValue("event_8")) continue;
 				else if (!featureGatingTable->FeatureUnlocked(gating)) {
 					// The feature is not unlocked, so we can skip loading this object
-					skipLoadingObject = true;
+					skipLoadingObject |= true;
 					break;
 				}
 			}
 			// If this is a client only object, we can skip loading it
 			if (data->GetKey() == u"loadOnClientOnly") {
-				skipLoadingObject = static_cast<bool>(std::stoi(data->GetValueAsString()));
+				skipLoadingObject |= static_cast<bool>(std::stoi(data->GetValueAsString()));
 				break;
 			}
 		}

--- a/dZoneManager/Level.cpp
+++ b/dZoneManager/Level.cpp
@@ -269,7 +269,7 @@ void Level::ReadSceneObjectDataChunk(std::istream& file, Header& header) {
 				else if (gating.featureName == Game::config->GetValue("event_8")) continue;
 				else if (!featureGatingTable->FeatureUnlocked(gating)) {
 					// The feature is not unlocked, so we can skip loading this object
-					skipLoadingObject |= true;
+					skipLoadingObject = true;
 					break;
 				}
 			}


### PR DESCRIPTION
Fixes an issue when players cannot load into Avant Gardens Survival and other script based minigames with more than 1 zone control object in the level files.  (why are there 26 zone control objects in BoNS and AGS)