### PR TITLE
feat: Split out system() calls from the rest of MasterServer

### DIFF
--- a/dMasterServer/CMakeLists.txt
+++ b/dMasterServer/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(DMASTERSERVER_SOURCES
 	"InstanceManager.cpp"
 	"ObjectIDManager.cpp"
+	"Start.cpp"
 )
 
 add_library(dMasterServer ${DMASTERSERVER_SOURCES})

--- a/dMasterServer/InstanceManager.cpp
+++ b/dMasterServer/InstanceManager.cpp
@@ -9,9 +9,10 @@
 #include "CDZoneTableTable.h"
 #include "MasterPackets.h"
 #include "BitStreamUtils.h"
-#include "BinaryPathFinder.h"
 #include "eConnectionType.h"
 #include "eMasterMessageType.h"
+
+#include "Start.h"
 
 InstanceManager::InstanceManager(Logger* logger, const std::string& externalIP) {
 	mLogger = logger;
@@ -57,33 +58,7 @@ Instance* InstanceManager::GetInstance(LWOMAPID mapID, bool isFriendTransfer, LW
 	instance = new Instance(mExternalIP, port, mapID, ++m_LastInstanceID, cloneID, softCap, maxPlayers);
 
 	//Start the actual process:
-#ifdef _WIN32
-	std::string cmd = "start " + (BinaryPathFinder::GetBinaryDir() / "WorldServer.exe").string() + " -zone ";
-#else
-	std::string cmd;
-	if (std::atoi(Game::config->GetValue("use_sudo_world").c_str())) {
-		cmd = "sudo " + (BinaryPathFinder::GetBinaryDir() / "WorldServer").string() + " -zone ";
-	} else {
-		cmd = (BinaryPathFinder::GetBinaryDir() / "WorldServer").string() + " -zone ";
-	}
-#endif
-
-	cmd.append(std::to_string(mapID));
-	cmd.append(" -port ");
-	cmd.append(std::to_string(port));
-	cmd.append(" -instance ");
-	cmd.append(std::to_string(m_LastInstanceID));
-	cmd.append(" -maxclients ");
-	cmd.append(std::to_string(maxPlayers));
-
-	cmd.append(" -clone ");
-	cmd.append(std::to_string(cloneID));
-
-#ifndef _WIN32
-	cmd.append("&"); //Sends our next process to the background on Linux
-#endif
-
-	auto ret = system(cmd.c_str());
+	StartWorldServer(mapID, port, m_LastInstanceID, maxPlayers, cloneID);
 
 	m_Instances.push_back(instance);
 
@@ -318,28 +293,7 @@ Instance* InstanceManager::CreatePrivateInstance(LWOMAPID mapID, LWOCLONEID clon
 	instance = new Instance(mExternalIP, port, mapID, ++m_LastInstanceID, cloneID, maxPlayers, maxPlayers, true, password);
 
 	//Start the actual process:
-	std::string cmd = "start " + (BinaryPathFinder::GetBinaryDir() / "WorldServer").string() + " -zone ";
-
-#ifndef _WIN32
-	cmd = (BinaryPathFinder::GetBinaryDir() / "WorldServer").string() + " -zone ";
-#endif
-
-	cmd.append(std::to_string(mapID));
-	cmd.append(" -port ");
-	cmd.append(std::to_string(port));
-	cmd.append(" -instance ");
-	cmd.append(std::to_string(m_LastInstanceID));
-	cmd.append(" -maxclients ");
-	cmd.append(std::to_string(maxPlayers));
-
-	cmd.append(" -clone ");
-	cmd.append(std::to_string(cloneID));
-
-#ifndef WIN32
-	cmd.append("&"); //Sends our next process to the background on Linux
-#endif
-
-	auto ret = system(cmd.c_str());
+	StartWorldServer(mapID, port, m_LastInstanceID, maxPlayers, cloneID);
 
 	m_Instances.push_back(instance);
 

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -43,6 +43,7 @@
 #include "PacketUtils.h"
 #include "FdbToSqlite.h"
 #include "BitStreamUtils.h"
+#include "Start.h"
 
 namespace Game {
 	Logger* logger = nullptr;
@@ -58,8 +59,6 @@ bool shutdownSequenceStarted = false;
 void ShutdownSequence(int32_t signal = -1);
 int32_t FinalizeShutdown(int32_t signal = -1);
 Logger* SetupLogger();
-void StartAuthServer();
-void StartChatServer();
 void HandlePacket(Packet* packet);
 std::map<uint32_t, std::string> activeSessions;
 SystemAddress authServerMasterPeerSysAddr;
@@ -812,43 +811,6 @@ void HandlePacket(Packet* packet) {
 			LOG("Unknown master packet ID from server: %i", packet->data[3]);
 		}
 	}
-}
-
-void StartChatServer() {
-	if (Game::shouldShutdown) {
-		LOG("Currently shutting down.  Chat will not be restarted.");
-		return;
-	}
-#ifdef __APPLE__
-	//macOS doesn't need sudo to run on ports < 1024
-	auto result = system(((BinaryPathFinder::GetBinaryDir() / "ChatServer").string() + "&").c_str());
-#elif _WIN32
-	auto result = system(("start " + (BinaryPathFinder::GetBinaryDir() / "ChatServer.exe").string()).c_str());
-#else
-	if (std::atoi(Game::config->GetValue("use_sudo_chat").c_str())) {
-		auto result = system(("sudo " + (BinaryPathFinder::GetBinaryDir() / "ChatServer").string() + "&").c_str());
-	} else {
-		auto result = system(((BinaryPathFinder::GetBinaryDir() / "ChatServer").string() + "&").c_str());
-}
-#endif
-}
-
-void StartAuthServer() {
-	if (Game::shouldShutdown) {
-		LOG("Currently shutting down.  Auth will not be restarted.");
-		return;
-	}
-#ifdef __APPLE__
-	auto result = system(((BinaryPathFinder::GetBinaryDir() / "AuthServer").string() + "&").c_str());
-#elif _WIN32
-	auto result = system(("start " + (BinaryPathFinder::GetBinaryDir() / "AuthServer.exe").string()).c_str());
-#else
-	if (std::atoi(Game::config->GetValue("use_sudo_auth").c_str())) {
-		auto result = system(("sudo " + (BinaryPathFinder::GetBinaryDir() / "AuthServer").string() + "&").c_str());
-	} else {
-		auto result = system(((BinaryPathFinder::GetBinaryDir() / "AuthServer").string() + "&").c_str());
-}
-#endif
 }
 
 void ShutdownSequence(int32_t signal) {

--- a/dMasterServer/Start.cpp
+++ b/dMasterServer/Start.cpp
@@ -1,0 +1,71 @@
+#include "Start.h"
+#include "Logger.h"
+#include "dConfig.h"
+#include "Game.h"
+#include "BinaryPathFinder.h"
+
+void StartChatServer() {
+	if (Game::shouldShutdown) {
+		LOG("Currently shutting down.  Chat will not be restarted.");
+		return;
+	}
+#ifdef __APPLE__
+	//macOS doesn't need sudo to run on ports < 1024
+	auto result = system(((BinaryPathFinder::GetBinaryDir() / "ChatServer").string() + "&").c_str());
+#elif _WIN32
+	auto result = system(("start " + (BinaryPathFinder::GetBinaryDir() / "ChatServer.exe").string()).c_str());
+#else
+	if (std::atoi(Game::config->GetValue("use_sudo_chat").c_str())) {
+		auto result = system(("sudo " + (BinaryPathFinder::GetBinaryDir() / "ChatServer").string() + "&").c_str());
+	} else {
+		auto result = system(((BinaryPathFinder::GetBinaryDir() / "ChatServer").string() + "&").c_str());
+}
+#endif
+}
+
+void StartAuthServer() {
+	if (Game::shouldShutdown) {
+		LOG("Currently shutting down.  Auth will not be restarted.");
+		return;
+	}
+#ifdef __APPLE__
+	auto result = system(((BinaryPathFinder::GetBinaryDir() / "AuthServer").string() + "&").c_str());
+#elif _WIN32
+	auto result = system(("start " + (BinaryPathFinder::GetBinaryDir() / "AuthServer.exe").string()).c_str());
+#else
+	if (std::atoi(Game::config->GetValue("use_sudo_auth").c_str())) {
+		auto result = system(("sudo " + (BinaryPathFinder::GetBinaryDir() / "AuthServer").string() + "&").c_str());
+	} else {
+		auto result = system(((BinaryPathFinder::GetBinaryDir() / "AuthServer").string() + "&").c_str());
+}
+#endif
+}
+
+void StartWorldServer(LWOMAPID mapID, uint16_t port, LWOINSTANCEID lastInstanceID, int maxPlayers, LWOCLONEID cloneID) {
+#ifdef _WIN32
+	std::string cmd = "start " + (BinaryPathFinder::GetBinaryDir() / "WorldServer.exe").string() + " -zone ";
+#else
+	std::string cmd;
+	if (std::atoi(Game::config->GetValue("use_sudo_world").c_str())) {
+		cmd = "sudo " + (BinaryPathFinder::GetBinaryDir() / "WorldServer").string() + " -zone ";
+	} else {
+		cmd = (BinaryPathFinder::GetBinaryDir() / "WorldServer").string() + " -zone ";
+	}
+#endif
+
+	cmd.append(std::to_string(mapID));
+	cmd.append(" -port ");
+	cmd.append(std::to_string(port));
+	cmd.append(" -instance ");
+	cmd.append(std::to_string(lastInstanceID));
+	cmd.append(" -maxclients ");
+	cmd.append(std::to_string(maxPlayers));
+	cmd.append(" -clone ");
+	cmd.append(std::to_string(cloneID));
+
+#ifndef _WIN32
+	cmd.append("&"); //Sends our next process to the background on Linux
+#endif
+
+	auto ret = system(cmd.c_str());
+}

--- a/dMasterServer/Start.h
+++ b/dMasterServer/Start.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "dCommonVars.h"
+
+void StartAuthServer();
+void StartChatServer();
+void StartWorldServer(LWOMAPID mapID, uint16_t port, LWOINSTANCEID lastInstanceID, int maxPlayers, LWOCLONEID cloneID);


### PR DESCRIPTION
I want to try out ways to spawn the server binaries on a different host at some point, and this would make it easier to swap out the existing implementation without breaking anything or having diffs in too many places.

Also de-duplicates the two places where "WorldServer" is called right now, which seem like slightly out of sync copy-paste code.