### PR TITLE
fix: crash and log ignoring no log

### DIFF
--- a/dCommon/Logger.cpp
+++ b/dCommon/Logger.cpp
@@ -16,7 +16,7 @@ Writer::~Writer() {
 }
 
 void Writer::Log(const char* time, const char* message) {
-	if (!m_Outfile) return;
+	if (!m_Outfile || !m_Enabled) return;
 
 	fputs(time, m_Outfile);
 	fputs(message, m_Outfile);

--- a/dGame/dComponents/BuffComponent.cpp
+++ b/dGame/dComponents/BuffComponent.cpp
@@ -95,10 +95,16 @@ void BuffComponent::Update(float deltaTime) {
 
 		if (buff.second.time <= 0.0f) {
 			RemoveBuff(buff.first);
-
-			break;
 		}
 	}
+
+	if (m_BuffsToRemove.empty()) return;
+
+	for (const auto& buff : m_BuffsToRemove) {
+		m_Buffs.erase(buff);
+	}
+
+	m_BuffsToRemove.clear();
 }
 
 const std::string& GetFxName(const std::string& buffname) {
@@ -216,7 +222,7 @@ void BuffComponent::RemoveBuff(int32_t id, bool fromUnEquip, bool removeImmunity
 
 	GameMessages::SendRemoveBuff(m_Parent, fromUnEquip, removeImmunity, id);
 
-	m_Buffs.erase(iter);
+	m_BuffsToRemove.push_back(id);
 
 	RemoveBuffEffect(id);
 }

--- a/dGame/dComponents/BuffComponent.h
+++ b/dGame/dComponents/BuffComponent.h
@@ -140,6 +140,9 @@ private:
 	 */
 	std::map<int32_t, Buff> m_Buffs;
 
+	// Buffs to remove at the end of the update frame.
+	std::vector<int32_t> m_BuffsToRemove;
+
 	/**
 	 * Parameters (=effects) for each buff
 	 */


### PR DESCRIPTION
Tested that using the Inventor Beehive 1 skill on an entity that is about to die no longer causes the service to halt.
Tested that disabling console logging no longer logs to console.