### PR TITLE
fix: make include paths consistent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,7 @@ set(INCLUDED_DIRECTORIES
 	"thirdparty/recastnavigation"
 	"thirdparty/SQLite"
 	"thirdparty/cpplinq"
+	"thirdparty/cpp-httplib"
 
 	"tests"
 	"tests/dCommonTests"

--- a/dAuthServer/AuthServer.cpp
+++ b/dAuthServer/AuthServer.cpp
@@ -16,7 +16,7 @@
 
 //RakNet includes:
 #include "RakNetDefines.h"
-#include <MessageIdentifiers.h>
+#include "MessageIdentifiers.h"
 
 //Auth includes:
 #include "AuthPackets.h"

--- a/dChatServer/ChatServer.cpp
+++ b/dChatServer/ChatServer.cpp
@@ -25,7 +25,7 @@
 
 //RakNet includes:
 #include "RakNetDefines.h"
-#include <MessageIdentifiers.h>
+#include "MessageIdentifiers.h"
 
 namespace Game {
 	Logger* logger = nullptr;

--- a/dCommon/AmfSerialize.h
+++ b/dCommon/AmfSerialize.h
@@ -4,7 +4,7 @@
 #include "Amf3.h"
 
 // RakNet
-#include <BitStream.h>
+#include "BitStream.h"
 
 /*!
  \file AmfSerialize.h

--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -9,7 +9,7 @@
 #include <functional>
 #include <type_traits>
 #include <stdexcept>
-#include <BitStream.h>
+#include "BitStream.h"
 #include "NiPoint3.h"
 
 #include "Game.h"

--- a/dCommon/ZCompression.cpp
+++ b/dCommon/ZCompression.cpp
@@ -1,6 +1,6 @@
 #include "ZCompression.h"
 
-#include <zlib.h>
+#include "zlib.h"
 
 namespace ZCompression {
 	int32_t GetMaxCompressedLength(int32_t nLenSrc) {

--- a/dCommon/dClient/AssetManager.cpp
+++ b/dCommon/dClient/AssetManager.cpp
@@ -4,7 +4,7 @@
 #include "Game.h"
 #include "Logger.h"
 
-#include <zlib.h>
+#include "zlib.h"
 
 AssetManager::AssetManager(const std::filesystem::path& path) {
 	if (!std::filesystem::is_directory(path)) {

--- a/dGame/Character.h
+++ b/dGame/Character.h
@@ -3,7 +3,7 @@
 
 #include "dCommonVars.h"
 #include <vector>
-#include "../thirdparty/tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 #include <unordered_map>
 #include <map>
 

--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -3,7 +3,7 @@
 #include "CDClientManager.h"
 #include "Game.h"
 #include "Logger.h"
-#include <PacketUtils.h>
+#include "PacketUtils.h"
 #include <functional>
 #include "CDDestructibleComponentTable.h"
 #include "CDClientDatabase.h"

--- a/dGame/User.h
+++ b/dGame/User.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <vector>
-#include "../thirdparty/raknet/Source/RakNetTypes.h"
+#include "RakNetTypes.h"
 #include "dCommonVars.h"
 
 #include <unordered_map>

--- a/dGame/UserManager.cpp
+++ b/dGame/UserManager.cpp
@@ -8,9 +8,9 @@
 #include "Game.h"
 #include "Logger.h"
 #include "User.h"
-#include <WorldPackets.h>
+#include "WorldPackets.h"
 #include "Character.h"
-#include <BitStream.h>
+#include "BitStream.h"
 #include "PacketUtils.h"
 #include "../dWorldServer/ObjectIDManager.h"
 #include "Logger.h"

--- a/dGame/dComponents/ActivityComponent.cpp
+++ b/dGame/dComponents/ActivityComponent.cpp
@@ -7,7 +7,7 @@
 #include "ZoneInstanceManager.h"
 #include "Game.h"
 #include "Logger.h"
-#include <WorldPackets.h>
+#include "WorldPackets.h"
 #include "EntityManager.h"
 #include "ChatPackets.h"
 #include "Player.h"

--- a/dGame/dComponents/BaseCombatAIComponent.cpp
+++ b/dGame/dComponents/BaseCombatAIComponent.cpp
@@ -1,5 +1,5 @@
 #include "BaseCombatAIComponent.h"
-#include <BitStream.h>
+#include "BitStream.h"
 
 #include "Entity.h"
 #include "EntityManager.h"

--- a/dGame/dComponents/BouncerComponent.cpp
+++ b/dGame/dComponents/BouncerComponent.cpp
@@ -6,7 +6,7 @@
 #include "Game.h"
 #include "Logger.h"
 #include "GameMessages.h"
-#include <BitStream.h>
+#include "BitStream.h"
 #include "eTriggerEventType.h"
 
 BouncerComponent::BouncerComponent(Entity* parent) : Component(parent) {

--- a/dGame/dComponents/BuffComponent.cpp
+++ b/dGame/dComponents/BuffComponent.cpp
@@ -1,5 +1,5 @@
 #include "BuffComponent.h"
-#include <BitStream.h>
+#include "BitStream.h"
 #include "CDClientDatabase.h"
 #include <stdexcept>
 #include "DestroyableComponent.h"

--- a/dGame/dComponents/CharacterComponent.cpp
+++ b/dGame/dComponents/CharacterComponent.cpp
@@ -1,5 +1,5 @@
 #include "CharacterComponent.h"
-#include <BitStream.h>
+#include "BitStream.h"
 #include "tinyxml2.h"
 #include "Game.h"
 #include "Logger.h"

--- a/dGame/dComponents/Component.h
+++ b/dGame/dComponents/Component.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../thirdparty/tinyxml2/tinyxml2.h"
+#include "tinyxml2.h"
 
 class Entity;
 

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -1,5 +1,5 @@
 #include "DestroyableComponent.h"
-#include <BitStream.h>
+#include "BitStream.h"
 #include "Logger.h"
 #include "Game.h"
 #include "dConfig.h"

--- a/dGame/dComponents/PropertyEntranceComponent.cpp
+++ b/dGame/dComponents/PropertyEntranceComponent.cpp
@@ -1,6 +1,6 @@
 #include "PropertyEntranceComponent.h"
 
-#include <CDPropertyEntranceComponentTable.h>
+#include "CDPropertyEntranceComponentTable.h"
 
 #include "Character.h"
 #include "Database.h"

--- a/dGame/dComponents/QuickBuildComponent.h
+++ b/dGame/dComponents/QuickBuildComponent.h
@@ -1,7 +1,7 @@
 #ifndef QUICKBUILDCOMPONENT_H
 #define QUICKBUILDCOMPONENT_H
 
-#include <BitStream.h>
+#include "BitStream.h"
 #include <vector>
 #include <string>
 #include "dCommonVars.h"

--- a/dGame/dComponents/RenderComponent.h
+++ b/dGame/dComponents/RenderComponent.h
@@ -1,7 +1,7 @@
 #ifndef RENDERCOMPONENT_H
 #define RENDERCOMPONENT_H
 
-#include <BitStream.h>
+#include "BitStream.h"
 #include <vector>
 #include <string>
 #include <unordered_map>

--- a/dGame/dGameMessages/GameMessageHandler.cpp
+++ b/dGame/dGameMessages/GameMessageHandler.cpp
@@ -7,7 +7,7 @@
 #include "MissionComponent.h"
 #include "BitStreamUtils.h"
 #include "dServer.h"
-#include "../thirdparty/raknet/Source/RakNetworkFactory.h"
+#include "RakNetworkFactory.h"
 #include <future>
 #include "User.h"
 #include "UserManager.h"

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -50,7 +50,7 @@
 #include <chrono>
 #include "RakString.h"
 
-#include "../thirdparty/cpp-httplib/httplib.h" //sorry not sorry.
+#include "httplib.h" //sorry not sorry.
 
 //CDB includes:
 #include "CDClientManager.h"

--- a/dNet/AuthPackets.cpp
+++ b/dNet/AuthPackets.cpp
@@ -13,7 +13,7 @@
 
 #include <bcrypt/BCrypt.hpp>
 
-#include <BitStream.h>
+#include "BitStream.h"
 #include <future>
 
 #include "Game.h"

--- a/dNet/PacketUtils.h
+++ b/dNet/PacketUtils.h
@@ -1,8 +1,8 @@
 #ifndef PACKETUTILS_H
 #define PACKETUTILS_H
 
-#include <MessageIdentifiers.h>
-#include <BitStream.h>
+#include "MessageIdentifiers.h"
+#include "BitStream.h"
 #include <string>
 
 enum class eConnectionType : uint16_t;

--- a/dNet/ZoneInstanceManager.h
+++ b/dNet/ZoneInstanceManager.h
@@ -7,7 +7,7 @@
 #include <string>
 
 // RakNet
-#include <RakNetTypes.h>
+#include "RakNetTypes.h"
 
 class dServer;
 

--- a/tests/dCommonTests/dCommonDependencies.h
+++ b/tests/dCommonTests/dCommonDependencies.h
@@ -4,8 +4,6 @@
 #include "Game.h"
 #include "Logger.h"
 #include "dServer.h"
-#include "EntityInfo.h"
-#include "EntityManager.h"
 #include "dConfig.h"
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
tests pass

Looked through the codebase for `#include "..` and `(#include <)(.*)(\.h>)` and updated include paths to what we use across the codebase.