### PR TITLE
fix: Mission offering for NPCs

### DIFF
--- a/dGame/dComponents/MissionOfferComponent.cpp
+++ b/dGame/dComponents/MissionOfferComponent.cpp
@@ -55,22 +55,9 @@ MissionOfferComponent::MissionOfferComponent(Entity* parent, const LOT parentLot
 			});
 
 		for (auto& mission : missions) {
-			auto* offeredMission = new OfferedMission(mission.missionID, mission.offersMission, mission.acceptsMission);
-			this->offeredMissions.push_back(offeredMission);
+			this->offeredMissions.emplace_back(mission.missionID, mission.offersMission, mission.acceptsMission);
 		}
 	}
-}
-
-
-MissionOfferComponent::~MissionOfferComponent() {
-	for (auto* mission : this->offeredMissions) {
-		if (mission) {
-			delete mission;
-			mission = nullptr;
-		}
-	}
-
-	offeredMissions.clear();
 }
 
 void MissionOfferComponent::OnUse(Entity* originator) {
@@ -79,14 +66,12 @@ void MissionOfferComponent::OnUse(Entity* originator) {
 
 void MissionOfferComponent::OfferMissions(Entity* entity, const uint32_t specifiedMissionId) {
 	// First, get the entity's MissionComponent. If there is not one, then we cannot offer missions to this entity.
-	auto* missionComponent = static_cast<MissionComponent*>(entity->GetComponent(eReplicaComponentType::MISSION));
+	auto* missionComponent = entity->GetComponent<MissionComponent>();
 
 	if (!missionComponent) {
 		LOG("Unable to get mission component for Entity %llu", entity->GetObjectID());
 		return;
 	}
-
-	std::vector<uint32_t> offered{};
 
 	CDMissions info{};
 
@@ -94,15 +79,15 @@ void MissionOfferComponent::OfferMissions(Entity* entity, const uint32_t specifi
 		return;
 	}
 
-	for (auto* offeredMission : this->offeredMissions) {
+	for (const auto offeredMission : this->offeredMissions) {
 		if (specifiedMissionId > 0) {
-			if (offeredMission->GetMissionId() != specifiedMissionId && !info.isRandom) {
+			if (offeredMission.GetMissionId() != specifiedMissionId && !info.isRandom) {
 				continue;
 			}
 		}
 
 		// First, check if we already have the mission
-		const auto missionId = offeredMission->GetMissionId();
+		const auto missionId = offeredMission.GetMissionId();
 
 		auto* mission = missionComponent->GetMission(missionId);
 
@@ -118,8 +103,6 @@ void MissionOfferComponent::OfferMissions(Entity* entity, const uint32_t specifi
 			if (mission->IsActive() || mission->IsReadyToComplete()) {
 				GameMessages::SendOfferMission(entity->GetObjectID(), entity->GetSystemAddress(), missionId, m_Parent->GetObjectID());
 
-				offered.push_back(missionId);
-
 				continue;
 			}
 		}
@@ -127,20 +110,13 @@ void MissionOfferComponent::OfferMissions(Entity* entity, const uint32_t specifi
 		const auto canAccept = MissionPrerequisites::CanAccept(missionId, missionComponent->GetMissions());
 
 		// Mission has not yet been accepted - check the prereqs
-		if (!canAccept)
-			continue;
-
-		if (!Mission::IsValidMission(missionId, info)) {
-			continue;
-		}
+		if (!canAccept || !Mission::IsValidMission(missionId, info)) continue;
 
 		const auto& randomPool = info.randomPool;
 		const auto isRandom = info.isRandom;
 
-		if (isRandom && randomPool.empty()) // This means the mission is part of a random pool of missions.
-		{
-			continue;
-		}
+		// This means the mission is part of a random pool of missions.
+		if (isRandom && randomPool.empty()) continue;
 
 		if (isRandom && !randomPool.empty()) {
 			std::istringstream stream(randomPool);
@@ -180,9 +156,7 @@ void MissionOfferComponent::OfferMissions(Entity* entity, const uint32_t specifi
 					sample == specifiedMissionId) {
 					mission = missionComponent->GetMission(sample);
 
-					if (mission == nullptr || mission->IsAchievement()) {
-						continue;
-					}
+					if (mission == nullptr || mission->IsAchievement()) continue;
 
 					GameMessages::SendOfferMission(entity->GetObjectID(), entity->GetSystemAddress(), sample, m_Parent->GetObjectID());
 
@@ -191,22 +165,18 @@ void MissionOfferComponent::OfferMissions(Entity* entity, const uint32_t specifi
 					break;
 				}
 
-				if (std::find(offered.begin(), offered.end(), sample) == offered.end() && MissionPrerequisites::CanAccept(sample, missionComponent->GetMissions())) {
+				if (MissionPrerequisites::CanAccept(sample, missionComponent->GetMissions())) {
 					canAcceptPool.push_back(sample);
 				}
 			}
 
 			// If the mission is already active or we already completed one of them today
-			if (canAcceptPool.empty())
-				continue;
+			if (canAcceptPool.empty()) continue;
 
 			const auto selected = canAcceptPool[GeneralUtils::GenerateRandomNumber<int>(0, canAcceptPool.size() - 1)];
 
 			GameMessages::SendOfferMission(entity->GetObjectID(), entity->GetSystemAddress(), selected, m_Parent->GetObjectID());
-		} else if (
-			std::find(offered.begin(), offered.end(), missionId) == offered.end()
-			&&
-			(offeredMission->GetOffersMission() || offeredMission->GetAcceptsMission())) {
+		} else if (offeredMission.GetOffersMission()) {
 			GameMessages::SendOfferMission(entity->GetObjectID(), entity->GetSystemAddress(), missionId, m_Parent->GetObjectID());
 		}
 	}

--- a/dGame/dComponents/MissionOfferComponent.h
+++ b/dGame/dComponents/MissionOfferComponent.h
@@ -64,7 +64,6 @@ public:
 	inline static const eReplicaComponentType ComponentType = eReplicaComponentType::MISSION_OFFER;
 
 	MissionOfferComponent(Entity* parent, LOT parentLot);
-	~MissionOfferComponent() override;
 
 	/**
 	 * Handles the OnUse event triggered by some entity, determines which missions to show based on what they may
@@ -85,7 +84,7 @@ private:
 	/**
 	 * The missions this entity has to offer
 	 */
-	std::vector<OfferedMission*> offeredMissions;
+	std::vector<OfferedMission> offeredMissions;
 };
 
 #endif // MISSIONOFFERCOMPONENT_H

--- a/dGame/dMission/Mission.cpp
+++ b/dGame/dMission/Mission.cpp
@@ -257,7 +257,7 @@ bool Mission::IsComplete() const {
 }
 
 bool Mission::IsActive() const {
-	return m_State == eMissionState::ACTIVE || m_State == eMissionState::COMPLETE_AVAILABLE;
+	return m_State == eMissionState::ACTIVE || m_State == eMissionState::COMPLETE_ACTIVE;
 }
 
 void Mission::MakeActive() {


### PR DESCRIPTION
O7fixes an issue where NPCs would offer the incorrect missions which caused odd blocks.  Consolidated logic for mission offering and removed redundant code.

Tested that not having the Find the Sentinels Mission but having the mission Anchor Management complete no longer shows Find the Sentinels for completion instead of Anchor Management.
Tested that 
![image](https://github.com/DarkflameUniverse/DarkflameServer/assets/39972741/2b527466-dced-4717-8127-e9f2d4b4da87)
if both of these missions are active, I can cycle between them instead of having to do one first, and then the other.

Fixes #1360 