### PR TITLE
fix: don't crash if some configs values aren't present

### DIFF
--- a/dAuthServer/AuthServer.cpp
+++ b/dAuthServer/AuthServer.cpp
@@ -83,12 +83,15 @@ int main(int argc, char** argv) {
 	Game::randomEngine = std::mt19937(time(0));
 
 	//It's safe to pass 'localhost' here, as the IP is only used as the external IP.
-	uint32_t maxClients = 50;
+	uint32_t maxClients = 999;
 	uint32_t ourPort = 1001; //LU client is hardcoded to use this for auth port, so I'm making it the default.
-	if (Game::config->GetValue("max_clients") != "") maxClients = std::stoi(Game::config->GetValue("max_clients"));
-	if (Game::config->GetValue("auth_server_port") != "") ourPort = std::atoi(Game::config->GetValue("auth_server_port").c_str());
+	std::string ourIP = "localhost";
+	GeneralUtils::TryParse(Game::config->GetValue("max_clients"), maxClients);
+	GeneralUtils::TryParse(Game::config->GetValue("auth_server_port"), ourPort);
+	const auto externalIPString = Game::config->GetValue("external_ip");
+	if (!externalIPString.empty()) ourIP = externalIPString;
 
-	Game::server = new dServer(Game::config->GetValue("external_ip"), ourPort, 0, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::Auth, Game::config, &Game::lastSignal);
+	Game::server = new dServer(ourIP, ourPort, 0, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::Auth, Game::config, &Game::lastSignal);
 
 	//Run it until server gets a kill message from Master:
 	auto t = std::chrono::high_resolution_clock::now();

--- a/dChatServer/ChatServer.cpp
+++ b/dChatServer/ChatServer.cpp
@@ -99,14 +99,19 @@ int main(int argc, char** argv) {
 		masterPort = masterInfo->port;
 	}
 	//It's safe to pass 'localhost' here, as the IP is only used as the external IP.
-	uint32_t maxClients = 50;
+	uint32_t maxClients = 999;
 	uint32_t ourPort = 1501;
-	if (Game::config->GetValue("max_clients") != "") maxClients = std::stoi(Game::config->GetValue("max_clients"));
-	if (Game::config->GetValue("chat_server_port") != "") ourPort = std::atoi(Game::config->GetValue("chat_server_port").c_str());
+	std::string ourIP = "localhost";
+	GeneralUtils::TryParse(Game::config->GetValue("max_clients"), maxClients);
+	GeneralUtils::TryParse(Game::config->GetValue("chat_server_port"), ourPort);
+	const auto externalIPString = Game::config->GetValue("external_ip");
+	if (!externalIPString.empty()) ourIP = externalIPString;
 
-	Game::server = new dServer(Game::config->GetValue("external_ip"), ourPort, 0, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::Chat, Game::config, &Game::lastSignal);
+	Game::server = new dServer(ourIP, ourPort, 0, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::Chat, Game::config, &Game::lastSignal);
 
-	Game::chatFilter = new dChatFilter(Game::assetManager->GetResPath().string() + "/chatplus_en_us", bool(std::stoi(Game::config->GetValue("dont_generate_dcf"))));
+	bool dontGenerateDCF = false;
+	GeneralUtils::TryParse(Game::config->GetValue("dont_generate_dcf"), dontGenerateDCF);
+	Game::chatFilter = new dChatFilter(Game::assetManager->GetResPath().string() + "/chatplus_en_us", dontGenerateDCF);
 	
 	Game::randomEngine = std::mt19937(time(0));
 

--- a/dMasterServer/InstanceManager.cpp
+++ b/dMasterServer/InstanceManager.cpp
@@ -17,7 +17,7 @@
 InstanceManager::InstanceManager(Logger* logger, const std::string& externalIP) {
 	mLogger = logger;
 	mExternalIP = externalIP;
-	m_LastPort = std::atoi(Game::config->GetValue("world_port_start").c_str());
+	GeneralUtils::TryParse(Game::config->GetValue("world_port_start"), m_LastPort);
 	m_LastInstanceID = LWOINSTANCEID_INVALID;
 }
 

--- a/dMasterServer/InstanceManager.h
+++ b/dMasterServer/InstanceManager.h
@@ -134,7 +134,7 @@ private:
 	Logger* mLogger;
 	std::string mExternalIP;
 	std::vector<Instance*> m_Instances;
-	unsigned short m_LastPort;
+	unsigned short m_LastPort = 3000;
 	LWOINSTANCEID m_LastInstanceID;
 
 	/**

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -81,45 +81,21 @@ int main(int argc, char** argv) {
 	Game::logger = SetupLogger();
 	if (!Game::logger) return EXIT_FAILURE;
 
-	if (!dConfig::Exists("authconfig.ini")) {
-		LOG("Couldnt find authconfig.ini");
-		return EXIT_FAILURE;
-	}
-
-	if (!dConfig::Exists("chatconfig.ini")) {
-		LOG("Couldnt find chatconfig.ini");
-		return EXIT_FAILURE;
-	}
-
-	if (!dConfig::Exists("masterconfig.ini")) {
-		LOG("Couldnt find masterconfig.ini");
-		return EXIT_FAILURE;
-	}
-
-	if (!dConfig::Exists("sharedconfig.ini")) {
-		LOG("Couldnt find sharedconfig.ini");
-		return EXIT_FAILURE;
-	}
-
-	if (!dConfig::Exists("worldconfig.ini")) {
-		LOG("Couldnt find worldconfig.ini");
-		return EXIT_FAILURE;
-	}
+	if (!dConfig::Exists("authconfig.ini")) LOG("Could not find authconfig.ini, using default settings");
+	if (!dConfig::Exists("chatconfig.ini")) LOG("Could not find chatconfig.ini, using default settings");
+	if (!dConfig::Exists("masterconfig.ini")) LOG("Could not find masterconfig.ini, using default settings");
+	if (!dConfig::Exists("sharedconfig.ini")) LOG("Could not find sharedconfig.ini, using default settings");
+	if (!dConfig::Exists("worldconfig.ini")) LOG("Could not find worldconfig.ini, using default settings");
 
 	Game::config = new dConfig("masterconfig.ini");
 	Game::logger->SetLogToConsole(Game::config->GetValue("log_to_console") != "0");
 	Game::logger->SetLogDebugStatements(Game::config->GetValue("log_debug_statements") == "1");
 
-	uint32_t clientNetVersion = 0;
-	if (!GeneralUtils::TryParse(Game::config->GetValue("client_net_version"), clientNetVersion)) {
-		LOG("Failed to parse (%s) as net version. Cannot start server as no clients could connect.",Game::config->GetValue("client_net_version").c_str());
-		LOG("As of version 1.1.1, client_net_version is required to be defined in sharedconfig.ini as opposed to in CMakeVariables.txt as NET_VERSION.");
-		LOG("Rerun cmake to ensure all config values exist. If client_net_version already exists in sharedconfig.ini, please ensure it is a valid number.");
-		LOG("like 171022");
-		return EXIT_FAILURE;
-	}
+	uint32_t clientNetVersion = 171022;
+	const auto clientNetVersionString = Game::config->GetValue("client_net_version");
+	if (!clientNetVersionString.empty()) GeneralUtils::TryParse(clientNetVersionString, clientNetVersion);
 
-	LOG("Using net version %s", Game::config->GetValue("client_net_version").c_str());
+	LOG("Using net version %i", clientNetVersion);
 
 	LOG("Starting Master server...");
 	LOG("Version: %s", PROJECT_VERSION);
@@ -283,19 +259,22 @@ int main(int argc, char** argv) {
 
 	Game::randomEngine = std::mt19937(time(0));
 	uint32_t maxClients = 999;
-	uint32_t ourPort = 1000;
-	if (Game::config->GetValue("max_clients") != "") maxClients = std::stoi(Game::config->GetValue("max_clients"));
-	if (Game::config->GetValue("master_server_port") != "") ourPort = std::stoi(Game::config->GetValue("master_server_port"));
+	uint32_t ourPort = 2000;
+	std::string ourIP = "localhost";
+	const auto maxClientsString = Game::config->GetValue("max_clients");
+	if (!maxClientsString.empty()) maxClients = std::stoi(maxClientsString);
+	const auto masterServerPortString = Game::config->GetValue("master_server_port");
+	if (!masterServerPortString.empty()) ourPort = std::atoi(masterServerPortString.c_str());
+	const auto externalIPString = Game::config->GetValue("external_ip");
+	if (!externalIPString.empty()) ourIP = externalIPString;
 
-	Game::server = new dServer(Game::config->GetValue("external_ip"), ourPort, 0, maxClients, true, false, Game::logger, "", 0, ServerType::Master, Game::config, &Game::lastSignal);
+	Game::server = new dServer(ourIP, ourPort, 0, maxClients, true, false, Game::logger, "", 0, ServerType::Master, Game::config, &Game::lastSignal);
 
-	//Query for the database for a server labeled "master"
+	std::string master_server_ip = "localhost";
+	const auto masterServerIPString = Game::config->GetValue("master_ip");
+	if (!masterServerIPString.empty()) master_server_ip = masterServerIPString;
 
-	auto master_server_ip = Game::config->GetValue("master_ip");
-
-	if (master_server_ip == "") {
-		master_server_ip = Game::server->GetIP();
-	}
+	if (master_server_ip == "") master_server_ip = Game::server->GetIP();
 
 	Database::Get()->SetMasterIp(master_server_ip, Game::server->GetPort());
 
@@ -304,7 +283,7 @@ int main(int argc, char** argv) {
 	Game::im = new InstanceManager(Game::logger, Game::server->GetIP());
 
 	//Depending on the config, start up servers:
-	if (Game::config->GetValue("prestart_servers") != "" && Game::config->GetValue("prestart_servers") == "1") {
+	if (Game::config->GetValue("prestart_servers") != "0") {
 		StartChatServer();
 
 		Game::im->GetInstance(0, false, 0);

--- a/dNet/AuthPackets.cpp
+++ b/dNet/AuthPackets.cpp
@@ -54,14 +54,12 @@ void AuthPackets::HandleHandshake(dServer* server, Packet* packet) {
 void AuthPackets::SendHandshake(dServer* server, const SystemAddress& sysAddr, const std::string& nextServerIP, uint16_t nextServerPort, const ServerType serverType) {
 	RakNet::BitStream bitStream;
 	BitStreamUtils::WriteHeader(bitStream, eConnectionType::SERVER, eServerMessageType::VERSION_CONFIRM);
-	uint32_t netVersion;
-	const std::string& expectedVersion = Game::config->GetValue("client_net_version");
-	LOG("Expected Version: '%s'", expectedVersion.c_str());
-	if (!GeneralUtils::TryParse(expectedVersion, netVersion)) {
-		LOG("Failed to parse client_net_version. Cannot authenticate to %s:%i", nextServerIP.c_str(), nextServerPort);
-		return;
-	}
-	bitStream.Write<uint32_t>(netVersion);
+	
+	uint32_t clientNetVersion = 171022;
+	const auto clientNetVersionString = Game::config->GetValue("client_net_version");
+	if (!clientNetVersionString.empty()) GeneralUtils::TryParse(clientNetVersionString, clientNetVersion);
+
+	bitStream.Write<uint32_t>(clientNetVersion);
 	bitStream.Write<uint32_t>(0x93);
 
 	if (serverType == ServerType::Auth) bitStream.Write(uint32_t(1)); //Conn: auth
@@ -95,7 +93,6 @@ void AuthPackets::HandleLoginRequest(dServer* server, Packet* packet) {
 	}
 
 	if (Game::config->GetValue("dont_use_keys") != "1" && accountInfo->maxGmLevel == eGameMasterLevel::CIVILIAN) {
-		LOG("");
 		//Check to see if we have a play key:
 		if (accountInfo->playKeyId == 0) {
 			AuthPackets::SendLoginResponse(server, packet->systemAddress, eLoginResponse::PERMISSIONS_NOT_HIGH_ENOUGH, "Your account doesn't have a play key associated with it!", "", 2001, username);

--- a/dNet/dServer.cpp
+++ b/dNet/dServer.cpp
@@ -14,6 +14,7 @@
 #include "BitStreamUtils.h"
 #include "MasterPackets.h"
 #include "ZoneInstanceManager.h"
+#include "StringifiedEnum.h"
 
 //! Replica Constructor class
 class ReplicaConstructor : public ReceiveConstructionInterface {
@@ -65,9 +66,9 @@ dServer::dServer(const std::string& ip, int port, int instanceID, int maxConnect
 
 	if (mIsOkay) {
 		if (zoneID == 0)
-			LOG("Server is listening on %s:%i with encryption: %i", ip.c_str(), port, int(useEncryption));
+			LOG("%s Server is listening on %s:%i with encryption: %i", StringifiedEnum::ToString(serverType).data(), ip.c_str(), port, int(useEncryption));
 		else
-			LOG("Server is listening on %s:%i with encryption: %i, running zone %i / %i", ip.c_str(), port, int(useEncryption), zoneID, instanceID);
+			LOG("%s Server is listening on %s:%i with encryption: %i, running zone %i / %i", StringifiedEnum::ToString(serverType).data(), ip.c_str(), port, int(useEncryption), zoneID, instanceID);
 	} else { LOG("FAILED TO START SERVER ON IP/PORT: %s:%i", ip.c_str(), port); return; }
 
 	mLogger->SetLogToConsole(prevLogSetting);

--- a/dPhysics/dpWorld.cpp
+++ b/dPhysics/dpWorld.cpp
@@ -10,14 +10,17 @@
 #include "dConfig.h"
 
 void dpWorld::Initialize(unsigned int zoneID, bool generateNewNavMesh) {
-	phys_sp_tilecount = std::atoi(Game::config->GetValue("phys_sp_tilecount").c_str());
-	phys_sp_tilesize = std::atoi(Game::config->GetValue("phys_sp_tilesize").c_str());
+	const auto physSpTilecount = Game::config->GetValue("phys_sp_tilecount");
+	if (!physSpTilecount.empty()) GeneralUtils::TryParse(physSpTilecount, phys_sp_tilecount);
+	const auto physSpTilesize = Game::config->GetValue("phys_sp_tilesize");
+	if (!physSpTilesize.empty()) GeneralUtils::TryParse(physSpTilesize, phys_sp_tilesize);
+	const auto physSpatialPartitioning = Game::config->GetValue("phys_spatial_partitioning");
+	if (!physSpatialPartitioning.empty()) phys_spatial_partitioning = physSpatialPartitioning == "1";
 
 	//If spatial partitioning is enabled, then we need to create the m_Grid.
 	//if m_Grid exists, then the old method will be used.
 	//SP will NOT be used unless it is added to ShouldUseSP();
-	if (std::atoi(Game::config->GetValue("phys_spatial_partitioning").c_str()) == 1
-		&& ShouldUseSP(zoneID)) {
+	if (ShouldUseSP(zoneID)) {
 		m_Grid = new dpGrid(phys_sp_tilecount, phys_sp_tilesize);
 	}
 
@@ -123,6 +126,8 @@ void dpWorld::RemoveEntity(dpEntity* entity) {
 }
 
 bool dpWorld::ShouldUseSP(unsigned int zoneID) {
+	if (!phys_spatial_partitioning) return false;
+
 	// TODO: Add to this list as needed.
 	// Only large maps should be added as tiling likely makes little difference on small maps.
 

--- a/dPhysics/dpWorld.h
+++ b/dPhysics/dpWorld.h
@@ -36,7 +36,7 @@ public:
 
 private:
 	dpGrid* m_Grid;
-	bool phys_spatial_partitioning = 1;
+	bool phys_spatial_partitioning = true;
 	int phys_sp_tilesize = 205;
 	int phys_sp_tilecount = 12;
 

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -210,7 +210,10 @@ int main(int argc, char** argv) {
 
 	ObjectIDManager::Instance()->Initialize();
 	UserManager::Instance()->Initialize();
-	Game::chatFilter = new dChatFilter(Game::assetManager->GetResPath().string() + "/chatplus_en_us", bool(std::stoi(Game::config->GetValue("dont_generate_dcf"))));
+
+	bool dontGenerateDCF = false;
+	GeneralUtils::TryParse(Game::config->GetValue("dont_generate_dcf"), dontGenerateDCF);
+	Game::chatFilter = new dChatFilter(Game::assetManager->GetResPath().string() + "/chatplus_en_us", dontGenerateDCF);
 
 	Game::server = new dServer(masterIP, ourPort, instanceID, maxClients, false, true, Game::logger, masterIP, masterPort, ServerType::World, Game::config, &Game::lastSignal, zoneID);
 


### PR DESCRIPTION
remove not starting if ini's aren't present since everything can run from env vars now

tested running a server with no ini's and the db connector game proper feedback
tested running with only the MYSQL_XXXX configs set as env vars and the server ran perfect and I was able to connect with a client