### PR TITLE
AssetManager: fix deleting no file

### DIFF
--- a/dCommon/dClient/AssetManager.h
+++ b/dCommon/dClient/AssetManager.h
@@ -26,7 +26,7 @@ struct AssetMemoryBuffer : std::streambuf {
 	}
 
 	~AssetMemoryBuffer() {
-		free(m_Base);
+		if (m_Success) free(m_Base);
 	}
 
 	pos_type seekpos(pos_type sp, std::ios_base::openmode which) override {


### PR DESCRIPTION
Tested that if a file is missing, the service does not halt.