### PR TITLE
feat: Allow env var override for game config

### DIFF
--- a/dCommon/dConfig.cpp
+++ b/dCommon/dConfig.cpp
@@ -34,6 +34,11 @@ void dConfig::ReloadConfig() {
 }
 
 const std::string& dConfig::GetValue(std::string key) {
+	std::string upper_key(key);
+	std::transform(upper_key.begin(), upper_key.end(), upper_key.begin(), ::toupper);
+	if (const char* env_p = std::getenv(upper_key.c_str())) {
+		this->m_ConfigValues[key] = env_p;
+	}
 	return this->m_ConfigValues[key];
 }
 


### PR DESCRIPTION
This allows users to override ini config with environment variables. This will cut down the amount of weird pre-processing required for a docker / kubernetes setup even more. For now, we just check the uppercase version of the config key agains the environment (windows is case-insensitive, linux isn't), so e.g. `MYSQL_HOST` can be used as an env var to specify where the DB is at.