### PR TITLE
fix: nullptr access for logger in master

### DIFF
--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -812,6 +812,7 @@ void HandlePacket(Packet* packet) {
 }
 
 int ShutdownSequence(int32_t signal) {
+	if (!Game::logger) return -1;
 	LOG("Recieved Signal %d", signal);
 	if (shutdownSequenceStarted) {
 		LOG("Duplicate Shutdown Sequence");
@@ -900,9 +901,13 @@ int32_t FinalizeShutdown(int32_t signal) {
 	//Delete our objects here:
 	Database::Destroy("MasterServer");
 	if (Game::config) delete Game::config;
+	Game::config = nullptr;
 	if (Game::im) delete Game::im;
+	Game::im = nullptr;
 	if (Game::server) delete Game::server;
+	Game::server = nullptr;
 	if (Game::logger) delete Game::logger;
+	Game::logger = nullptr;
 
 	if (signal != EXIT_SUCCESS) exit(signal);
 	return signal;

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -73,7 +73,7 @@ int main(int argc, char** argv) {
 #endif
 
 	//Triggers the shutdown sequence at application exit
-	std::atexit([]() { printf("\n"); ShutdownSequence(); });
+	std::atexit([]() { ShutdownSequence(); });
 	std::signal(SIGINT, Game::OnSignal);
 	std::signal(SIGTERM, Game::OnSignal);
 

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -1291,13 +1291,16 @@ void WorldShutdownProcess(uint32_t zoneId) {
 }
 
 void WorldShutdownSequence() {
+	bool shouldShutdown = Game::ShouldShutdown() || worldShutdownSequenceComplete;
 	Game::lastSignal = -1;
 #ifndef DARKFLAME_PLATFORM_WIN32
-	if (Game::ShouldShutdown() || worldShutdownSequenceComplete)
+	if (shouldShutdown)
 #endif
 	{
 		return;
 	}
+
+	if (!Game::logger) return;
 
 	LOG("Zone (%i) instance (%i) shutting down outside of main loop!", Game::server->GetZoneID(), instanceID);
 	WorldShutdownProcess(Game::server->GetZoneID());


### PR DESCRIPTION
Tested that my characters position and data saves on shutdown now and that master no longer hangs on shutdown