### PR TITLE
chore: remove non cstdint integer types in CDClientTables

### DIFF
--- a/dDatabase/CDClientDatabase/CDClientTables/CDActivitiesTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDActivitiesTable.cpp
@@ -2,7 +2,7 @@
 
 void CDActivitiesTable::LoadValuesFromDatabase() {
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM Activities");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDActivitiesTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDActivitiesTable.h
@@ -4,22 +4,22 @@
 #include "CDTable.h"
 
 struct CDActivities {
-	unsigned int ActivityID;
-	unsigned int locStatus;
-	unsigned int instanceMapID;
-	unsigned int minTeams;
-	unsigned int maxTeams;
-	unsigned int minTeamSize;
-	unsigned int maxTeamSize;
-	unsigned int waitTime;
-	unsigned int startDelay;
+	uint32_t ActivityID;
+	uint32_t locStatus;
+	uint32_t instanceMapID;
+	uint32_t minTeams;
+	uint32_t maxTeams;
+	uint32_t minTeamSize;
+	uint32_t maxTeamSize;
+	uint32_t waitTime;
+	uint32_t startDelay;
 	bool requiresUniqueData;
-	unsigned int leaderboardType;
+	uint32_t leaderboardType;
 	bool localize;
-	int optionalCostLOT;
-	int optionalCostCount;
+	int32_t optionalCostLOT;
+	int32_t optionalCostCount;
 	bool showUIRewards;
-	unsigned int CommunityActivityFlagID;
+	uint32_t CommunityActivityFlagID;
 	std::string gate_version;
 	bool noTeamLootOnDeath;
 	float optionalPercentage;

--- a/dDatabase/CDClientDatabase/CDClientTables/CDActivityRewardsTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDActivityRewardsTable.cpp
@@ -3,7 +3,7 @@
 void CDActivityRewardsTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM ActivityRewards");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDActivityRewardsTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDActivityRewardsTable.h
@@ -4,12 +4,12 @@
 #include "CDTable.h"
 
 struct CDActivityRewards {
-	unsigned int objectTemplate;        //!< The object template (?)
-	unsigned int ActivityRewardIndex;   //!< The activity reward index
-	int activityRating;                 //!< The activity rating
-	unsigned int LootMatrixIndex;       //!< The loot matrix index
-	unsigned int CurrencyIndex;         //!< The currency index
-	unsigned int ChallengeRating;       //!< The challenge rating
+	uint32_t objectTemplate;        //!< The object template (?)
+	uint32_t ActivityRewardIndex;   //!< The activity reward index
+	int32_t activityRating;                 //!< The activity rating
+	uint32_t LootMatrixIndex;       //!< The loot matrix index
+	uint32_t CurrencyIndex;         //!< The currency index
+	uint32_t ChallengeRating;       //!< The challenge rating
 	std::string description;            //!< The description
 };
 

--- a/dDatabase/CDClientDatabase/CDClientTables/CDAnimationsTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDAnimationsTable.h
@@ -4,13 +4,13 @@
 #include <list>
 
 struct CDAnimation {
-	// unsigned int animationGroupID;
+	// uint32_t animationGroupID;
 	// std::string animation_type;
 	// The above two are a pair to represent a primary key in the map.
 	std::string animation_name;        //!< The animation name
 	float chance_to_play;           //!< The chance to play the animation
-	UNUSED_COLUMN(unsigned int min_loops;)                 //!< The minimum number of loops
-	UNUSED_COLUMN(unsigned int max_loops;)                 //!< The maximum number of loops
+	UNUSED_COLUMN(uint32_t min_loops;)                 //!< The minimum number of loops
+	UNUSED_COLUMN(uint32_t max_loops;)                 //!< The maximum number of loops
 	float animation_length;         //!< The animation length
 	UNUSED_COLUMN(bool hideEquip;)                 //!< Whether or not to hide the equip
 	UNUSED_COLUMN(bool ignoreUpperBody;)           //!< Whether or not to ignore the upper body

--- a/dDatabase/CDClientDatabase/CDClientTables/CDBehaviorTemplateTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDBehaviorTemplateTable.cpp
@@ -3,7 +3,7 @@
 void CDBehaviorTemplateTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM BehaviorTemplate");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDBehaviorTemplateTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDBehaviorTemplateTable.h
@@ -6,9 +6,9 @@
 #include <unordered_set>
 
 struct CDBehaviorTemplate {
-	unsigned int behaviorID;                                         //!< The Behavior ID
-	unsigned int templateID;                                         //!< The Template ID (LOT)
-	unsigned int effectID;                                           //!< The Effect ID attached
+	uint32_t behaviorID;                                         //!< The Behavior ID
+	uint32_t templateID;                                         //!< The Template ID (LOT)
+	uint32_t effectID;                                           //!< The Effect ID attached
 	std::unordered_set<std::string>::iterator effectHandle;          //!< The effect handle
 };
 

--- a/dDatabase/CDClientDatabase/CDClientTables/CDBrickIDTableTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDBrickIDTableTable.cpp
@@ -3,7 +3,7 @@
 void CDBrickIDTableTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM BrickIDTable");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDBrickIDTableTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDBrickIDTableTable.h
@@ -10,8 +10,8 @@
 
  //! BrickIDTable Entry Struct
 struct CDBrickIDTable {
-	unsigned int NDObjectID;
-	unsigned int LEGOBrickID;
+	uint32_t NDObjectID;
+	uint32_t LEGOBrickID;
 };
 
 

--- a/dDatabase/CDClientDatabase/CDClientTables/CDComponentsRegistryTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDComponentsRegistryTable.h
@@ -7,9 +7,9 @@
 
 enum class eReplicaComponentType : uint32_t;
 struct CDComponentsRegistry {
-	unsigned int id;                    //!< The LOT is used as the ID
+	uint32_t id;                    //!< The LOT is used as the ID
 	eReplicaComponentType component_type;        //!< See ComponentTypes enum for values
-	unsigned int component_id;          //!< The ID used within the component's table (0 may either mean it's non-networked, or that the ID is actually 0
+	uint32_t component_id;          //!< The ID used within the component's table (0 may either mean it's non-networked, or that the ID is actually 0
 };
 
 

--- a/dDatabase/CDClientDatabase/CDClientTables/CDCurrencyTableTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDCurrencyTableTable.cpp
@@ -4,7 +4,7 @@
 void CDCurrencyTableTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM CurrencyTable");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDCurrencyTableTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDCurrencyTableTable.h
@@ -10,11 +10,11 @@
 
  //! CurrencyTable Struct
 struct CDCurrencyTable {
-	unsigned int currencyIndex;         //!< The Currency Index
-	unsigned int npcminlevel;           //!< The minimum level of the npc
-	unsigned int minvalue;              //!< The minimum currency
-	unsigned int maxvalue;              //!< The maximum currency
-	unsigned int id;                    //!< The ID of the currency index
+	uint32_t currencyIndex;         //!< The Currency Index
+	uint32_t npcminlevel;           //!< The minimum level of the npc
+	uint32_t minvalue;              //!< The minimum currency
+	uint32_t maxvalue;              //!< The maximum currency
+	uint32_t id;                    //!< The ID of the currency index
 };
 
 //! CurrencyTable table

--- a/dDatabase/CDClientDatabase/CDClientTables/CDDestructibleComponentTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDDestructibleComponentTable.cpp
@@ -2,7 +2,7 @@
 
 void CDDestructibleComponentTable::LoadValuesFromDatabase() {
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM DestructibleComponent");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDDestructibleComponentTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDDestructibleComponentTable.h
@@ -4,20 +4,20 @@
 #include "CDTable.h"
 
 struct CDDestructibleComponent {
-	unsigned int id;                            //!< The component ID from the ComponentsRegistry Table
-	int faction;                       //!< The Faction ID of the object
+	uint32_t id;                            //!< The component ID from the ComponentsRegistry Table
+	int32_t faction;                       //!< The Faction ID of the object
 	std::string factionList;               //!< A list of the faction IDs
-	int life;                          //!< The amount of life of the object
-	unsigned int imagination;                   //!< The amount of imagination of the object
-	int LootMatrixIndex;               //!< The Loot Matrix Index
-	int CurrencyIndex;                 //!< The Currency Index
-	unsigned int level;                         //!< ???
+	int32_t life;                          //!< The amount of life of the object
+	uint32_t imagination;                   //!< The amount of imagination of the object
+	int32_t LootMatrixIndex;               //!< The Loot Matrix Index
+	int32_t CurrencyIndex;                 //!< The Currency Index
+	uint32_t level;                         //!< ???
 	float armor;                        //!< The amount of armor of the object
-	unsigned int death_behavior;                //!< The behavior ID of the death behavior
+	uint32_t death_behavior;                //!< The behavior ID of the death behavior
 	bool isnpc;                         //!< Whether or not the object is an NPC
-	unsigned int attack_priority;               //!< ???
+	uint32_t attack_priority;               //!< ???
 	bool isSmashable;                   //!< Whether or not the object is smashable
-	int difficultyLevel;               //!< ???
+	int32_t difficultyLevel;               //!< ???
 };
 
 class CDDestructibleComponentTable : public CDTable<CDDestructibleComponentTable> {

--- a/dDatabase/CDClientDatabase/CDClientTables/CDEmoteTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDEmoteTable.cpp
@@ -20,7 +20,7 @@ void CDEmoteTableTable::LoadValuesFromDatabase() {
 	tableData.finalize();
 }
 
-CDEmoteTable* CDEmoteTableTable::GetEmote(int id) {
+CDEmoteTable* CDEmoteTableTable::GetEmote(int32_t id) {
 	auto itr = entries.find(id);
 	return itr != entries.end() ? &itr->second : nullptr;
 }

--- a/dDatabase/CDClientDatabase/CDClientTables/CDEmoteTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDEmoteTable.h
@@ -16,11 +16,11 @@ struct CDEmoteTable {
 		gateVersion = "";
 	}
 
-	int ID;
+	int32_t ID;
 	std::string animationName;
 	std::string iconFilename;
-	int locState;
-	int channel;
+	int32_t locState;
+	int32_t channel;
 	bool locked;
 	bool localize;
 	std::string gateVersion;
@@ -33,5 +33,5 @@ private:
 public:
 	void LoadValuesFromDatabase();
 	// Returns an emote by ID
-	CDEmoteTable* GetEmote(int id);
+	CDEmoteTable* GetEmote(int32_t id);
 };

--- a/dDatabase/CDClientDatabase/CDClientTables/CDFeatureGatingTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDFeatureGatingTable.cpp
@@ -3,7 +3,7 @@
 void CDFeatureGatingTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM FeatureGating");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDInventoryComponentTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDInventoryComponentTable.cpp
@@ -3,7 +3,7 @@
 void CDInventoryComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM InventoryComponent");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDInventoryComponentTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDInventoryComponentTable.h
@@ -4,9 +4,9 @@
 #include "CDTable.h"
 
 struct CDInventoryComponent {
-	unsigned int id;                //!< The component ID for this object
-	unsigned int itemid;            //!< The LOT of the object
-	unsigned int count;             //!< The count of the items the object has
+	uint32_t id;                //!< The component ID for this object
+	uint32_t itemid;            //!< The LOT of the object
+	uint32_t count;             //!< The count of the items the object has
 	bool equip;             //!< Whether or not to equip the item
 };
 

--- a/dDatabase/CDClientDatabase/CDClientTables/CDItemComponentTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDItemComponentTable.cpp
@@ -5,7 +5,7 @@ CDItemComponent CDItemComponentTable::Default = {};
 
 void CDItemComponentTable::LoadValuesFromDatabase() {
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM ItemComponent");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);
@@ -69,7 +69,7 @@ void CDItemComponentTable::LoadValuesFromDatabase() {
 	tableData.finalize();
 }
 
-const CDItemComponent& CDItemComponentTable::GetItemComponentByID(unsigned int skillID) {
+const CDItemComponent& CDItemComponentTable::GetItemComponentByID(uint32_t skillID) {
 	const auto& it = this->entries.find(skillID);
 	if (it != this->entries.end()) {
 		return it->second;

--- a/dDatabase/CDClientDatabase/CDClientTables/CDItemComponentTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDItemComponentTable.h
@@ -5,60 +5,60 @@
 #include "dCommonVars.h"
 
 struct CDItemComponent {
-	unsigned int id;                        //!< The Component ID
+	uint32_t id;                        //!< The Component ID
 	std::string equipLocation;         //!< The equip location
-	unsigned int baseValue;                 //!< The monetary base value of the item
+	uint32_t baseValue;                 //!< The monetary base value of the item
 	bool isKitPiece;                //!< Whether or not the item belongs to a kit
-	unsigned int rarity;                    //!< The rarity of the item
-	unsigned int itemType;                  //!< The item type
+	uint32_t rarity;                    //!< The rarity of the item
+	uint32_t itemType;                  //!< The item type
 	int64_t itemInfo;                  //!< The item info
 	bool inLootTable;               //!< Whether or not the item is in a loot table
 	bool inVendor;                  //!< Whether or not the item is in a vendor inventory
 	bool isUnique;                  //!< ???
 	bool isBOP;                     //!< ???
 	bool isBOE;                     //!< ???
-	unsigned int reqFlagID;                 //!< User must have completed this flag to get the item
-	unsigned int reqSpecialtyID;            //!< ???
-	unsigned int reqSpecRank;               //!< ???
-	unsigned int reqAchievementID;          //!< The required achievement must be completed
-	unsigned int stackSize;                 //!< The stack size of the item
-	unsigned int color1;                    //!< Something to do with item color...
-	unsigned int decal;                     //!< The decal of the item
-	unsigned int offsetGroupID;             //!< Something to do with group IDs
-	unsigned int buildTypes;                //!< Something to do with building
+	uint32_t reqFlagID;                 //!< User must have completed this flag to get the item
+	uint32_t reqSpecialtyID;            //!< ???
+	uint32_t reqSpecRank;               //!< ???
+	uint32_t reqAchievementID;          //!< The required achievement must be completed
+	uint32_t stackSize;                 //!< The stack size of the item
+	uint32_t color1;                    //!< Something to do with item color...
+	uint32_t decal;                     //!< The decal of the item
+	uint32_t offsetGroupID;             //!< Something to do with group IDs
+	uint32_t buildTypes;                //!< Something to do with building
 	std::string reqPrecondition;       //!< The required precondition
-	unsigned int animationFlag;             //!< The Animation Flag
-	unsigned int equipEffects;              //!< The effect played when the item is equipped
+	uint32_t animationFlag;             //!< The Animation Flag
+	uint32_t equipEffects;              //!< The effect played when the item is equipped
 	bool readyForQA;                //!< ???
-	unsigned int itemRating;                //!< ???
+	uint32_t itemRating;                //!< ???
 	bool isTwoHanded;               //!< Whether or not the item is double handed
-	unsigned int minNumRequired;            //!< Maybe the minimum number required for a mission, or to own this object?
-	unsigned int delResIndex;               //!< ???
-	unsigned int currencyLOT;               //!< ???
-	unsigned int altCurrencyCost;           //!< ???
+	uint32_t minNumRequired;            //!< Maybe the minimum number required for a mission, or to own this object?
+	uint32_t delResIndex;               //!< ???
+	uint32_t currencyLOT;               //!< ???
+	uint32_t altCurrencyCost;           //!< ???
 	std::string subItems;              //!< A comma seperate string of sub items (maybe for multi-itemed things like faction test gear set)
 	UNUSED(std::string audioEventUse);         //!< ???
 	bool noEquipAnimation;          //!< Whether or not there is an equip animation
-	unsigned int commendationLOT;           //!< The commendation LOT
-	unsigned int commendationCost;          //!< The commendation cost
+	uint32_t commendationLOT;           //!< The commendation LOT
+	uint32_t commendationCost;          //!< The commendation cost
 	UNUSED(std::string audioEquipMetaEventSet);    //!< ???
 	std::string currencyCosts;         //!< Used for crafting
 	UNUSED(std::string ingredientInfo);        //!< Unused
-	unsigned int locStatus;                 //!< ???
-	unsigned int forgeType;                 //!< Forge Type
+	uint32_t locStatus;                 //!< ???
+	uint32_t forgeType;                 //!< Forge Type
 	float SellMultiplier;           //!< Something to do with early vendors perhaps (but replaced)
 };
 
 class CDItemComponentTable : public CDTable<CDItemComponentTable> {
 private:
-	std::map<unsigned int, CDItemComponent> entries;
+	std::map<uint32_t, CDItemComponent> entries;
 
 public:
 	void LoadValuesFromDatabase();
 	static std::map<LOT, uint32_t> ParseCraftingCurrencies(const CDItemComponent& itemComponent);
 
 	// Gets an entry by ID
-	const CDItemComponent& GetItemComponentByID(unsigned int skillID);
+	const CDItemComponent& GetItemComponentByID(uint32_t skillID);
 
 	static CDItemComponent Default;
 };

--- a/dDatabase/CDClientDatabase/CDClientTables/CDItemSetSkillsTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDItemSetSkillsTable.cpp
@@ -3,7 +3,7 @@
 void CDItemSetSkillsTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM ItemSetSkills");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);
@@ -44,7 +44,7 @@ const std::vector<CDItemSetSkills>& CDItemSetSkillsTable::GetEntries() const {
 	return this->entries;
 }
 
-std::vector<CDItemSetSkills> CDItemSetSkillsTable::GetBySkillID(unsigned int SkillSetID) {
+std::vector<CDItemSetSkills> CDItemSetSkillsTable::GetBySkillID(uint32_t SkillSetID) {
 	std::vector<CDItemSetSkills> toReturn;
 
 	for (CDItemSetSkills entry : this->entries) {

--- a/dDatabase/CDClientDatabase/CDClientTables/CDItemSetSkillsTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDItemSetSkillsTable.h
@@ -4,9 +4,9 @@
 #include "CDTable.h"
 
 struct CDItemSetSkills {
-	unsigned int SkillSetID;            //!< The skill set ID
-	unsigned int SkillID;               //!< The skill ID
-	unsigned int SkillCastType;         //!< The skill cast type
+	uint32_t SkillSetID;            //!< The skill set ID
+	uint32_t SkillID;               //!< The skill ID
+	uint32_t SkillCastType;         //!< The skill cast type
 };
 
 class CDItemSetSkillsTable : public CDTable<CDItemSetSkillsTable> {
@@ -20,5 +20,5 @@ public:
 
 	const std::vector<CDItemSetSkills>& GetEntries() const;
 
-	std::vector<CDItemSetSkills> GetBySkillID(unsigned int SkillSetID);
+	std::vector<CDItemSetSkills> GetBySkillID(uint32_t SkillSetID);
 };

--- a/dDatabase/CDClientDatabase/CDClientTables/CDItemSetsTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDItemSetsTable.cpp
@@ -3,7 +3,7 @@
 void CDItemSetsTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM ItemSets");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDItemSetsTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDItemSetsTable.h
@@ -4,20 +4,20 @@
 #include "CDTable.h"
 
 struct CDItemSets {
-	unsigned int setID;             //!< The item set ID
-	unsigned int locStatus;         //!< The loc status
+	uint32_t setID;             //!< The item set ID
+	uint32_t locStatus;         //!< The loc status
 	std::string itemIDs;       //!< THe item IDs
-	unsigned int kitType;           //!< The item kit type
-	unsigned int kitRank;           //!< The item kit rank
-	unsigned int kitImage;          //!< The item kit image
-	unsigned int skillSetWith2;     //!< The skill set with 2
-	unsigned int skillSetWith3;     //!< The skill set with 3
-	unsigned int skillSetWith4;     //!< The skill set with 4
-	unsigned int skillSetWith5;     //!< The skill set with 5
-	unsigned int skillSetWith6;     //!< The skill set with 6
+	uint32_t kitType;           //!< The item kit type
+	uint32_t kitRank;           //!< The item kit rank
+	uint32_t kitImage;          //!< The item kit image
+	uint32_t skillSetWith2;     //!< The skill set with 2
+	uint32_t skillSetWith3;     //!< The skill set with 3
+	uint32_t skillSetWith4;     //!< The skill set with 4
+	uint32_t skillSetWith5;     //!< The skill set with 5
+	uint32_t skillSetWith6;     //!< The skill set with 6
 	bool localize;          //!< Whether or localize
 	std::string gate_version;  //!< The gate version
-	unsigned int kitID;             //!< The kit ID
+	uint32_t kitID;             //!< The kit ID
 	float priority;         //!< The priority
 };
 

--- a/dDatabase/CDClientDatabase/CDClientTables/CDLevelProgressionLookupTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDLevelProgressionLookupTable.cpp
@@ -3,7 +3,7 @@
 void CDLevelProgressionLookupTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM LevelProgressionLookup");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDLevelProgressionLookupTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDLevelProgressionLookupTable.h
@@ -4,8 +4,8 @@
 #include "CDTable.h"
 
 struct CDLevelProgressionLookup {
-	unsigned int id;                    //!< The Level ID
-	unsigned int requiredUScore;        //!< The required LEGO Score
+	uint32_t id;                    //!< The Level ID
+	uint32_t requiredUScore;        //!< The required LEGO Score
 	std::string BehaviorEffect;    //!< The behavior effect attached to this
 };
 

--- a/dDatabase/CDClientDatabase/CDClientTables/CDLootMatrixTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDLootMatrixTable.cpp
@@ -16,7 +16,7 @@ CDLootMatrix CDLootMatrixTable::ReadRow(CppSQLite3Query& tableData) const {
 void CDLootMatrixTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM LootMatrix");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDLootMatrixTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDLootMatrixTable.h
@@ -4,12 +4,12 @@
 #include "CDTable.h"
 
 struct CDLootMatrix {
-	unsigned int LootTableIndex;            //!< The Loot Table Index
-	unsigned int RarityTableIndex;          //!< The Rarity Table Index
+	uint32_t LootTableIndex;            //!< The Loot Table Index
+	uint32_t RarityTableIndex;          //!< The Rarity Table Index
 	float percent;                   //!< The percent that this matrix is used?
-	unsigned int minToDrop;                 //!< The minimum amount of loot from this matrix to drop
-	unsigned int maxToDrop;                 //!< The maximum amount of loot from this matrix to drop
-	unsigned int flagID;                    //!< ???
+	uint32_t minToDrop;                 //!< The minimum amount of loot from this matrix to drop
+	uint32_t maxToDrop;                 //!< The maximum amount of loot from this matrix to drop
+	uint32_t flagID;                    //!< ???
 	UNUSED(std::string gate_version);          //!< The Gate Version
 };
 

--- a/dDatabase/CDClientDatabase/CDClientTables/CDLootTableTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDLootTableTable.cpp
@@ -40,7 +40,7 @@ CDLootTable CDLootTableTable::ReadRow(CppSQLite3Query& tableData) const {
 void CDLootTableTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM LootTable");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDLootTableTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDLootTableTable.h
@@ -4,10 +4,10 @@
 #include "CDTable.h"
 
 struct CDLootTable {
-	unsigned int itemid;                 //!< The LOT of the item
-	unsigned int LootTableIndex;         //!< The Loot Table Index
+	uint32_t itemid;                 //!< The LOT of the item
+	uint32_t LootTableIndex;         //!< The Loot Table Index
 	bool MissionDrop;               //!< Whether or not this loot table is a mission drop
-	unsigned int sortPriority;           //!< The sorting priority
+	uint32_t sortPriority;           //!< The sorting priority
 };
 
 typedef uint32_t LootTableIndex;

--- a/dDatabase/CDClientDatabase/CDClientTables/CDMissionEmailTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDMissionEmailTable.cpp
@@ -3,7 +3,7 @@
 void CDMissionEmailTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM MissionEmail");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDMissionEmailTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDMissionEmailTable.h
@@ -4,13 +4,13 @@
 #include "CDTable.h"
 
 struct CDMissionEmail {
-	unsigned int ID;
-	unsigned int messageType;
-	unsigned int notificationGroup;
-	unsigned int missionID;
-	unsigned int attachmentLOT;
+	uint32_t ID;
+	uint32_t messageType;
+	uint32_t notificationGroup;
+	uint32_t missionID;
+	uint32_t attachmentLOT;
 	bool localize;
-	unsigned int locStatus;
+	uint32_t locStatus;
 	std::string gate_version;
 };
 

--- a/dDatabase/CDClientDatabase/CDClientTables/CDMissionNPCComponentTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDMissionNPCComponentTable.cpp
@@ -3,7 +3,7 @@
 void CDMissionNPCComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM MissionNPCComponent");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDMissionNPCComponentTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDMissionNPCComponentTable.h
@@ -4,8 +4,8 @@
 #include "CDTable.h"
 
 struct CDMissionNPCComponent {
-	unsigned int id;                //!< The ID
-	unsigned int missionID;         //!< The Mission ID
+	uint32_t id;                //!< The ID
+	uint32_t missionID;         //!< The Mission ID
 	bool offersMission;     //!< Whether or not this NPC offers a mission
 	bool acceptsMission;    //!< Whether or not this NPC accepts a mission
 	std::string gate_version;  //!< The gate version

--- a/dDatabase/CDClientDatabase/CDClientTables/CDMissionTasksTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDMissionTasksTable.cpp
@@ -3,7 +3,7 @@
 void CDMissionTasksTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM MissionTasks");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDMissionTasksTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDMissionTasksTable.h
@@ -4,17 +4,17 @@
 #include "CDTable.h"
 
 struct CDMissionTasks {
-	unsigned int id;                //!< The Mission ID that the task belongs to
-	UNUSED(unsigned int locStatus);         //!< ???
-	unsigned int taskType;          //!< The task type
-	unsigned int target;            //!< The mission target
+	uint32_t id;                //!< The Mission ID that the task belongs to
+	UNUSED(uint32_t locStatus);         //!< ???
+	uint32_t taskType;          //!< The task type
+	uint32_t target;            //!< The mission target
 	std::string targetGroup;        //!< The mission target group
-	int targetValue;       //!< The target value
+	int32_t targetValue;       //!< The target value
 	std::string taskParam1;    //!< The task param 1
 	UNUSED(std::string largeTaskIcon); //!< ???
-	UNUSED(unsigned int IconID);            //!< ???
-	unsigned int uid;               //!< ???
-	UNUSED(unsigned int largeTaskIconID);   //!< ???
+	UNUSED(uint32_t IconID);            //!< ???
+	uint32_t uid;               //!< ???
+	UNUSED(uint32_t largeTaskIconID);   //!< ???
 	UNUSED(bool localize);          //!< Whether or not the task should be localized
 	UNUSED(std::string gate_version);  //!< ???
 };

--- a/dDatabase/CDClientDatabase/CDClientTables/CDMissionsTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDMissionsTable.cpp
@@ -5,7 +5,7 @@ CDMissions CDMissionsTable::Default = {};
 void CDMissionsTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM Missions");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDMissionsTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDMissionsTable.h
@@ -6,58 +6,58 @@
 #include <cstdint>
 
 struct CDMissions {
-	int id;                        //!< The Mission ID
+	int32_t id;                        //!< The Mission ID
 	std::string defined_type;          //!< The type of mission
 	std::string defined_subtype;       //!< The subtype of the mission
-	int UISortOrder;               //!< The UI Sort Order for the mission
-	int offer_objectID;            //!< The LOT of the mission giver
-	int target_objectID;           //!< The LOT of the mission's target
+	int32_t UISortOrder;               //!< The UI Sort Order for the mission
+	int32_t offer_objectID;            //!< The LOT of the mission giver
+	int32_t target_objectID;           //!< The LOT of the mission's target
 	int64_t reward_currency;           //!< The amount of currency to reward the player
-	int LegoScore;                 //!< The amount of LEGO Score to reward the player
+	int32_t LegoScore;                 //!< The amount of LEGO Score to reward the player
 	int64_t reward_reputation;         //!< The reputation to award the player
 	bool isChoiceReward;            //!< Whether or not the user has the option to choose their loot
-	int reward_item1;              //!< The first rewarded item
-	int reward_item1_count;        //!< The count of the first item to be rewarded
-	int reward_item2;              //!< The second rewarded item
-	int reward_item2_count;        //!< The count of the second item to be rewarded
-	int reward_item3;              //!< The third rewarded item
-	int reward_item3_count;        //!< The count of the third item to be rewarded
-	int reward_item4;              //!< The fourth rewarded item
-	int reward_item4_count;        //!< The count of the fourth item to be rewarded
-	int reward_emote;              //!< The first emote to be rewarded
-	int reward_emote2;             //!< The second emote to be rewarded
-	int reward_emote3;             //!< The third emote to be rewarded
-	int reward_emote4;             //!< The fourth emote to be rewarded
-	int reward_maximagination;     //!< The amount of max imagination to reward
-	int reward_maxhealth;          //!< The amount of max health to reward
-	int reward_maxinventory;       //!< The amount of max inventory to reward
-	int reward_maxmodel;           //!< ???
-	int reward_maxwidget;          //!< ???
-	int reward_maxwallet;          //!< ???
+	int32_t reward_item1;              //!< The first rewarded item
+	int32_t reward_item1_count;        //!< The count of the first item to be rewarded
+	int32_t reward_item2;              //!< The second rewarded item
+	int32_t reward_item2_count;        //!< The count of the second item to be rewarded
+	int32_t reward_item3;              //!< The third rewarded item
+	int32_t reward_item3_count;        //!< The count of the third item to be rewarded
+	int32_t reward_item4;              //!< The fourth rewarded item
+	int32_t reward_item4_count;        //!< The count of the fourth item to be rewarded
+	int32_t reward_emote;              //!< The first emote to be rewarded
+	int32_t reward_emote2;             //!< The second emote to be rewarded
+	int32_t reward_emote3;             //!< The third emote to be rewarded
+	int32_t reward_emote4;             //!< The fourth emote to be rewarded
+	int32_t reward_maximagination;     //!< The amount of max imagination to reward
+	int32_t reward_maxhealth;          //!< The amount of max health to reward
+	int32_t reward_maxinventory;       //!< The amount of max inventory to reward
+	int32_t reward_maxmodel;           //!< ???
+	int32_t reward_maxwidget;          //!< ???
+	int32_t reward_maxwallet;          //!< ???
 	bool repeatable;                //!< Whether or not this mission can be repeated (for instance, is it a daily mission)
 	int64_t reward_currency_repeatable;   //!< The repeatable reward
-	int reward_item1_repeatable;      //!< The first rewarded item
-	int reward_item1_repeat_count;    //!< The count of the first item to be rewarded
-	int reward_item2_repeatable;      //!< The second rewarded item
-	int reward_item2_repeat_count;    //!< The count of the second item to be rewarded
-	int reward_item3_repeatable;      //!< The third rewarded item
-	int reward_item3_repeat_count;    //!< The count of the third item to be rewarded
-	int reward_item4_repeatable;      //!< The fourth rewarded item
-	int reward_item4_repeat_count;    //!< The count of the fourth item to be rewarded
-	int time_limit;                //!< The time limit of the mission
+	int32_t reward_item1_repeatable;      //!< The first rewarded item
+	int32_t reward_item1_repeat_count;    //!< The count of the first item to be rewarded
+	int32_t reward_item2_repeatable;      //!< The second rewarded item
+	int32_t reward_item2_repeat_count;    //!< The count of the second item to be rewarded
+	int32_t reward_item3_repeatable;      //!< The third rewarded item
+	int32_t reward_item3_repeat_count;    //!< The count of the third item to be rewarded
+	int32_t reward_item4_repeatable;      //!< The fourth rewarded item
+	int32_t reward_item4_repeat_count;    //!< The count of the fourth item to be rewarded
+	int32_t time_limit;                //!< The time limit of the mission
 	bool isMission;                 //!< Maybe to differentiate between missions and achievements?
-	int missionIconID;             //!< The mission icon ID
+	int32_t missionIconID;             //!< The mission icon ID
 	std::string prereqMissionID;       //!< A '|' seperated list of prerequisite missions
 	bool localize;                  //!< Whether or not to localize the mission
 	bool inMOTD;                    //!< In Match of the Day(?)
 	int64_t cooldownTime;              //!< The mission cooldown time
 	bool isRandom;                  //!< ???
 	std::string randomPool;            //!< ???
-	int UIPrereqID;                //!< ???
+	int32_t UIPrereqID;                //!< ???
 	UNUSED(std::string gate_version);          //!< The gate version
 	UNUSED(std::string HUDStates);             //!< ???
-	UNUSED(int locStatus);                 //!< ???
-	int reward_bankinventory;      //!< The amount of bank space this mission rewards
+	UNUSED(int32_t locStatus);                 //!< ???
+	int32_t reward_bankinventory;      //!< The amount of bank space this mission rewards
 };
 
 class CDMissionsTable : public CDTable<CDMissionsTable> {

--- a/dDatabase/CDClientDatabase/CDClientTables/CDMovementAIComponentTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDMovementAIComponentTable.cpp
@@ -3,7 +3,7 @@
 void CDMovementAIComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM MovementAIComponent");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDMovementAIComponentTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDMovementAIComponentTable.h
@@ -4,7 +4,7 @@
 #include "CDTable.h"
 
 struct CDMovementAIComponent {
-	unsigned int id;
+	uint32_t id;
 	std::string MovementType;
 	float WanderChance;
 	float WanderDelayMin;

--- a/dDatabase/CDClientDatabase/CDClientTables/CDObjectSkillsTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDObjectSkillsTable.cpp
@@ -3,7 +3,7 @@
 void CDObjectSkillsTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM ObjectSkills");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDObjectSkillsTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDObjectSkillsTable.h
@@ -4,10 +4,10 @@
 #include "CDTable.h"
 
 struct CDObjectSkills {
-	unsigned int objectTemplate;        //!< The LOT of the item
-	unsigned int skillID;               //!< The Skill ID of the object
-	unsigned int castOnType;            //!< ???
-	unsigned int AICombatWeight;        //!< ???
+	uint32_t objectTemplate;        //!< The LOT of the item
+	uint32_t skillID;               //!< The Skill ID of the object
+	uint32_t castOnType;            //!< ???
+	uint32_t AICombatWeight;        //!< ???
 };
 
 class CDObjectSkillsTable : public CDTable<CDObjectSkillsTable> {

--- a/dDatabase/CDClientDatabase/CDClientTables/CDObjectsTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDObjectsTable.cpp
@@ -2,7 +2,7 @@
 
 void CDObjectsTable::LoadValuesFromDatabase() {
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM Objects");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);
@@ -40,7 +40,7 @@ void CDObjectsTable::LoadValuesFromDatabase() {
 	m_default.id = 0;
 }
 
-const CDObjects& CDObjectsTable::GetByID(unsigned int LOT) {
+const CDObjects& CDObjectsTable::GetByID(uint32_t LOT) {
 	const auto& it = this->entries.find(LOT);
 	if (it != this->entries.end()) {
 		return it->second;

--- a/dDatabase/CDClientDatabase/CDClientTables/CDObjectsTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDObjectsTable.h
@@ -4,30 +4,30 @@
 #include "CDTable.h"
 
 struct CDObjects {
-	unsigned int id;                            //!< The LOT of the object
+	uint32_t id;                            //!< The LOT of the object
 	std::string name;                      //!< The internal name of the object
-	UNUSED(unsigned int placeable);                     //!< Whether or not the object is placable
+	UNUSED(uint32_t placeable);                     //!< Whether or not the object is placable
 	std::string type;                      //!< The object type
 	UNUSED(std::string description);               //!< An internal description of the object
-	UNUSED(unsigned int localize);                      //!< Whether or not the object should localize
-	UNUSED(unsigned int npcTemplateID);                 //!< Something related to NPCs...
+	UNUSED(uint32_t localize);                      //!< Whether or not the object should localize
+	UNUSED(uint32_t npcTemplateID);                 //!< Something related to NPCs...
 	UNUSED(std::string displayName);               //!< The display name of the object
 	float interactionDistance;          //!< The interaction distance of the object
-	UNUSED(unsigned int nametag);                       //!< ???
+	UNUSED(uint32_t nametag);                       //!< ???
 	UNUSED(std::string _internalNotes);            //!< Some internal notes (rarely used)
-	UNUSED(unsigned int locStatus);                     //!< ???
+	UNUSED(uint32_t locStatus);                     //!< ???
 	UNUSED(std::string gate_version);              //!< The gate version for the object
-	UNUSED(unsigned int HQ_valid);                      //!< Probably used for the Nexus HQ database on LEGOUniverse.com
+	UNUSED(uint32_t HQ_valid);                      //!< Probably used for the Nexus HQ database on LEGOUniverse.com
 };
 
 class CDObjectsTable : public CDTable<CDObjectsTable> {
 private:
-	std::map<unsigned int, CDObjects> entries;
+	std::map<uint32_t, CDObjects> entries;
 	CDObjects m_default;
 
 public:
 	void LoadValuesFromDatabase();
 	// Gets an entry by ID
-	const CDObjects& GetByID(unsigned int LOT);
+	const CDObjects& GetByID(uint32_t LOT);
 };
 

--- a/dDatabase/CDClientDatabase/CDClientTables/CDPackageComponentTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDPackageComponentTable.cpp
@@ -3,7 +3,7 @@
 void CDPackageComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM PackageComponent");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDPackageComponentTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDPackageComponentTable.h
@@ -4,9 +4,9 @@
 #include "CDTable.h"
 
 struct CDPackageComponent {
-	unsigned int id;
-	unsigned int LootMatrixIndex;
-	unsigned int packageType;
+	uint32_t id;
+	uint32_t LootMatrixIndex;
+	uint32_t packageType;
 };
 
 class CDPackageComponentTable : public CDTable<CDPackageComponentTable> {

--- a/dDatabase/CDClientDatabase/CDClientTables/CDPhysicsComponentTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDPhysicsComponentTable.cpp
@@ -28,7 +28,7 @@ void CDPhysicsComponentTable::LoadValuesFromDatabase() {
 	tableData.finalize();
 }
 
-CDPhysicsComponent* CDPhysicsComponentTable::GetByID(unsigned int componentID) {
+CDPhysicsComponent* CDPhysicsComponentTable::GetByID(uint32_t componentID) {
 	auto itr = m_entries.find(componentID);
 	return itr != m_entries.end() ? &itr->second : nullptr;
 }

--- a/dDatabase/CDClientDatabase/CDClientTables/CDPhysicsComponentTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDPhysicsComponentTable.h
@@ -3,7 +3,7 @@
 #include <string>
 
 struct CDPhysicsComponent {
-	int id;
+	int32_t id;
 	bool bStatic;
 	std::string physicsAsset;
 	UNUSED(bool jump);
@@ -12,8 +12,8 @@ struct CDPhysicsComponent {
 	UNUSED(float rotSpeed);
 	float playerHeight;
 	float playerRadius;
-	int pcShapeType;
-	int collisionGroup;
+	int32_t pcShapeType;
+	int32_t collisionGroup;
 	UNUSED(float airSpeed);
 	UNUSED(std::string boundaryAsset);
 	UNUSED(float jumpAirSpeed);
@@ -26,8 +26,8 @@ public:
 	void LoadValuesFromDatabase();
 
 	static const std::string GetTableName() { return "PhysicsComponent"; };
-	CDPhysicsComponent* GetByID(unsigned int componentID);
+	CDPhysicsComponent* GetByID(uint32_t componentID);
 
 private:
-	std::map<unsigned int, CDPhysicsComponent> m_entries;
+	std::map<uint32_t, CDPhysicsComponent> m_entries;
 };

--- a/dDatabase/CDClientDatabase/CDClientTables/CDProximityMonitorComponentTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDProximityMonitorComponentTable.cpp
@@ -3,7 +3,7 @@
 void CDProximityMonitorComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM ProximityMonitorComponent");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDProximityMonitorComponentTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDProximityMonitorComponentTable.h
@@ -4,7 +4,7 @@
 #include "CDTable.h"
 
 struct CDProximityMonitorComponent {
-	unsigned int id;
+	uint32_t id;
 	std::string Proximities;
 	bool LoadOnClient;
 	bool LoadOnServer;

--- a/dDatabase/CDClientDatabase/CDClientTables/CDRarityTableTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDRarityTableTable.cpp
@@ -3,7 +3,7 @@
 void CDRarityTableTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM RarityTable");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDRarityTableTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDRarityTableTable.h
@@ -5,7 +5,7 @@
 
 struct CDRarityTable {
 	float randmax;
-	unsigned int rarity;
+	uint32_t rarity;
 };
 
 typedef std::vector<CDRarityTable> RarityTable;

--- a/dDatabase/CDClientDatabase/CDClientTables/CDRebuildComponentTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDRebuildComponentTable.cpp
@@ -3,7 +3,7 @@
 void CDRebuildComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM RebuildComponent");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDRebuildComponentTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDRebuildComponentTable.h
@@ -4,15 +4,15 @@
 #include "CDTable.h"
 
 struct CDRebuildComponent {
-	unsigned int id;                        //!< The component Id
+	uint32_t id;                        //!< The component Id
 	float reset_time;               //!< The reset time
 	float complete_time;            //!< The complete time
-	unsigned int take_imagination;          //!< The amount of imagination it costs
+	uint32_t take_imagination;          //!< The amount of imagination it costs
 	bool interruptible;             //!< Whether or not the rebuild is interruptible
 	bool self_activator;            //!< Whether or not the rebuild is a rebuild activator itself
 	std::string custom_modules;        //!< The custom modules
-	unsigned int activityID;                //!< The activity ID
-	unsigned int post_imagination_cost;     //!< The post imagination cost
+	uint32_t activityID;                //!< The activity ID
+	uint32_t post_imagination_cost;     //!< The post imagination cost
 	float time_before_smash;        //!< The time before smash
 };
 

--- a/dDatabase/CDClientDatabase/CDClientTables/CDRewardCodesTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDRewardCodesTable.cpp
@@ -3,7 +3,7 @@
 void CDRewardCodesTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM RewardCodes");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDScriptComponentTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDScriptComponentTable.cpp
@@ -3,7 +3,7 @@
 void CDScriptComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM ScriptComponent");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);
@@ -28,8 +28,8 @@ void CDScriptComponentTable::LoadValuesFromDatabase() {
 	tableData.finalize();
 }
 
-const CDScriptComponent& CDScriptComponentTable::GetByID(unsigned int id) {
-	std::map<unsigned int, CDScriptComponent>::iterator it = this->entries.find(id);
+const CDScriptComponent& CDScriptComponentTable::GetByID(uint32_t id) {
+	std::map<uint32_t, CDScriptComponent>::iterator it = this->entries.find(id);
 	if (it != this->entries.end()) {
 		return it->second;
 	}

--- a/dDatabase/CDClientDatabase/CDClientTables/CDScriptComponentTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDScriptComponentTable.h
@@ -4,19 +4,19 @@
 #include "CDTable.h"
 
 struct CDScriptComponent {
-	unsigned int id;                        //!< The component ID
+	uint32_t id;                        //!< The component ID
 	std::string script_name;           //!< The script name
 	std::string client_script_name;    //!< The client script name
 };
 
 class CDScriptComponentTable : public CDTable<CDScriptComponentTable> {
 private:
-	std::map<unsigned int, CDScriptComponent> entries;
+	std::map<uint32_t, CDScriptComponent> entries;
 	CDScriptComponent m_ToReturnWhenNoneFound;
 
 public:
 	void LoadValuesFromDatabase();
 	// Gets an entry by scriptID
-	const CDScriptComponent& GetByID(unsigned int id);
+	const CDScriptComponent& GetByID(uint32_t id);
 };
 

--- a/dDatabase/CDClientDatabase/CDClientTables/CDSkillBehaviorTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDSkillBehaviorTable.cpp
@@ -4,7 +4,7 @@ void CDSkillBehaviorTable::LoadValuesFromDatabase() {
 	m_empty = CDSkillBehavior();
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM SkillBehavior");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);
@@ -49,8 +49,8 @@ void CDSkillBehaviorTable::LoadValuesFromDatabase() {
 	tableData.finalize();
 }
 
-const CDSkillBehavior& CDSkillBehaviorTable::GetSkillByID(unsigned int skillID) {
-	std::map<unsigned int, CDSkillBehavior>::iterator it = this->entries.find(skillID);
+const CDSkillBehavior& CDSkillBehaviorTable::GetSkillByID(uint32_t skillID) {
+	std::map<uint32_t, CDSkillBehavior>::iterator it = this->entries.find(skillID);
 	if (it != this->entries.end()) {
 		return it->second;
 	}

--- a/dDatabase/CDClientDatabase/CDClientTables/CDSkillBehaviorTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDSkillBehaviorTable.h
@@ -4,36 +4,36 @@
 #include "CDTable.h"
 
 struct CDSkillBehavior {
-	unsigned int skillID;               //!< The Skill ID of the skill
-	UNUSED(unsigned int locStatus);             //!< ??
-	unsigned int behaviorID;            //!< The Behavior ID of the skill
-	unsigned int imaginationcost;       //!< The imagination cost of the skill
-	unsigned int cooldowngroup;         //!< The cooldown group ID of the skill
+	uint32_t skillID;               //!< The Skill ID of the skill
+	UNUSED(uint32_t locStatus);             //!< ??
+	uint32_t behaviorID;            //!< The Behavior ID of the skill
+	uint32_t imaginationcost;       //!< The imagination cost of the skill
+	uint32_t cooldowngroup;         //!< The cooldown group ID of the skill
 	float cooldown;             //!< The cooldown time of the skill
 	UNUSED(bool isNpcEditor);           //!< ???
-	UNUSED(unsigned int skillIcon);             //!< The Skill Icon ID
+	UNUSED(uint32_t skillIcon);             //!< The Skill Icon ID
 	UNUSED(std::string oomSkillID);        //!< ???
-	UNUSED(unsigned int oomBehaviorEffectID);   //!< ???
-	UNUSED(unsigned int castTypeDesc);          //!< The cast type description(?)
-	UNUSED(unsigned int imBonusUI);             //!< The imagination bonus of the skill
-	UNUSED(nsigned int lifeBonusUI);           //!< The life bonus of the skill
-	UNUSED(unsigned int armorBonusUI);          //!< The armor bonus of the skill
-	UNUSED(unsigned int damageUI);             //!< ???
+	UNUSED(uint32_t oomBehaviorEffectID);   //!< ???
+	UNUSED(uint32_t castTypeDesc);          //!< The cast type description(?)
+	UNUSED(uint32_t imBonusUI);             //!< The imagination bonus of the skill
+	UNUSED(nint32_t lifeBonusUI);           //!< The life bonus of the skill
+	UNUSED(uint32_t armorBonusUI);          //!< The armor bonus of the skill
+	UNUSED(uint32_t damageUI);             //!< ???
 	UNUSED(bool hideIcon);              //!< Whether or not to show the icon
 	UNUSED(bool localize);              //!< ???
 	UNUSED(std::string gate_version);      //!< ???
-	UNUSED(unsigned int cancelType);            //!< The cancel type (?)
+	UNUSED(uint32_t cancelType);            //!< The cancel type (?)
 };
 
 class CDSkillBehaviorTable : public CDTable<CDSkillBehaviorTable> {
 private:
-	std::map<unsigned int, CDSkillBehavior> entries;
+	std::map<uint32_t, CDSkillBehavior> entries;
 	CDSkillBehavior m_empty;
 
 public:
 	void LoadValuesFromDatabase();
 
 	// Gets an entry by skillID
-	const CDSkillBehavior& GetSkillByID(unsigned int skillID);
+	const CDSkillBehavior& GetSkillByID(uint32_t skillID);
 };
 

--- a/dDatabase/CDClientDatabase/CDClientTables/CDVendorComponentTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDVendorComponentTable.cpp
@@ -3,7 +3,7 @@
 void CDVendorComponentTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM VendorComponent");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);

--- a/dDatabase/CDClientDatabase/CDClientTables/CDVendorComponentTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDVendorComponentTable.h
@@ -4,11 +4,11 @@
 #include "CDTable.h"
 
 struct CDVendorComponent {
-	unsigned int id;           //!< The Component ID
+	uint32_t id;           //!< The Component ID
 	float buyScalar;            //!< Buy Scalar (what does that mean?)
 	float sellScalar;          //!< Sell Scalar (what does that mean?)
 	float refreshTimeSeconds;  //!< The refresh time
-	unsigned int LootMatrixIndex; //!< LootMatrixIndex of the vendor's items
+	uint32_t LootMatrixIndex; //!< LootMatrixIndex of the vendor's items
 };
 
 class CDVendorComponentTable : public CDTable<CDVendorComponentTable> {

--- a/dDatabase/CDClientDatabase/CDClientTables/CDZoneTableTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDZoneTableTable.cpp
@@ -3,7 +3,7 @@
 void CDZoneTableTable::LoadValuesFromDatabase() {
 
 	// First, get the size of the table
-	unsigned int size = 0;
+	uint32_t size = 0;
 	auto tableSize = CDClientDatabase::ExecuteQuery("SELECT COUNT(*) FROM ZoneTable");
 	while (!tableSize.eof()) {
 		size = tableSize.getIntField(0, 0);
@@ -53,7 +53,7 @@ void CDZoneTableTable::LoadValuesFromDatabase() {
 }
 
 //! Queries the table with a zoneID to find.
-const CDZoneTable* CDZoneTableTable::Query(unsigned int zoneID) {
+const CDZoneTable* CDZoneTableTable::Query(uint32_t zoneID) {
 	const auto& iter = m_Entries.find(zoneID);
 
 	if (iter != m_Entries.end()) {

--- a/dDatabase/CDClientDatabase/CDClientTables/CDZoneTableTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDZoneTableTable.h
@@ -4,14 +4,14 @@
 #include "CDTable.h"
 
 struct CDZoneTable {
-	unsigned int zoneID;                        //!< The Zone ID of the object
-	unsigned int locStatus;                     //!< The Locale Status(?)
+	uint32_t zoneID;                        //!< The Zone ID of the object
+	uint32_t locStatus;                     //!< The Locale Status(?)
 	std::string zoneName;                  //!< The name of the zone
-	unsigned int scriptID;                      //!< The Script ID of the zone (ScriptsTable)
+	uint32_t scriptID;                      //!< The Script ID of the zone (ScriptsTable)
 	float ghostdistance_min;            //!< The minimum ghosting distance
 	float ghostdistance;                //!< The ghosting distance
-	unsigned int population_soft_cap;           //!< The "soft cap" on the world population
-	unsigned int population_hard_cap;           //!< The "hard cap" on the world population
+	uint32_t population_soft_cap;           //!< The "soft cap" on the world population
+	uint32_t population_hard_cap;           //!< The "hard cap" on the world population
 	UNUSED(std::string DisplayDescription);        //!< The display description of the world
 	UNUSED(std::string mapFolder);                 //!< ???
 	float smashableMinDistance;         //!< The minimum smashable distance?
@@ -19,9 +19,9 @@ struct CDZoneTable {
 	UNUSED(std::string mixerProgram);              //!< ???
 	UNUSED(std::string clientPhysicsFramerate);    //!< The client physics framerate
 	std::string serverPhysicsFramerate;    //!< The server physics framerate
-	unsigned int zoneControlTemplate;           //!< The Zone Control template
-	unsigned int widthInChunks;                 //!< The width of the world in chunks
-	unsigned int heightInChunks;                //!< The height of the world in chunks
+	uint32_t zoneControlTemplate;           //!< The Zone Control template
+	uint32_t widthInChunks;                 //!< The width of the world in chunks
+	uint32_t heightInChunks;                //!< The height of the world in chunks
 	bool petsAllowed;                   //!< Whether or not pets are allowed in the world
 	bool localize;                      //!< Whether or not the world should be localized
 	float fZoneWeight;                  //!< ???
@@ -35,11 +35,11 @@ struct CDZoneTable {
 
 class CDZoneTableTable : public CDTable<CDZoneTableTable> {
 private:
-	std::map<unsigned int, CDZoneTable> m_Entries;
+	std::map<uint32_t, CDZoneTable> m_Entries;
 
 public:
 	void LoadValuesFromDatabase();
 
 	// Queries the table with a zoneID to find.
-	const CDZoneTable* Query(unsigned int zoneID);
+	const CDZoneTable* Query(uint32_t zoneID);
 };


### PR DESCRIPTION
The only thing done in this pr is the following
- Replace all `unsigned int` with `uint32_t`
- Replace all `int ` with `int32_t `
- fix type typo in SkillBehaviorTable entry

There is no functional change here.  Only a type consistency change.
I have however kept the return type of execDml as an `int` to keep the interface 1:1 with what the sqlite code returns.