### PR TITLE
fix: Docker Compose README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,7 @@
 # Full path to the LEGO Universe client
-CLIENT_PATH=/Users/someuser/LEGO Universe
-# Can improve build time
-BUILD_THREADS=1
+CLIENT_PATH=./client
 # Updates NET_VERSION in CMakeVariables.txt
-BUILD_VERSION=171022
+NET_VERSION=171022
 # make sure this is a long random string
 # grab a "SHA 256-bit Key" from here: https://keygen.io/
 ACCOUNT_MANAGER_SECRET=
@@ -12,6 +10,5 @@ EXTERNAL_IP=localhost
 # Database values
 # Be careful with special characters here. It is more safe to use normal characters and/or numbers.
 MARIADB_USER=darkflame
-MARIADB_PASSWORD=SECRET_VALUE_CHANGE_ME
-MARIADB_ROOT_PASSWORD=SECRET_VALUE_CHANGE_ME
+MARIADB_PASSWORD=
 MARIADB_DATABASE=darkflame

--- a/README.md
+++ b/README.md
@@ -348,12 +348,36 @@ certutil -hashfile <file> SHA1
 Known good *SHA1* checksum of the Darkflame Universe client:
 - `91498e09b83ce69f46baf9e521d48f23fe502985` (packed client, zip compressed)
 
+
 # Docker
 
