### PR TITLE
fix: signal handling

### DIFF
--- a/dAuthServer/AuthServer.cpp
+++ b/dAuthServer/AuthServer.cpp
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <string>
 #include <ctime>
+#include <csignal>
 #include <chrono>
 #include <thread>
 
@@ -28,12 +29,17 @@ namespace Game {
 	Logger* logger = nullptr;
 	dServer* server = nullptr;
 	dConfig* config = nullptr;
-	bool shouldShutdown = false;
+	Game::signal_t lastSignal = 0;
 	std::mt19937 randomEngine;
 }
 
 Logger* SetupLogger();
 void HandlePacket(Packet* packet);
+
+void OnSignal(int signal)
+{
+    Game::lastSignal = signal;
+}
 
 int main(int argc, char** argv) {
 	constexpr uint32_t authFramerate = mediumFramerate;
@@ -41,6 +47,9 @@ int main(int argc, char** argv) {
 	Diagnostics::SetProcessName("Auth");
 	Diagnostics::SetProcessFileName(argv[0]);
 	Diagnostics::Initialize();
+
+	std::signal(SIGINT, OnSignal);
+	std::signal(SIGTERM, OnSignal);
 
 	//Create all the objects we need to run our service:
 	Game::logger = SetupLogger();
@@ -74,6 +83,7 @@ int main(int argc, char** argv) {
 		masterIP = masterInfo->ip;
 		masterPort = masterInfo->port;
 	}
+	LOG("Master is at %s:%d", masterIP.c_str(), masterPort);
 
 	Game::randomEngine = std::mt19937(time(0));
 
@@ -83,7 +93,7 @@ int main(int argc, char** argv) {
 	if (Game::config->GetValue("max_clients") != "") maxClients = std::stoi(Game::config->GetValue("max_clients"));
 	if (Game::config->GetValue("port") != "") ourPort = std::atoi(Game::config->GetValue("port").c_str());
 
-	Game::server = new dServer(Game::config->GetValue("external_ip"), ourPort, 0, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::Auth, Game::config, &Game::shouldShutdown);
+	Game::server = new dServer(Game::config->GetValue("external_ip"), ourPort, 0, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::Auth, Game::config, &Game::lastSignal);
 
 	//Run it until server gets a kill message from Master:
 	auto t = std::chrono::high_resolution_clock::now();
@@ -96,13 +106,16 @@ int main(int argc, char** argv) {
 
 	AuthPackets::LoadClaimCodes();
 	
-	while (!Game::shouldShutdown) {
+	Game::logger->Flush(); // once immediately before main loop
+	while (!Game::ShouldShutdown()) {
 		//Check if we're still connected to master:
 		if (!Game::server->GetIsConnectedToMaster()) {
 			framesSinceMasterDisconnect++;
 
-			if (framesSinceMasterDisconnect >= authFramerate)
+			if (framesSinceMasterDisconnect >= authFramerate) {
+				LOG("No connection to master!");
 				break; //Exit our loop, shut down.
+			}
 		} else framesSinceMasterDisconnect = 0;
 
 		//In world we'd update our other systems here.
@@ -141,6 +154,7 @@ int main(int argc, char** argv) {
 		std::this_thread::sleep_until(t);
 	}
 
+	LOG("Exited Main Loop! (signal %d)", Game::lastSignal);
 	//Delete our objects here:
 	Database::Destroy("AuthServer");
 	delete Game::server;

--- a/dAuthServer/AuthServer.cpp
+++ b/dAuthServer/AuthServer.cpp
@@ -36,11 +36,6 @@ namespace Game {
 Logger* SetupLogger();
 void HandlePacket(Packet* packet);
 
-void OnSignal(int signal)
-{
-    Game::lastSignal = signal;
-}
-
 int main(int argc, char** argv) {
 	constexpr uint32_t authFramerate = mediumFramerate;
 	constexpr uint32_t authFrameDelta = mediumFrameDelta;
@@ -48,8 +43,8 @@ int main(int argc, char** argv) {
 	Diagnostics::SetProcessFileName(argv[0]);
 	Diagnostics::Initialize();
 
-	std::signal(SIGINT, OnSignal);
-	std::signal(SIGTERM, OnSignal);
+	std::signal(SIGINT, Game::OnSignal);
+	std::signal(SIGTERM, Game::OnSignal);
 
 	//Create all the objects we need to run our service:
 	Game::logger = SetupLogger();

--- a/dChatServer/ChatServer.cpp
+++ b/dChatServer/ChatServer.cpp
@@ -41,11 +41,6 @@ namespace Game {
 Logger* SetupLogger();
 void HandlePacket(Packet* packet);
 
-void OnSignal(int signal)
-{
-    Game::lastSignal = signal;
-}
-
 int main(int argc, char** argv) {
 	constexpr uint32_t chatFramerate = mediumFramerate;
 	constexpr uint32_t chatFrameDelta = mediumFrameDelta;
@@ -53,8 +48,8 @@ int main(int argc, char** argv) {
 	Diagnostics::SetProcessFileName(argv[0]);
 	Diagnostics::Initialize();
 
-	std::signal(SIGINT, OnSignal);
-	std::signal(SIGTERM, OnSignal);
+	std::signal(SIGINT, Game::OnSignal);
+	std::signal(SIGTERM, Game::OnSignal);
 
 	//Create all the objects we need to run our service:
 	Game::logger = SetupLogger();

--- a/dCommon/CMakeLists.txt
+++ b/dCommon/CMakeLists.txt
@@ -5,6 +5,7 @@ set(DCOMMON_SOURCES
 		"dConfig.cpp"
 		"Diagnostics.cpp"
 		"Logger.cpp"
+		"Game.cpp"
 		"GeneralUtils.cpp"
 		"LDFFormat.cpp"
 		"MD5.cpp"

--- a/dCommon/Game.cpp
+++ b/dCommon/Game.cpp
@@ -1,0 +1,7 @@
+#include "Game.h"
+
+namespace Game {
+	void OnSignal(int signal) {
+		lastSignal = signal;
+	}
+}

--- a/dCommon/Game.h
+++ b/dCommon/Game.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <random>
+#include <csignal>
 
 class dServer;
 class Logger;
@@ -16,6 +17,7 @@ class dZoneManager;
 class PlayerContainer;
 
 namespace Game {
+	using signal_t = volatile std::sig_atomic_t;
 	extern Logger* logger;
 	extern dServer* server;
 	extern InstanceManager* im;
@@ -25,9 +27,13 @@ namespace Game {
 	extern RakPeerInterface* chatServer;
 	extern AssetManager* assetManager;
 	extern SystemAddress chatSysAddr;
-	extern bool shouldShutdown;
+	extern signal_t lastSignal;
 	extern EntityManager* entityManager;
 	extern dZoneManager* zoneManager;
 	extern PlayerContainer playerContainer;
 	extern std::string projectVersion;
+
+	inline bool ShouldShutdown() {
+		return lastSignal != 0;
+	}
 }

--- a/dCommon/Game.h
+++ b/dCommon/Game.h
@@ -36,4 +36,5 @@ namespace Game {
 	inline bool ShouldShutdown() {
 		return lastSignal != 0;
 	}
+	void OnSignal(int signal);
 }

--- a/dCommon/Logger.cpp
+++ b/dCommon/Logger.cpp
@@ -6,6 +6,8 @@
 #include <stdarg.h>
 
 Writer::~Writer() {
+	// Flush before we close
+	Flush();
 	// Dont try to close stdcout...
 	if (!m_Outfile || m_IsConsoleWriter) return;
 

--- a/dMasterServer/InstanceManager.cpp
+++ b/dMasterServer/InstanceManager.cpp
@@ -134,7 +134,7 @@ void InstanceManager::RemoveInstance(Instance* instance) {
 		if (m_Instances[i] == instance) {
 			instance->SetShutdownComplete(true);
 
-			if (!Game::shouldShutdown) RedirectPendingRequests(instance);
+			if (!Game::ShouldShutdown()) RedirectPendingRequests(instance);
 
 			delete m_Instances[i];
 

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -61,11 +61,6 @@ std::map<uint32_t, std::string> activeSessions;
 SystemAddress authServerMasterPeerSysAddr;
 SystemAddress chatServerMasterPeerSysAddr;
 
-void OnSignal(int signal)
-{
-    Game::lastSignal = signal;
-}
-
 int main(int argc, char** argv) {
 	constexpr uint32_t masterFramerate = mediumFramerate;
 	constexpr uint32_t masterFrameDelta = mediumFrameDelta;
@@ -79,8 +74,8 @@ int main(int argc, char** argv) {
 
 	//Triggers the shutdown sequence at application exit
 	std::atexit([]() { ShutdownSequence(); });
-	std::signal(SIGINT, OnSignal);
-	std::signal(SIGTERM, OnSignal);
+	std::signal(SIGINT, Game::OnSignal);
+	std::signal(SIGTERM, Game::OnSignal);
 
 	//Create all the objects we need to run our service:
 	Game::logger = SetupLogger();

--- a/dMasterServer/Start.cpp
+++ b/dMasterServer/Start.cpp
@@ -5,7 +5,7 @@
 #include "BinaryPathFinder.h"
 
 void StartChatServer() {
-	if (Game::shouldShutdown) {
+	if (Game::ShouldShutdown()) {
 		LOG("Currently shutting down.  Chat will not be restarted.");
 		return;
 	}
@@ -24,7 +24,7 @@ void StartChatServer() {
 }
 
 void StartAuthServer() {
-	if (Game::shouldShutdown) {
+	if (Game::ShouldShutdown()) {
 		LOG("Currently shutting down.  Auth will not be restarted.");
 		return;
 	}

--- a/dNet/AuthPackets.cpp
+++ b/dNet/AuthPackets.cpp
@@ -55,7 +55,9 @@ void AuthPackets::SendHandshake(dServer* server, const SystemAddress& sysAddr, c
 	RakNet::BitStream bitStream;
 	BitStreamUtils::WriteHeader(bitStream, eConnectionType::SERVER, eServerMessageType::VERSION_CONFIRM);
 	uint32_t netVersion;
-	if (!GeneralUtils::TryParse(Game::config->GetValue("client_net_version"), netVersion)) {
+	const std::string& expectedVersion = Game::config->GetValue("client_net_version");
+	LOG("Expected Version: '%s'", expectedVersion.c_str());
+	if (!GeneralUtils::TryParse(expectedVersion, netVersion)) {
 		LOG("Failed to parse client_net_version. Cannot authenticate to %s:%i", nextServerIP.c_str(), nextServerPort);
 		return;
 	}

--- a/dNet/dServer.cpp
+++ b/dNet/dServer.cpp
@@ -39,7 +39,7 @@ public:
 	}
 } ReceiveDownloadCompleteCB;
 
-dServer::dServer(const std::string& ip, int port, int instanceID, int maxConnections, bool isInternal, bool useEncryption, Logger* logger, const std::string masterIP, int masterPort, ServerType serverType, dConfig* config, bool* shouldShutdown, unsigned int zoneID) {
+dServer::dServer(const std::string& ip, int port, int instanceID, int maxConnections, bool isInternal, bool useEncryption, Logger* logger, const std::string masterIP, int masterPort, ServerType serverType, dConfig* config, Game::signal_t* lastSignal, unsigned int zoneID) {
 	mIP = ip;
 	mPort = port;
 	mZoneID = zoneID;
@@ -55,7 +55,7 @@ dServer::dServer(const std::string& ip, int port, int instanceID, int maxConnect
 	mReplicaManager = nullptr;
 	mServerType = serverType;
 	mConfig = config;
-	mShouldShutdown = shouldShutdown;
+	mShouldShutdown = lastSignal;
 	//Attempt to start our server here:
 	mIsOkay = Startup();
 
@@ -75,7 +75,9 @@ dServer::dServer(const std::string& ip, int port, int instanceID, int maxConnect
 	//Connect to master if we are not master:
 	if (serverType != ServerType::Master) {
 		SetupForMasterConnection();
-		ConnectToMaster();
+		if (!ConnectToMaster()) {
+			LOG("Failed ConnectToMaster!");
+		}
 	}
 
 	//Set up Replica if we're a world server:
@@ -129,7 +131,7 @@ Packet* dServer::ReceiveFromMaster() {
 					break;
 				}
 				case eMasterMessageType::SHUTDOWN:
-					*mShouldShutdown = true;
+					*mShouldShutdown = -2;
 					break;
 
 				//When we handle these packets in World instead dServer, we just return the packet's pointer.
@@ -236,10 +238,12 @@ void dServer::Shutdown() {
 void dServer::SetupForMasterConnection() {
 	mMasterSocketDescriptor = SocketDescriptor(uint16_t(mPort + 1), 0);
 	mMasterPeer = RakNetworkFactory::GetRakPeerInterface();
-	mMasterPeer->Startup(1, 30, &mMasterSocketDescriptor, 1);
+	bool ret = mMasterPeer->Startup(1, 30, &mMasterSocketDescriptor, 1);
+	if (!ret) LOG("Failed MasterPeer Startup!");
 }
 
 bool dServer::ConnectToMaster() {
+	//LOG("Connection to Master %s:%d", mMasterIP.c_str(), mMasterPort);
 	return mMasterPeer->Connect(mMasterIP.c_str(), mMasterPort, "3.25 DARKFLAME1", 15);
 }
 

--- a/dNet/dServer.h
+++ b/dNet/dServer.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <csignal>
 #include "RakPeerInterface.h"
 #include "ReplicaManager.h"
 #include "NetworkIDManager.h"
@@ -14,6 +15,10 @@ enum class ServerType : uint32_t {
 	Chat,
 	World
 };
+
+namespace Game {
+	using signal_t = volatile std::sig_atomic_t;
+}
 
 class dServer {
 public:
@@ -31,7 +36,7 @@ public:
 		int masterPort,
 		ServerType serverType,
 		dConfig* config,
-		bool* shouldShutdown,
+		Game::signal_t* shouldShutdown,
 		unsigned int zoneID = 0);
 	~dServer();
 
@@ -81,9 +86,9 @@ private:
 	NetworkIDManager* mNetIDManager = nullptr;
 
 	/**
-	 * Whether or not to shut down the server.  Pointer to Game::shouldShutdown.
+	 * Whether or not to shut down the server.  Pointer to Game::lastSignal.
 	 */
-	bool* mShouldShutdown = nullptr;
+	Game::signal_t* mShouldShutdown = nullptr;
 	SocketDescriptor mSocketDescriptor;
 	std::string mIP;
 	int mPort;

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -313,6 +313,8 @@ int main(int argc, char** argv) {
 	uint32_t saveTime = 10 * 60 * currentFramerate; // 10 minutes in frames
 	uint32_t sqlPingTime = 10 * 60 * currentFramerate; // 10 minutes in frames
 	uint32_t emptyShutdownTime = (cloneID == 0 ? 30 : 5) * 60 * currentFramerate; // 30 minutes for main worlds, 5 for all others.
+
+	Game::logger->Flush(); // once immediately before the main loop
 	while (true) {
 		Metrics::StartMeasurement(MetricVariable::Frame);
 		Metrics::StartMeasurement(MetricVariable::GameLoop);

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -124,8 +124,8 @@ int main(int argc, char** argv) {
 	// Triggers the shutdown sequence at application exit
 	std::atexit(WorldShutdownSequence);
 
-	signal(SIGINT, [](int) { WorldShutdownSequence(); });
-	signal(SIGTERM, [](int) { WorldShutdownSequence(); });
+	std::signal(SIGINT, Game::OnSignal);
+	std::signal(SIGTERM, Game::OnSignal);
 
 	uint32_t zoneID = 1000;
 	uint32_t cloneID = 0;


### PR DESCRIPTION
This PR improves graceful shutdown of the server binaries in the following ways:
- Fix signal handling (e.g. SIGTERM, Ctrl-C), so that we do as little as possible in the handler itself. This is mandated by POSIX because handlers might be called while inside functions like printf and it's not safe to call a logger or almost anything in there.
- Flush the logger in more places, including immediately before the server loops and in its destructor.
- Add SIGINT and SIGTERM handling to Auth and Chat.

WorldServer hasn't been updated completely yet, because I haven't gotten around to test that.