### PR TITLE
feat: get & print std::current_exception

### DIFF
--- a/dCommon/Diagnostics.cpp
+++ b/dCommon/Diagnostics.cpp
@@ -115,6 +115,13 @@ void GenerateDump() {
 }
 
 void CatchUnhandled(int sig) {
+	std::exception_ptr eptr = std::current_exception();
+	try {
+		if (eptr) std::rethrow_exception(eptr);
+	} catch(const std::exception& e) {
+		LOG("Caught exception: '%s'", e.what());
+	}
+
 #ifndef __include_backtrace__
 
 	std::string fileName = Diagnostics::GetOutDirectory() + "crash_" + Diagnostics::GetProcessName() + "_" + std::to_string(getpid()) + ".log";


### PR DESCRIPTION
This improves the linux diagnostics code to print the current exception if there is one. This would probably work on windows as well, but this matches the `std::set_terminate` call, and as far as I can tell, the windows code does something else entirely.

c.f. <https://en.cppreference.com/w/cpp/error/exception_ptr>