-## Standalone
+The Darkflame Server is automatically built and published as a Docker Container / [OCI](https://opencontainers.org/) Image to the GitHub Container Registry at:
+[`ghcr.io/darkflameuniverse/darkflameserver`](https://github.com/DarkflameUniverse/DarkflameServer/pkgs/container/darkflameserver).
 
-For standalone deployment, you can use the image provided via Github's Container Repository:
-`ghcr.io/darkflameuniverse/darkflameserver`
+## Compose
+
+You can use the `docker-compose` tool to [setup a MariaDB database](#database-setup), run the Darkflame Server and manage it with [Nexus Dashboard](https://github.com/DarkflameUniverse/NexusDashboard) all
+at once. For that:
+
+- [Install Docker Desktop](https://docs.docker.com/get-docker/)
+- Open the directory that contains your LU Client
+  - If the `legouniverse.exe` is in a subfolder called `client`, you're good to go. There may also be a folder `versions`.
+  - Otherwise, create a new `client` folder and move the exe and everything else (e.g. `res` and `locale`) in there. This is necessary to work around a bug in the client that will prevent that you to log back in after getting disconnected.
+- Download the [docker-compose.yml](docker-compose.yml) file and place it next to `client`.
+- Download the [.env.example](.env.example) file and place it next to `client` with the name file name `.env`
+  - Update the `ACCOUNT_MANAGER_SECRET` and `MARIADB_PASSWORD` with strong random passwords.
+    - Use a password generator like <https://keygen.io>
+    - Once the database user is created, changing the password will not update it, so the server will just fail to connect.
+  - You may get warnings that this name starts with a dot, acknowledge those, this is intentional. Depending on your operating system, you may need to activate showing hidden files (e.g. Ctrl-H in Gnome on Linux) and/or file extensions ("File name extensions" in the "View" tab on Windows).
+  - Set `EXTERNAL_IP` to your LAN IP or public IP if you want to host the game for friends & family
+- Open a terminal in the folder with the `docker-compose.yml` and `client`
+- Run `docker compose up -d`
+- Run `docker exec -it dlu-darkflameserver-1 /app/MasterServer -a` and follow the instructions to create the initial admin account
+- Set `AUTHSERVERIP=0:localhost` in `client/boot.cfg`
+  - Replace `localhost` with the value of `EXTERNAL_IP` if you changed that earlier.
+- Open <http://localhost:8000> to access Nexus Dashboard
+
+## Standalone
 
 This assumes that you have a database deployed to your host or in another docker container.
 
@@ -375,14 +399,6 @@ ghcr.io/darkflameuniverse/darkflameserver:latest
 You will need to replace the `/path/to/`'s to reflect the paths on your host.
 
 Any config option in the `.ini`'s can be overridden with environmental variables: Ex: `log_to_console=1` from `shared_config.ini` would be overidden like  `-e LOG_TO_CONSOLE=0`
-
-## Compose
-
-See the [compose](docker-compose.yml) file in the root of the repo.
-
-This compose file is for a full deployment: MariaDB, DarkflameServer, and Nexus Dashboard.
-
-All of the environmental options are listed in the compose file so the can be pass through, or you can edit the compose file to suit your specific needs
 
 # Development Documentation
 This is a Work in Progress, but below are some quick links to documentaion for systems and structs in the server

--- a/README.md
+++ b/README.md
@@ -375,9 +375,11 @@ at once. For that:
 - Run `docker compose up -d`
   - This might require `sudo` on Linux, and a recent version of [docker compose](https://docs.docker.com/compose/install/)
 - Run `docker exec -it dlu-darkflameserver-1 /app/MasterServer -a` and follow the instructions to create the initial admin account
+- Open <http://localhost:8000> to access Nexus Dashboard with the admin account to create normal users
 - Set `AUTHSERVERIP=0:localhost` in `client/boot.cfg`
   - Replace `localhost` with the value of `EXTERNAL_IP` if you changed that earlier.
-- Open <http://localhost:8000> to access Nexus Dashboard
+  - Also make sure `UGCUSE3DSERVICES=7:` is set to `0`
+- Launch `legouniverse.exe`
 
 ## Standalone
 

--- a/README.md
+++ b/README.md
@@ -365,12 +365,11 @@ at once. For that:
   - Otherwise, create a new `client` folder and move the exe and everything else (e.g. `res` and `locale`) in there. This is necessary to work around a bug in the client that will prevent that you to log back in after getting disconnected.
 - Download the [docker-compose.yml](docker-compose.yml) file and place it next to `client`.
 - Download the [.env.example](.env.example) file and place it next to `client` with the file name `.env`
-  - You may get warnings that this name starts with a dot, acknowledge those, this is intentional. Depending on your operating system, you may need to activate showing hidden files (e.g. Ctrl-H in Gnome on Linux) and/or file extensions 
+  - You may get warnings that this name starts with a dot, acknowledge those, this is intentional. Depending on your operating system, you may need to activate showing hidden files (e.g. Ctrl-H in Gnome on Linux) and/or file extensions ("File name extensions" in the "View" tab on Windows).
   - Update the `ACCOUNT_MANAGER_SECRET` and `MARIADB_PASSWORD` with strong random passwords.
     - Use a password generator like <https://keygen.io>
     - Avoid `:` and `@` characters
     - Once the database user is created, changing the password will not update it, so the server will just fail to connect.
-  ("File name extensions" in the "View" tab on Windows).
   - Set `EXTERNAL_IP` to your LAN IP or public IP if you want to host the game for friends & family
 - Open a terminal in the folder with the `docker-compose.yml` and `client`
 - Run `docker compose up -d`

--- a/README.md
+++ b/README.md
@@ -373,6 +373,7 @@ at once. For that:
   - Set `EXTERNAL_IP` to your LAN IP or public IP if you want to host the game for friends & family
 - Open a terminal in the folder with the `docker-compose.yml` and `client`
 - Run `docker compose up -d`
+  - This might require `sudo` on Linux, and a recent version of [docker compose](https://docs.docker.com/compose/install/)
 - Run `docker exec -it dlu-darkflameserver-1 /app/MasterServer -a` and follow the instructions to create the initial admin account
 - Set `AUTHSERVERIP=0:localhost` in `client/boot.cfg`
   - Replace `localhost` with the value of `EXTERNAL_IP` if you changed that earlier.

--- a/README.md
+++ b/README.md
@@ -367,6 +367,7 @@ at once. For that:
 - Download the [.env.example](.env.example) file and place it next to `client` with the name file name `.env`
   - Update the `ACCOUNT_MANAGER_SECRET` and `MARIADB_PASSWORD` with strong random passwords.
     - Use a password generator like <https://keygen.io>
+    - Avoid `:` and `@` characters
     - Once the database user is created, changing the password will not update it, so the server will just fail to connect.
   - You may get warnings that this name starts with a dot, acknowledge those, this is intentional. Depending on your operating system, you may need to activate showing hidden files (e.g. Ctrl-H in Gnome on Linux) and/or file extensions ("File name extensions" in the "View" tab on Windows).
   - Set `EXTERNAL_IP` to your LAN IP or public IP if you want to host the game for friends & family

--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ at once. For that:
   - If the `legouniverse.exe` is in a subfolder called `client`, you're good to go. There may also be a folder `versions`.
   - Otherwise, create a new `client` folder and move the exe and everything else (e.g. `res` and `locale`) in there. This is necessary to work around a bug in the client that will prevent that you to log back in after getting disconnected.
 - Download the [docker-compose.yml](docker-compose.yml) file and place it next to `client`.
-- Download the [.env.example](.env.example) file and place it next to `client` with the name file name `.env`
+- Download the [.env.example](.env.example) file and place it next to `client` with the file name `.env`
   - You may get warnings that this name starts with a dot, acknowledge those, this is intentional. Depending on your operating system, you may need to activate showing hidden files (e.g. Ctrl-H in Gnome on Linux) and/or file extensions 
   - Update the `ACCOUNT_MANAGER_SECRET` and `MARIADB_PASSWORD` with strong random passwords.
     - Use a password generator like <https://keygen.io>

--- a/README.md
+++ b/README.md
@@ -365,11 +365,12 @@ at once. For that:
   - Otherwise, create a new `client` folder and move the exe and everything else (e.g. `res` and `locale`) in there. This is necessary to work around a bug in the client that will prevent that you to log back in after getting disconnected.
 - Download the [docker-compose.yml](docker-compose.yml) file and place it next to `client`.
 - Download the [.env.example](.env.example) file and place it next to `client` with the name file name `.env`
+  - You may get warnings that this name starts with a dot, acknowledge those, this is intentional. Depending on your operating system, you may need to activate showing hidden files (e.g. Ctrl-H in Gnome on Linux) and/or file extensions 
   - Update the `ACCOUNT_MANAGER_SECRET` and `MARIADB_PASSWORD` with strong random passwords.
     - Use a password generator like <https://keygen.io>
     - Avoid `:` and `@` characters
     - Once the database user is created, changing the password will not update it, so the server will just fail to connect.
-  - You may get warnings that this name starts with a dot, acknowledge those, this is intentional. Depending on your operating system, you may need to activate showing hidden files (e.g. Ctrl-H in Gnome on Linux) and/or file extensions ("File name extensions" in the "View" tab on Windows).
+  ("File name extensions" in the "View" tab on Windows).
   - Set `EXTERNAL_IP` to your LAN IP or public IP if you want to host the game for friends & family
 - Open a terminal in the folder with the `docker-compose.yml` and `client`
 - Run `docker compose up -d`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
       - CLIENT_LOCATION=/app/luclient/
       - CACHE_LOCATION=/app/cache/
       - CD_SQLITE_LOCATION=/app/cdclient/
+      - USER_ENABLE_REGISTER=1 # "0" is _not_ false, to disable, remove this line
     depends_on:
       - darkflamedb
       - darkflameserver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,58 +1,72 @@
 version: "3"
+name: dlu
 
 services:
   darkflamedb:
-    image: mariadb:latest
-    environment:
-      - MARIADB_USER=${MARIADB_USER:-darkflame}
-      - MARIADB_PASSWORD=${MARIADB_PASSWORD:-darkflame}
-      - MARIADB_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD:-darkflame}
-      - MARIADB_DATABASE=${MARIADB_DATABASE:-darkflame}
     networks:
       - darkflame
+    image: mariadb:latest
+    volumes:
+      - ${DB_DATA_DIR:-./db/data}:/var/lib/mysql
+    environment:
+      - MARIADB_RANDOM_ROOT_PASSWORD=1
+      - MARIADB_USER=${MARIADB_USER:-darkflame}
+      - MARIADB_PASSWORD=${MARIADB_PASSWORD:?error}
+      - MARIADB_DATABASE=${MARIADB_DATABASE:-darkflame}
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
 
   darkflameserver:
     networks:
       - darkflame
     image: ghcr.io/darkflameuniverse/darkflameserver:latest
     volumes:
-      - $HOST_CONFIG_DIR:/app/configs/
-      - $HOST_CLIENT_LOCATION:$CLIENT_LOCATION:ro
-      - $HOST_RESSERVER_LOCATION:/app/resServer/
-      - $HOST_DUMP_FOLDER:$DUMP_FOLDER
-      - $HOST_LOGS_DIR:/app/logs/
+      - ${HOST_CONFIG_DIR:-./server/config}:/app/configs/
+      - ${CLIENT_PATH:-./client}:/app/luclient:ro
+      - ${HOST_RESSERVER_LOCATION:-./server/res}:/app/resServer/
+      - ${HOST_DUMP_FOLDER:-./server/dump}:/app/dump/
+      - ${HOST_LOGS_DIR:-./server/logs}:/app/logs/
     environment:
+      - CLIENT_LOCATION=/app/luclient
       - DLU_CONFIG_DIR=/app/configs
+      - DUMP_FOLDER=/app/dump
       - MYSQL_HOST=darkflamedb
       - MYSQL_DATABASE=${MARIADB_DATABASE:-darkflame}
       - MYSQL_USERNAME=${MARIADB_USER:-darkflame}
-      - MYSQL_PASSWORD=${MARIADB_PASSWORD:-darkflame}
+      - MYSQL_PASSWORD=${MARIADB_PASSWORD:?error}
       - EXTERNAL_IP=${EXTERNAL_IP:-localhost}
-      - DUMP_FOLDER=$DUMP_FOLDER
-      - CLIENT_LOCATION=$CLIENT_LOCATION
+      - CLIENT_NET_VERSION=${CLIENT_NET_VERSION:-171022}
     depends_on:
       - darkflamedb
     ports:
       - "1001:1001/udp"
       - "2005:2005/udp"
       - "3000-3300:3000-3300/udp"
+    healthcheck:
+      test: ["CMD", "ls", "/app/resServer/CDServer.sqlite"]
 
   darkflameweb:
     networks:
       - darkflame
     image: ghcr.io/darkflameuniverse/nexusdashboard:latest
     volumes:
-      - $HOST_CLIENT_LOCATION:/app/luclient:ro
-      - $HOST_CACHE_LOCATION:/app/cache
-      - $HOST_CD_SQLITE_LOCATION:/app/cdclient:ro
+      - ${CLIENT_PATH:-./client}:/app/luclient:ro
+      - ${HOST_CACHE_LOCATION:-./web/cache}:/app/cache
+      - ${HOST_RESSERVER_LOCATION:-./server/res}:/app/cdclient:ro
+      - ${HOST_ND_LOGS_LOCATION:-./web/logs}:/logs
     environment:
-      - APP_SECRET_KEY=$APP_SECRET_KEY
-      - APP_DATABASE_URI=mysql+pymysql://${MARIADB_USER:-darkflame}:${MARIADB_PASSWORD:-darkflame}@darkflamedb:3306/${MARIADB_DATABASE:-darkflame}
-      - CLIENT_LOCATION=/app/luclient
-      - CACHE_LOCATION=/app/cache
-      - CD_SQLITE_LOCATION=/app/cdclient
+      - APP_SECRET_KEY=${ACCOUNT_MANAGER_SECRET:?error}
+      - APP_DATABASE_URI=mysql+pymysql://${MARIADB_USER:-darkflame}:${MARIADB_PASSWORD:?error}@darkflamedb:3306/${MARIADB_DATABASE:-darkflame}
+      - CLIENT_LOCATION=/app/luclient/
+      - CACHE_LOCATION=/app/cache/
+      - CD_SQLITE_LOCATION=/app/cdclient/
     depends_on:
       - darkflamedb
+      - darkflameserver
     ports:
       - 8000:8000
     healthcheck:


### PR DESCRIPTION
This PR moves the Docker Compose section of the README before the Standalone version and updates `.env.example` and `docker-compose.yml` to require minimal user intervention to get a server up and running.

To try out, follow the new instructions at https://github.com/DarkflameUniverse/DarkflameServer/blob/fix/docker-readme/README.md#compose