### PR TITLE
feat: add DLU_CONFIG_DIR env var

### DIFF
--- a/dAuthServer/AuthServer.cpp
+++ b/dAuthServer/AuthServer.cpp
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
 	if (!Game::logger) return EXIT_FAILURE;
 
 	//Read our config:
-	Game::config = new dConfig((BinaryPathFinder::GetBinaryDir() / "authconfig.ini").string());
+	Game::config = new dConfig("authconfig.ini");
 	Game::logger->SetLogToConsole(Game::config->GetValue("log_to_console") != "0");
 	Game::logger->SetLogDebugStatements(Game::config->GetValue("log_debug_statements") == "1");
 

--- a/dChatServer/ChatServer.cpp
+++ b/dChatServer/ChatServer.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv) {
 	if (!Game::logger) return EXIT_FAILURE;
 
 	//Read our config:
-	Game::config = new dConfig((BinaryPathFinder::GetBinaryDir() / "chatconfig.ini").string());
+	Game::config = new dConfig("chatconfig.ini");
 	Game::logger->SetLogToConsole(Game::config->GetValue("log_to_console") != "0");
 	Game::logger->SetLogDebugStatements(Game::config->GetValue("log_debug_statements") == "1");
 

--- a/dCommon/dConfig.cpp
+++ b/dCommon/dConfig.cpp
@@ -10,7 +10,7 @@ dConfig::dConfig(const std::string& filepath) {
 	LoadConfig();
 }
 
-std::filesystem::path getConfigDir() {
+std::filesystem::path GetConfigDir() {
 	std::filesystem::path config_dir = BinaryPathFinder::GetBinaryDir();
 	if (const char* env_p = std::getenv("DLU_CONFIG_DIR")) {
 		config_dir /= env_p;
@@ -19,12 +19,12 @@ std::filesystem::path getConfigDir() {
 }
 
 const bool dConfig::Exists(const std::string& filepath) {
-	std::filesystem::path config_dir = getConfigDir();
+	std::filesystem::path config_dir = GetConfigDir();
 	return std::filesystem::exists(config_dir / filepath);
 }
 
 void dConfig::LoadConfig() {
-	std::filesystem::path config_dir = getConfigDir();
+	std::filesystem::path config_dir = GetConfigDir();
 
 	std::ifstream in(config_dir / m_ConfigFilePath);
 	if (!in.good()) return;

--- a/dCommon/dConfig.cpp
+++ b/dCommon/dConfig.cpp
@@ -10,8 +10,23 @@ dConfig::dConfig(const std::string& filepath) {
 	LoadConfig();
 }
 
+std::filesystem::path getConfigDir() {
+	std::filesystem::path config_dir = BinaryPathFinder::GetBinaryDir();
+	if (const char* env_p = std::getenv("DLU_CONFIG_DIR")) {
+		config_dir /= env_p;
+	}
+	return config_dir;
+}
+
+const bool dConfig::Exists(const std::string& filepath) {
+	std::filesystem::path config_dir = getConfigDir();
+	return std::filesystem::exists(config_dir / filepath);
+}
+
 void dConfig::LoadConfig() {
-	std::ifstream in(BinaryPathFinder::GetBinaryDir() / m_ConfigFilePath);
+	std::filesystem::path config_dir = getConfigDir();
+
+	std::ifstream in(config_dir / m_ConfigFilePath);
 	if (!in.good()) return;
 
 	std::string line{};
@@ -19,7 +34,7 @@ void dConfig::LoadConfig() {
 		if (!line.empty() && line.front() != '#') ProcessLine(line);
 	}
 
-	std::ifstream sharedConfig(BinaryPathFinder::GetBinaryDir() / "sharedconfig.ini", std::ios::in);
+	std::ifstream sharedConfig(config_dir / "sharedconfig.ini", std::ios::in);
 	if (!sharedConfig.good()) return;
 
 	line.clear();

--- a/dCommon/dConfig.h
+++ b/dCommon/dConfig.h
@@ -8,6 +8,11 @@ public:
 	dConfig(const std::string& filepath);
 
 	/**
+	 * Checks whether the specified filepath exists
+	 */
+	static const bool Exists(const std::string& filepath);
+
+	/**
 	 * Gets the specified key from the config.  Returns an empty string if the value is not found.
 	 *
 	 * @param key Key to find

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -84,32 +84,32 @@ int main(int argc, char** argv) {
 	Game::logger = SetupLogger();
 	if (!Game::logger) return EXIT_FAILURE;
 
-	if (!std::filesystem::exists(BinaryPathFinder::GetBinaryDir() / "authconfig.ini")) {
+	if (!dConfig::Exists("authconfig.ini")) {
 		LOG("Couldnt find authconfig.ini");
 		return EXIT_FAILURE;
 	}
 
-	if (!std::filesystem::exists(BinaryPathFinder::GetBinaryDir() / "chatconfig.ini")) {
+	if (!dConfig::Exists("chatconfig.ini")) {
 		LOG("Couldnt find chatconfig.ini");
 		return EXIT_FAILURE;
 	}
 
-	if (!std::filesystem::exists(BinaryPathFinder::GetBinaryDir() / "masterconfig.ini")) {
+	if (!dConfig::Exists("masterconfig.ini")) {
 		LOG("Couldnt find masterconfig.ini");
 		return EXIT_FAILURE;
 	}
 
-	if (!std::filesystem::exists(BinaryPathFinder::GetBinaryDir() / "sharedconfig.ini")) {
+	if (!dConfig::Exists("sharedconfig.ini")) {
 		LOG("Couldnt find sharedconfig.ini");
 		return EXIT_FAILURE;
 	}
 
-	if (!std::filesystem::exists(BinaryPathFinder::GetBinaryDir() / "worldconfig.ini")) {
+	if (!dConfig::Exists("worldconfig.ini")) {
 		LOG("Couldnt find worldconfig.ini");
 		return EXIT_FAILURE;
 	}
 
-	Game::config = new dConfig((BinaryPathFinder::GetBinaryDir() / "masterconfig.ini").string());
+	Game::config = new dConfig("masterconfig.ini");
 	Game::logger->SetLogToConsole(Game::config->GetValue("log_to_console") != "0");
 	Game::logger->SetLogDebugStatements(Game::config->GetValue("log_debug_statements") == "1");
 

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -147,7 +147,7 @@ int main(int argc, char** argv) {
 	if (!Game::logger) return EXIT_FAILURE;
 
 	//Read our config:
-	Game::config = new dConfig((BinaryPathFinder::GetBinaryDir() / "worldconfig.ini").string());
+	Game::config = new dConfig("worldconfig.ini");
 	Game::logger->SetLogToConsole(Game::config->GetValue("log_to_console") != "0");
 	Game::logger->SetLogDebugStatements(Game::config->GetValue("log_debug_statements") == "1");
 


### PR DESCRIPTION
This introduces a new env var `DLU_CONFIG_DIR` that can be set to be an absolute path or relative to the server binary where dConfig will look for its ini files. This is mostly useful for docker/k8s setups with mounted config files, everything else can keep using the main directory.