### PR TITLE
chore: Simplify and move Player functionality to relevant component

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -1879,7 +1879,7 @@ const NiQuaternion& Entity::GetRotation() const {
 	return NiQuaternion::IDENTITY;
 }
 
-void Entity::SetPosition(NiPoint3 position) {
+void Entity::SetPosition(const NiPoint3& position) {
 	auto* controllable = GetComponent<ControllablePhysicsComponent>();
 
 	if (controllable != nullptr) {
@@ -1907,7 +1907,7 @@ void Entity::SetPosition(NiPoint3 position) {
 	Game::entityManager->SerializeEntity(this);
 }
 
-void Entity::SetRotation(NiQuaternion rotation) {
+void Entity::SetRotation(const NiQuaternion& rotation) {
 	auto* controllable = GetComponent<ControllablePhysicsComponent>();
 
 	if (controllable != nullptr) {

--- a/dGame/Entity.h
+++ b/dGame/Entity.h
@@ -106,7 +106,7 @@ public:
 
 	virtual User* GetParentUser() const;
 
-	virtual SystemAddress GetSystemAddress() const { return UNASSIGNED_SYSTEM_ADDRESS; };
+	virtual const SystemAddress& GetSystemAddress() const { return UNASSIGNED_SYSTEM_ADDRESS; };
 
 	/**
 	 * Setters
@@ -124,13 +124,13 @@ public:
 
 	void SetNetworkId(uint16_t id);
 
-	void SetPosition(NiPoint3 position);
+	void SetPosition(const NiPoint3& position);
 
-	void SetRotation(NiQuaternion rotation);
+	void SetRotation(const NiQuaternion& rotation);
 
-	virtual void SetRespawnPos(NiPoint3 position) {}
+	virtual void SetRespawnPos(const NiPoint3& position) {}
 
-	virtual void SetRespawnRot(NiQuaternion rotation) {}
+	virtual void SetRespawnRot(const NiQuaternion& rotation) {}
 
 	virtual void SetSystemAddress(const SystemAddress& value) {};
 
@@ -229,8 +229,8 @@ public:
 	void TriggerEvent(eTriggerEventType event, Entity* optionalTarget = nullptr);
 	void ScheduleDestructionAfterUpdate() { m_ShouldDestroyAfterUpdate = true; }
 
-	virtual NiPoint3 GetRespawnPosition() const { return NiPoint3::ZERO; }
-	virtual NiQuaternion GetRespawnRotation() const { return NiQuaternion::IDENTITY; }
+	virtual const NiPoint3& GetRespawnPosition() const { return NiPoint3::ZERO; }
+	virtual const NiQuaternion& GetRespawnRotation() const { return NiQuaternion::IDENTITY; }
 
 	void Sleep();
 	void Wake();

--- a/dGame/Player.cpp
+++ b/dGame/Player.cpp
@@ -3,16 +3,11 @@
 #include <ctime>
 
 #include "Character.h"
-#include "Database.h"
-#include "MissionComponent.h"
 #include "UserManager.h"
 #include "EntityManager.h"
+#include "Game.h"
 #include "Logger.h"
-#include "ZoneInstanceManager.h"
-#include "WorldPackets.h"
 #include "dZoneManager.h"
-#include "CharacterComponent.h"
-#include "Mail.h"
 #include "User.h"
 #include "CppScripts.h"
 #include "Loot.h"
@@ -57,7 +52,6 @@ Player::Player(const LWOOBJID& objectID, const EntityInfo info, User* user, Enti
 	m_ParentUser->SetLoggedInChar(objectID);
 	m_GMLevel = m_Character->GetGMLevel();
 	m_SystemAddress = m_ParentUser->GetSystemAddress();
-	m_DroppedLoot = {};
 	m_DroppedCoins = 0;
 
 	m_GhostReferencePoint = NiPoint3::ZERO;

--- a/dGame/Player.h
+++ b/dGame/Player.h
@@ -18,63 +18,43 @@ public:
 	 * Getters
 	 */
 
-	User* GetParentUser() const override;
+	User* GetParentUser() const override { return m_ParentUser; };
 
-	SystemAddress GetSystemAddress() const override;
+	const SystemAddress& GetSystemAddress() const override { return m_SystemAddress; };
 
-	NiPoint3 GetRespawnPosition() const override;
+	const NiPoint3& GetRespawnPosition() const override { return m_respawnPos; };
 
-	NiQuaternion GetRespawnRotation() const override;
+	const NiQuaternion& GetRespawnRotation() const override { return m_respawnRot; };
 
-	const NiPoint3& GetGhostReferencePoint() const;
+	const NiPoint3& GetGhostReferencePoint() const { return m_GhostOverride ? m_GhostOverridePoint : m_GhostReferencePoint; };
 
-	const NiPoint3& GetOriginGhostReferencePoint() const;
+	const NiPoint3& GetOriginGhostReferencePoint() const { return m_GhostReferencePoint; };
 
-	const NiPoint3& GetGhostOverridePoint() const;
+	const NiPoint3& GetGhostOverridePoint() const { return m_GhostOverridePoint; };
 
-	bool GetGhostOverride() const;
+	bool GetGhostOverride() const { return m_GhostOverride; };
 
-	std::map<LWOOBJID, Loot::Info>& GetDroppedLoot();
+	std::map<LWOOBJID, Loot::Info>& GetDroppedLoot() { return m_DroppedLoot; };
 
-	uint64_t GetDroppedCoins();
+	uint64_t GetDroppedCoins() const { return m_DroppedCoins; };
 
 	/**
 	 * Setters
 	 */
 
+	void SetGhostOverride(bool value) { m_GhostOverride = value; };
+
+	void SetDroppedCoins(const uint64_t value) { m_DroppedCoins = value; };
+
 	void SetSystemAddress(const SystemAddress& value) override;
 
-	void SetRespawnPos(NiPoint3 position) override;
+	void SetRespawnPos(const NiPoint3& position) override;
 
-	void SetRespawnRot(NiQuaternion rotation) override;
+	void SetRespawnRot(const NiQuaternion& rotation) override;
 
 	void SetGhostReferencePoint(const NiPoint3& value);
 
 	void SetGhostOverridePoint(const NiPoint3& value);
-
-	void SetGhostOverride(bool value);
-
-	void SetDroppedCoins(uint64_t value);
-
-	/**
-	 * Wrapper for sending an in-game mail.
-	 *
-	 * @param sender id of the sender. LWOOBJID_EMPTY for system mail
-	 * @param senderName name of the sender. Max 32 characters.
-	 * @param subject mail subject. Max 50 characters.
-	 * @param body mail body. Max 400 characters.
-	 * @param attachment LOT of the attached item. LOT_NULL if no attachment.
-	 * @param attachmentCount stack size for attachment.
-	 */
-	void SendMail(LWOOBJID sender, const std::string& senderName, const std::string& subject, const std::string& body, LOT attachment, uint16_t attachmentCount) const;
-
-	/**
-	 * Wrapper for transfering the player to another instance.
-	 *
-	 * @param zoneId zoneID for the new instance.
-	 * @param cloneId cloneID for the new instance.
-	 */
-	void SendToZone(LWOMAPID zoneId, LWOCLONEID cloneId = 0);
 
 	/**
 	 * Ghosting
@@ -86,11 +66,11 @@ public:
 
 	void ConstructLimboEntities();
 
-	void ObserveEntity(int32_t id);
+	void ObserveEntity(const int32_t id);
 
-	bool IsObserved(int32_t id);
+	bool IsObserved(const int32_t id);
 
-	void GhostEntity(int32_t id);
+	void GhostEntity(const int32_t id);
 
 	/**
 	 * Static methods
@@ -122,15 +102,9 @@ private:
 
 	std::vector<int32_t> m_ObservedEntities;
 
-	int32_t m_ObservedEntitiesLength;
-
-	int32_t m_ObservedEntitiesUsed;
-
 	std::vector<LWOOBJID> m_LimboConstructions;
 
 	std::map<LWOOBJID, Loot::Info> m_DroppedLoot;
 
 	uint64_t m_DroppedCoins;
-
-	static std::vector<Player*> m_Players;
 };

--- a/dGame/dComponents/CharacterComponent.h
+++ b/dGame/dComponents/CharacterComponent.h
@@ -282,6 +282,14 @@ public:
 	LWOOBJID GetCurrentInteracting() {return m_CurrentInteracting;};
 
 	/**
+	 * Sends a player to another zone with an optional clone ID
+	 *
+	 * @param zoneId zoneID for the new instance.
+	 * @param cloneId cloneID for the new instance.
+	 */
+	void SendToZone(LWOMAPID zoneId, LWOCLONEID cloneId = 0) const;
+
+	/**
 	 * Character info regarding this character, including clothing styles, etc.
 	 */
 	Character* m_Character;

--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -31,6 +31,7 @@
 #include "eMissionTaskType.h"
 #include "eStateChangeType.h"
 #include "eUseItemResponse.h"
+#include "Mail.h"
 
 #include "CDComponentsRegistryTable.h"
 #include "CDInventoryComponentTable.h"
@@ -264,17 +265,11 @@ void InventoryComponent::AddItem(
 		}
 
 		if (slot == -1) {
-			auto* player = dynamic_cast<Player*>(GetParent());
-
-			if (player == nullptr) {
-				return;
-			}
-
 			outOfSpace += size;
 
 			switch (sourceType) {
 			case 0:
-				player->SendMail(LWOOBJID_EMPTY, "Darkflame Universe", "Lost Reward", "You received an item and didn&apos;t have room for it.", lot, size);
+				Mail::SendMail(LWOOBJID_EMPTY, "Darkflame Universe", m_Parent, "Lost Reward", "You received an item and didn&apos;t have room for it.", lot, size);
 				break;
 
 			case 1:

--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -20,6 +20,7 @@
 #include "InventoryComponent.h"
 #include "eMissionTaskType.h"
 #include "eObjectBits.h"
+#include "CharacterComponent.h"
 
 #include <vector>
 #include "CppScripts.h"
@@ -247,7 +248,8 @@ void PropertyManagementComponent::OnStartBuilding() {
 	for (auto* player : players) {
 		if (player == ownerEntity) continue;
 
-		player->SendToZone(zoneId);
+		auto* characterComponent = player->GetComponent<CharacterComponent>();
+		if (characterComponent) characterComponent->SendToZone(zoneId);
 	}
 	auto inventoryComponent = ownerEntity->GetComponent<InventoryComponent>();
 

--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -71,10 +71,8 @@ void RacingControlComponent::OnPlayerLoaded(Entity* player) {
 
 	// If the race has already started, send the player back to the main world.
 	if (m_Loaded || !vehicle) {
-		auto* playerInstance = dynamic_cast<Player*>(player);
-		if (playerInstance) {
-			playerInstance->SendToZone(m_MainWorld);
-		}
+		auto* characterComponent = player->GetComponent<CharacterComponent>();
+		if (characterComponent) characterComponent->SendToZone(m_MainWorld);
 		return;
 	}
 
@@ -105,10 +103,11 @@ void RacingControlComponent::LoadPlayerVehicle(Entity* player,
 
 	if (item == nullptr) {
 		LOG("Failed to find item");
-		auto* playerInstance = dynamic_cast<Player*>(player);
-		if (playerInstance) {
+		auto* characterComponent = player->GetComponent<CharacterComponent>();
+
+		if (characterComponent) {
 			m_LoadedPlayers--;
-			playerInstance->SendToZone(m_MainWorld);
+			characterComponent->SendToZone(m_MainWorld);
 		}
 		return;
 
@@ -427,9 +426,9 @@ void RacingControlComponent::HandleMessageBoxResponse(Entity* player, int32_t bu
 			m_Parent->GetObjectID(), 3, 0, LWOOBJID_EMPTY, u"",
 			player->GetObjectID(), UNASSIGNED_SYSTEM_ADDRESS);
 
-		auto* playerInstance = dynamic_cast<Player*>(player);
+		auto* characterComponent = player->GetComponent<CharacterComponent>();
 
-		playerInstance->SendToZone(m_MainWorld);
+		if (characterComponent) characterComponent->SendToZone(m_MainWorld);
 
 		vehicle->Kill();
 	}
@@ -561,9 +560,9 @@ void RacingControlComponent::Update(float deltaTime) {
 					continue;
 				}
 
-				auto* playerInstance = dynamic_cast<Player*>(playerEntity);
+				auto* characterComponent = playerEntity->GetComponent<CharacterComponent>();
 
-				playerInstance->SendToZone(m_MainWorld);
+				if (characterComponent) characterComponent->SendToZone(m_MainWorld);
 			}
 
 			m_LobbyPlayers.clear();
@@ -623,9 +622,9 @@ void RacingControlComponent::Update(float deltaTime) {
 					continue;
 				}
 
-				auto* playerInstance = dynamic_cast<Player*>(playerEntity);
+				auto* characterComponent = playerEntity->GetComponent<CharacterComponent>();
 
-				playerInstance->SendToZone(m_MainWorld);
+				if (characterComponent) characterComponent->SendToZone(m_MainWorld);
 			}
 
 			return;

--- a/dScripts/BaseConsoleTeleportServer.cpp
+++ b/dScripts/BaseConsoleTeleportServer.cpp
@@ -1,6 +1,6 @@
 #include "BaseConsoleTeleportServer.h"
 #include "GameMessages.h"
-#include "Player.h"
+#include "CharacterComponent.h"
 #include "RenderComponent.h"
 #include "EntityManager.h"
 #include "eTerminateType.h"
@@ -94,7 +94,9 @@ void BaseConsoleTeleportServer::TransferPlayer(Entity* self, Entity* player, int
 
 	const auto& teleportZone = self->GetVar<std::u16string>(u"transferZoneID");
 
-	static_cast<Player*>(player)->SendToZone(std::stoi(GeneralUtils::UTF16ToWTF8(teleportZone)));
+	auto* characterComponent = player->GetComponent<CharacterComponent>();
+
+	if (characterComponent) characterComponent->SendToZone(std::stoi(GeneralUtils::UTF16ToWTF8(teleportZone)));
 
 	UpdatePlayerTable(self, player, false);
 }

--- a/dScripts/BaseSurvivalServer.cpp
+++ b/dScripts/BaseSurvivalServer.cpp
@@ -3,7 +3,7 @@
 #include "DestroyableComponent.h"
 #include "EntityManager.h"
 #include "dZoneManager.h"
-#include "Player.h"
+#include "CharacterComponent.h"
 #include "eMissionTaskType.h"
 #include "eMissionState.h"
 #include "MissionComponent.h"
@@ -23,7 +23,8 @@ void BaseSurvivalServer::BasePlayerLoaded(Entity* self, Entity* player) {
 	const auto& playersIter = std::find(state.players.begin(), state.players.end(), player->GetObjectID());
 
 	if (waitingIter != state.waitingPlayers.end() || playersIter != state.players.end()) {
-		static_cast<Player*>(player)->SendToZone(player->GetCharacter()->GetLastNonInstanceZoneID());
+		auto* characterComponent = player->GetComponent<CharacterComponent>();
+		if (characterComponent) characterComponent->SendToZone(player->GetCharacter()->GetLastNonInstanceZoneID());
 
 		return;
 	}
@@ -161,8 +162,8 @@ void BaseSurvivalServer::BaseMessageBoxResponse(Entity* self, Entity* sender, in
 		if (sender->IsPlayer()) {
 			auto* character = sender->GetCharacter();
 			if (character != nullptr) {
-				auto* player = dynamic_cast<Player*>(sender);
-				player->SendToZone(character->GetLastNonInstanceZoneID());
+				auto* characterComponent = sender->GetComponent<CharacterComponent>();
+				if (characterComponent) characterComponent->SendToZone(character->GetLastNonInstanceZoneID());
 			}
 		}
 	}

--- a/dScripts/BaseWavesServer.cpp
+++ b/dScripts/BaseWavesServer.cpp
@@ -3,7 +3,7 @@
 #include "DestroyableComponent.h"
 #include "EntityManager.h"
 #include "dZoneManager.h"
-#include "Player.h"
+#include "CharacterComponent.h"
 #include "eMissionTaskType.h"
 #include "eMissionState.h"
 #include "MissionComponent.h"
@@ -162,8 +162,8 @@ void BaseWavesServer::BaseMessageBoxResponse(Entity* self, Entity* sender, int32
 		if (sender->IsPlayer()) {
 			auto* character = sender->GetCharacter();
 			if (character != nullptr) {
-				auto* player = dynamic_cast<Player*>(sender);
-				player->SendToZone(character->GetLastNonInstanceZoneID());
+				auto* characterComponent = sender->GetComponent<CharacterComponent>();
+				if (characterComponent) characterComponent->SendToZone(character->GetLastNonInstanceZoneID());
 			}
 		}
 	}

--- a/dScripts/ai/GENERAL/InstanceExitTransferPlayerToLastNonInstance.cpp
+++ b/dScripts/ai/GENERAL/InstanceExitTransferPlayerToLastNonInstance.cpp
@@ -1,6 +1,6 @@
 #include "InstanceExitTransferPlayerToLastNonInstance.h"
 #include "GameMessages.h"
-#include "Player.h"
+#include "CharacterComponent.h"
 #include "Character.h"
 #include "dServer.h"
 #include "eTerminateType.h"
@@ -23,10 +23,8 @@ void InstanceExitTransferPlayerToLastNonInstance::OnUse(Entity* self, Entity* us
 }
 
 void InstanceExitTransferPlayerToLastNonInstance::OnMessageBoxResponse(Entity* self, Entity* sender, int32_t button, const std::u16string& identifier, const std::u16string& userData) {
-	auto* player = dynamic_cast<Player*>(sender);
-	if (player == nullptr)
-		return;
-
+	if (!sender->IsPlayer()) return;
+	
 	auto* character = sender->GetCharacter();
 	if (character != nullptr) {
 		if (identifier == u"Instance_Exit" && button == 1) {
@@ -47,7 +45,8 @@ void InstanceExitTransferPlayerToLastNonInstance::OnMessageBoxResponse(Entity* s
 				}
 			}
 
-			player->SendToZone(lastInstance);
+			auto* characterComponent = sender->GetComponent<CharacterComponent>();
+			if (characterComponent) characterComponent->SendToZone(lastInstance);
 		}
 	}
 

--- a/dScripts/ai/MINIGAME/SG_GF/SERVER/SGCannon.cpp
+++ b/dScripts/ai/MINIGAME/SG_GF/SERVER/SGCannon.cpp
@@ -453,15 +453,10 @@ void SGCannon::SpawnNewModel(Entity* self) {
 
 void SGCannon::RemovePlayer(LWOOBJID playerID) {
 	auto* player = Game::entityManager->GetEntity(playerID);
-	if (player == nullptr)
-		return;
+	if (!player) return;
 
-	auto* playerObject = dynamic_cast<Player*>(player);
-	if (playerObject == nullptr)
-		return;
-
-	auto* character = playerObject->GetCharacter();
-	auto* characterComponent = playerObject->GetComponent<CharacterComponent>();
+	auto* character = player->GetCharacter();
+	auto* characterComponent = player->GetComponent<CharacterComponent>();
 	if (characterComponent && character) {
 		characterComponent->SendToZone(character->GetLastNonInstanceZoneID());
 	}

--- a/dScripts/ai/MINIGAME/SG_GF/SERVER/SGCannon.cpp
+++ b/dScripts/ai/MINIGAME/SG_GF/SERVER/SGCannon.cpp
@@ -461,8 +461,9 @@ void SGCannon::RemovePlayer(LWOOBJID playerID) {
 		return;
 
 	auto* character = playerObject->GetCharacter();
-	if (character != nullptr) {
-		playerObject->SendToZone(character->GetLastNonInstanceZoneID());
+	auto* characterComponent = playerObject->GetComponent<CharacterComponent>();
+	if (characterComponent && character) {
+		characterComponent->SendToZone(character->GetLastNonInstanceZoneID());
 	}
 }
 

--- a/dScripts/zone/LUPs/WblGenericZone.cpp
+++ b/dScripts/zone/LUPs/WblGenericZone.cpp
@@ -1,10 +1,11 @@
 #include "WblGenericZone.h"
-#include "Player.h"
+#include "CharacterComponent.h"
 
 void WblGenericZone::OnFireEventServerSide(Entity* self, Entity* sender, std::string args, int32_t param1, int32_t param2, int32_t param3) {
 	if (args == m_WblAbortMsg) {
 		if (!sender) return;
-		auto player = dynamic_cast<Player*>(sender);
-		if (player) player->SendToZone(m_WblMainZone);
+
+		auto* characterComponent = sender->GetComponent<CharacterComponent>();
+		if (characterComponent) characterComponent->SendToZone(m_WblMainZone);
 	}
 }


### PR DESCRIPTION
Already touched a few things here, so i'm stopping here for the next PR.

Detailed changes:
- Move code to CharacterComponent
- Remove extraneous interfaces
- Simplify some code greatly
- Change some types to return and take in const ref (only structs larger than 8 bytes benefit from this change.)
- Update code to use CharacterComponent for sending to zone instead of Player*.
- Remove static storage container (static containers can be destroyed before exit/terminate handler executes)

Tested that I am still able to leave cannon cove, battle of nimbus station and avant gardens survival.  Am also still able to receive mail when my inventory is full.  