### PR TITLE
fix: timer iteration using two containers for each timer set

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -1224,7 +1224,7 @@ void Entity::UpdateXMLDoc(tinyxml2::XMLDocument* doc) {
 }
 
 void Entity::Update(const float deltaTime) {
-	uint32_t timerPosition;
+	size_t timerPosition;
 	size_t currentSize = m_Timers.size();
 	for (timerPosition = 0; timerPosition < currentSize;) {
 		auto& timer = m_Timers[timerPosition];
@@ -1243,7 +1243,7 @@ void Entity::Update(const float deltaTime) {
 			// This is a clever removal trick that avoids having to copy the entire vector and instead replaces this now expired
 			// element with the last element in the vector and then removes the last element.
 			currentSize--;
-			if (currentSize > 1 && timerPosition < currentSize) {
+			if (currentSize > 0 && timerPosition < currentSize) {
 				m_Timers.at(timerPosition) = m_Timers.at(currentSize);
 			}
 			m_Timers.erase(m_Timers.begin() + currentSize);
@@ -1276,7 +1276,7 @@ void Entity::Update(const float deltaTime) {
 			// This is a clever removal trick that avoids having to copy the entire vector and instead replaces this now expired
 			// element with the last element in the vector and then removes the last element.
 			currentSize--;
-			if (currentSize > 1 && timerPosition < currentSize) {
+			if (currentSize > 0 && timerPosition < currentSize) {
 				m_CallbackTimers.at(timerPosition) = m_CallbackTimers.at(currentSize);
 			}
 			m_CallbackTimers.erase(m_CallbackTimers.begin() + currentSize);

--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -1225,24 +1225,28 @@ void Entity::UpdateXMLDoc(tinyxml2::XMLDocument* doc) {
 
 void Entity::Update(const float deltaTime) {
 	uint32_t timerPosition;
-	for (timerPosition = 0; timerPosition < m_Timers.size();) {
+	size_t currentSize = m_Timers.size();
+	for (timerPosition = 0; timerPosition < currentSize;) {
 		auto& timer = m_Timers[timerPosition];
 		timer.Update(deltaTime);
 		// If the timer is expired, erase it and dont increment the position because the next timer will be at the same position.
-		// Before: [0, 1, 2, 3, ..., n]
+		// Before: [0, 1, 2, 3, ..., sizeBeforeLoop, newTimers]
 		// timerPosition  ^
-		// After:  [0, 1, n, ..., n - 1] 2 is expired and removed now
+		// currentSize               ^^^^^^^^^^^^^^
+		// After:  [0, 1, n, ..., sizeBeforeLoop - 1, newTimers] 2 is expired and removed now and currentSize still points at the end of the vector before the loop started
 		// timerPosition  ^
+		// currentSize            ^^^^^^^^^^^^^^^^^^
 		if (timer.GetTime() <= 0) {
 			// Remove the timer from the list of timers first so that scripts and events can remove timers without causing iterator invalidation
 			auto timerName = timer.GetName();
 			// We don't need to copy the element if there is only 1 element nor do we need to copy if we are on the last element.
 			// This is a clever removal trick that avoids having to copy the entire vector and instead replaces this now expired
 			// element with the last element in the vector and then removes the last element.
-			if (m_Timers.size() > 1 && timerPosition < m_Timers.size() - 1) {
-				m_Timers[timerPosition] = m_Timers[m_Timers.size() - 1];
+			currentSize--;
+			if (currentSize > 1 && timerPosition < currentSize) {
+				m_Timers.at(timerPosition) = m_Timers.at(currentSize);
 			}
-			m_Timers.erase(m_Timers.end() - 1);
+			m_Timers.erase(m_Timers.begin() + currentSize);
 			for (CppScripts::Script* script : CppScripts::GetEntityScripts(this)) {
 				script->OnTimerDone(this, timerName);
 			}
@@ -1254,12 +1258,15 @@ void Entity::Update(const float deltaTime) {
 		}
 	}
 
-	for (timerPosition = 0; timerPosition < m_CallbackTimers.size(); ) {
+	currentSize = m_CallbackTimers.size();
+	for (timerPosition = 0; timerPosition < currentSize; ) {
 		// If the timer is expired, erase it and dont increment the position because the next timer will be at the same position.
-		// Before: [0, 1, 2, 3, ..., n]
+		// Before: [0, 1, 2, 3, ..., sizeBeforeLoop, newTimers]
 		// timerPosition  ^
-		// After:  [0, 1, n, ..., n - 1] 2 is expired and removed now
+		// currentSize               ^^^^^^^^^^^^^^
+		// After:  [0, 1, n, ..., sizeBeforeLoop - 1, newTimers] 2 is expired and removed now and currentSize still points at the end of the vector before the loop started
 		// timerPosition  ^
+		// currentSize            ^^^^^^^^^^^^^^^^^^
 		auto& callbackTimer = m_CallbackTimers[timerPosition];
 		callbackTimer.Update(deltaTime);
 		if (callbackTimer.GetTime() <= 0) {
@@ -1268,10 +1275,11 @@ void Entity::Update(const float deltaTime) {
 			// We don't need to copy the element if there is only 1 element nor do we need to copy if we are on the last element.
 			// This is a clever removal trick that avoids having to copy the entire vector and instead replaces this now expired
 			// element with the last element in the vector and then removes the last element.
-			if (m_CallbackTimers.size() > 1 && timerPosition < m_CallbackTimers.size() - 1) {
-				m_CallbackTimers[timerPosition] = m_CallbackTimers[m_CallbackTimers.size() - 1];
+			currentSize--;
+			if (currentSize > 1 && timerPosition < currentSize) {
+				m_CallbackTimers.at(timerPosition) = m_CallbackTimers.at(currentSize);
 			}
-			m_CallbackTimers.erase(m_CallbackTimers.end() - 1);
+			m_CallbackTimers.erase(m_CallbackTimers.begin() + currentSize);
 			callback();
 		} else {
 			timerPosition++;

--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -1266,17 +1266,6 @@ void Entity::Update(const float deltaTime) {
 		}
 	}
 
-	// Add pending timers to the list of timers so they start next tick.
-	if (!m_PendingTimers.empty()) {
-		m_Timers.insert(m_Timers.end(), m_PendingTimers.begin(), m_PendingTimers.end());
-		m_PendingTimers.clear();
-	}
-
-	if (!m_PendingCallbackTimers.empty()) {
-		m_CallbackTimers.insert(m_CallbackTimers.end(), m_PendingCallbackTimers.begin(), m_PendingCallbackTimers.end());
-		m_PendingCallbackTimers.clear();
-	}
-
 	if (IsSleeping()) {
 		Sleep();
 
@@ -1712,11 +1701,11 @@ void Entity::RemoveParent() {
 }
 
 void Entity::AddTimer(std::string name, float time) {
-	m_PendingTimers.emplace_back(name, time);
+	m_Timers.emplace_back(name, time);
 }
 
 void Entity::AddCallbackTimer(float time, std::function<void()> callback) {
-	m_PendingCallbackTimers.emplace_back(time, callback);
+	m_CallbackTimers.emplace_back(time, callback);
 }
 
 bool Entity::HasTimer(const std::string& name) {
@@ -1725,7 +1714,6 @@ bool Entity::HasTimer(const std::string& name) {
 
 void Entity::CancelCallbackTimers() {
 	m_CallbackTimers.clear();
-	m_PendingCallbackTimers.clear();
 }
 
 void Entity::ScheduleKillAfterUpdate(Entity* murderer) {
@@ -1747,9 +1735,7 @@ void Entity::CancelTimer(const std::string& name) {
 
 void Entity::CancelAllTimers() {
 	m_Timers.clear();
-	m_PendingTimers.clear();
 	m_CallbackTimers.clear();
-	m_PendingCallbackTimers.clear();
 }
 
 bool Entity::IsPlayer() const {

--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -1231,12 +1231,18 @@ void Entity::Update(const float deltaTime) {
 		// If the timer is expired, erase it and dont increment the position because the next timer will be at the same position.
 		// Before: [0, 1, 2, 3, ..., n]
 		// timerPosition  ^
-		// After:  [0, 1, 3, ..., n]
+		// After:  [0, 1, n, ..., n - 1] 2 is expired and removed now
 		// timerPosition  ^
 		if (timer.GetTime() <= 0) {
 			// Remove the timer from the list of timers first so that scripts and events can remove timers without causing iterator invalidation
 			auto timerName = timer.GetName();
-			m_Timers.erase(m_Timers.begin() + timerPosition);
+			// We don't need to copy the element if there is only 1 element nor do we need to copy if we are on the last element.
+			// This is a clever removal trick that avoids having to copy the entire vector and instead replaces this now expired
+			// element with the last element in the vector and then removes the last element.
+			if (m_Timers.size() > 1 && timerPosition < m_Timers.size() - 1) {
+				m_Timers[timerPosition] = m_Timers[m_Timers.size() - 1];
+			}
+			m_Timers.erase(m_Timers.end() - 1);
 			for (CppScripts::Script* script : CppScripts::GetEntityScripts(this)) {
 				script->OnTimerDone(this, timerName);
 			}
@@ -1252,14 +1258,20 @@ void Entity::Update(const float deltaTime) {
 		// If the timer is expired, erase it and dont increment the position because the next timer will be at the same position.
 		// Before: [0, 1, 2, 3, ..., n]
 		// timerPosition  ^
-		// After:  [0, 1, 3, ..., n]
+		// After:  [0, 1, n, ..., n - 1] 2 is expired and removed now
 		// timerPosition  ^
 		auto& callbackTimer = m_CallbackTimers[timerPosition];
 		callbackTimer.Update(deltaTime);
 		if (callbackTimer.GetTime() <= 0) {
 			// Remove the timer from the list of timers first so that callbacks can remove timers without causing iterator invalidation
 			auto callback = callbackTimer.GetCallback();
-			m_CallbackTimers.erase(m_CallbackTimers.begin() + timerPosition);
+			// We don't need to copy the element if there is only 1 element nor do we need to copy if we are on the last element.
+			// This is a clever removal trick that avoids having to copy the entire vector and instead replaces this now expired
+			// element with the last element in the vector and then removes the last element.
+			if (m_CallbackTimers.size() > 1 && timerPosition < m_CallbackTimers.size() - 1) {
+				m_CallbackTimers[timerPosition] = m_CallbackTimers[m_CallbackTimers.size() - 1];
+			}
+			m_CallbackTimers.erase(m_CallbackTimers.end() - 1);
 			callback();
 		} else {
 			timerPosition++;

--- a/dGame/Entity.h
+++ b/dGame/Entity.h
@@ -330,9 +330,7 @@ protected:
 
 	std::unordered_map<eReplicaComponentType, Component*> m_Components;
 	std::vector<EntityTimer> m_Timers;
-	std::vector<EntityTimer> m_PendingTimers;
 	std::vector<EntityCallbackTimer> m_CallbackTimers;
-	std::vector<EntityCallbackTimer> m_PendingCallbackTimers;
 
 	bool m_ShouldDestroyAfterUpdate = false;
 

--- a/dScripts/02_server/DLU/CMakeLists.txt
+++ b/dScripts/02_server/DLU/CMakeLists.txt
@@ -1,3 +1,4 @@
 set(DSCRIPTS_SOURCES_02_SERVER_DLU 
 	"DLUVanityNPC.cpp"
+	"TimerTestScript.cpp"
 	PARENT_SCOPE)

--- a/dScripts/02_server/DLU/TimerTestScript.cpp
+++ b/dScripts/02_server/DLU/TimerTestScript.cpp
@@ -1,0 +1,14 @@
+#include "TimerTestScript.h"
+#include "Entity.h"
+
+void TimerTestScript::OnTimerDone(Entity* self, std::string timerName) {
+	if (timerName == "addTwoTimers") {
+		self->AddTimer("expiredAddTwoTimers1", 10.0f);
+		self->AddTimer("expiredAddTwoTimers2", 11.0f);
+	}
+
+	if (timerName == "addedBefore2") {
+		self->AddTimer("expiredAddedBefore1", 12.0f);
+		self->AddTimer("expiredAddedBefore2", 13.0f);
+	}
+}

--- a/dScripts/02_server/DLU/TimerTestScript.h
+++ b/dScripts/02_server/DLU/TimerTestScript.h
@@ -1,0 +1,11 @@
+#ifndef __TIMERTESTSCRIPT__H__
+#define __TIMERTESTSCRIPT__H__
+
+#include "CppScripts.h"
+
+class TimerTestScript : public CppScripts::Script {
+public:
+	void OnTimerDone(Entity* self, std::string timerName) override;
+};
+
+#endif  //!__TIMERTESTSCRIPT__H__

--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -217,6 +217,7 @@
 
 // DLU Scripts
 #include "DLUVanityNPC.h"
+#include "TimerTestScript.h"
 
 // AM Scripts
 #include "AmConsoleTeleportServer.h"
@@ -836,6 +837,8 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 	//DLU:
 	else if (scriptName == "scripts\\02_server\\DLU\\DLUVanityNPC.lua")
 		script = new DLUVanityNPC();
+	else if (scriptName == "scripts\\02_server\\DLU\\TimerTestScript.lua")
+		script = new TimerTestScript();
 
 	// Survival minigame
 	else if (scriptName == "scripts\\02_server\\Enemy\\Survival\\L_AG_SURVIVAL_STROMBIE.lua")

--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -524,7 +524,7 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 		script = new PetDigBuild(); // Technically also used once in AG
 	else if (scriptName == "scripts\\02_server\\Map\\GF\\L_SPAWN_LION_SERVER.lua")
 		script = new SpawnLionServer();
-	else if (scriptName == "scripts\\02_server\\Enemy\\General\\L_BASE_ENEMY_APE.lua")
+	if (scriptName == "scripts\\02_server\\Enemy\\General\\L_BASE_ENEMY_APE.lua")
 		script = new BaseEnemyApe();
 	else if (scriptName == "scripts\\02_server\\Enemy\\General\\L_GF_APE_SMASHING_QB.lua")
 		script = new GfApeSmashingQB();
@@ -747,7 +747,7 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 		script = new AmShieldGenerator();
 	else if (scriptName == "scripts\\02_server\\Map\\AM\\L_SHIELD_GENERATOR_QUICKBUILD.lua")
 		script = new AmShieldGeneratorQuickbuild();
-	else if (scriptName == "scripts\\02_server\\Map\\AM\\L_DROPSHIP_COMPUTER.lua")
+	if (scriptName == "scripts\\02_server\\Map\\AM\\L_DROPSHIP_COMPUTER.lua")
 		script = new AmDropshipComputer();
 	else if (scriptName == "scripts\\02_server\\Map\\AM\\L_SCROLL_READER_SERVER.lua")
 		script = new AmScrollReaderServer();

--- a/tests/dGameTests/CMakeLists.txt
+++ b/tests/dGameTests/CMakeLists.txt
@@ -8,6 +8,9 @@ list(APPEND DGAMETEST_SOURCES ${DCOMPONENTS_TESTS})
 add_subdirectory(dGameMessagesTests)
 list(APPEND DGAMETEST_SOURCES ${DGAMEMESSAGES_TESTS})
 
+add_subdirectory(dEntityTests)
+list(APPEND DGAMETEST_SOURCES ${DENTITY_TESTS})
+
 file(COPY ${GAMEMESSAGE_TESTBITSTREAMS} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 # Add the executable.  Remember to add all tests above this!

--- a/tests/dGameTests/dEntityTests/CMakeLists.txt
+++ b/tests/dGameTests/dEntityTests/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(DENTITY_TESTS
+	"EntityTests.cpp"
+)
+
+# Get the folder name and prepend it to the files above
+get_filename_component(thisFolderName ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+list(TRANSFORM DENTITY_TESTS PREPEND "${thisFolderName}/")
+
+# Export to parent scope
+set(DENTITY_TESTS ${DENTITY_TESTS} PARENT_SCOPE)

--- a/tests/dGameTests/dEntityTests/EntityTests.cpp
+++ b/tests/dGameTests/dEntityTests/EntityTests.cpp
@@ -121,3 +121,63 @@ TEST_F(EntityTest, EntityCallbackTimerTest) {
 	TestingFunction(2, 0.5f, callbackTimerToAddTwoTimers);
 	TestingFunction(3, 4.5f, emptyLambda); // Make sure timers after the last one initially in the loop are not updated.
 }
+
+TEST_F(EntityTest, EntityTimerSmallTest) {
+	entity->AddTimer("Timer", 1.0f);
+	entity->AddTimer("Timer2", 1.1f);
+	entity->Update(1.0f);
+	ASSERT_EQ(entity->GetTimers().size(), 1);
+	ASSERT_EQ(entity->GetTimers().at(0).GetName(), "Timer2");
+	ASSERT_FLOAT_EQ(entity->GetTimers().at(0).GetTime(), 0.1f);
+}
+
+TEST_F(EntityTest, EntityTimerSmallTestInverse) {
+	entity->AddTimer("Timer", 1.1f);
+	entity->AddTimer("Timer2", 1.0f);
+	entity->Update(1.0f);
+	ASSERT_EQ(entity->GetTimers().size(), 1);
+	ASSERT_EQ(entity->GetTimers().at(0).GetName(), "Timer");
+	ASSERT_FLOAT_EQ(entity->GetTimers().at(0).GetTime(), 0.1f);
+}
+
+TEST_F(EntityTest, EntityTimerPositiveTest) {
+	entity->AddTimer("Timer", 1.0f);
+	entity->Update(1.0f);
+	ASSERT_TRUE(entity->GetTimers().empty());
+}
+
+TEST_F(EntityTest, EntityTimerThreeTestRemoveFirst) {
+	entity->AddTimer("Timer1", 1.0f);
+	entity->AddTimer("Timer2", 2.0f);
+	entity->AddTimer("Timer3", 3.0f);
+	entity->Update(1.0f);
+	ASSERT_EQ(entity->GetTimers().size(), 2);
+	ASSERT_EQ(entity->GetTimers().at(0).GetName(), "Timer3");
+	ASSERT_FLOAT_EQ(entity->GetTimers().at(0).GetTime(), 2.0f);
+	ASSERT_EQ(entity->GetTimers().at(1).GetName(), "Timer2");
+	ASSERT_FLOAT_EQ(entity->GetTimers().at(1).GetTime(), 1.0f);
+}
+
+TEST_F(EntityTest, EntityTimerThreeTestRemoveSecond) {
+	entity->AddTimer("Timer1", 2.0f);
+	entity->AddTimer("Timer2", 1.0f);
+	entity->AddTimer("Timer3", 3.0f);
+	entity->Update(1.0f);
+	ASSERT_EQ(entity->GetTimers().size(), 2);
+	ASSERT_EQ(entity->GetTimers().at(0).GetName(), "Timer1");
+	ASSERT_FLOAT_EQ(entity->GetTimers().at(0).GetTime(), 1.0f);
+	ASSERT_EQ(entity->GetTimers().at(1).GetName(), "Timer3");
+	ASSERT_FLOAT_EQ(entity->GetTimers().at(1).GetTime(), 2.0f);
+}
+
+TEST_F(EntityTest, EntityTimerThreeTestRemoveThird) {
+	entity->AddTimer("Timer1", 2.0f);
+	entity->AddTimer("Timer2", 3.0f);
+	entity->AddTimer("Timer3", 1.0f);
+	entity->Update(1.0f);
+	ASSERT_EQ(entity->GetTimers().size(), 2);
+	ASSERT_EQ(entity->GetTimers().at(0).GetName(), "Timer1");
+	ASSERT_FLOAT_EQ(entity->GetTimers().at(0).GetTime(), 1.0f);
+	ASSERT_EQ(entity->GetTimers().at(1).GetName(), "Timer2");
+	ASSERT_FLOAT_EQ(entity->GetTimers().at(1).GetTime(), 2.0f);
+}

--- a/tests/dGameTests/dEntityTests/EntityTests.cpp
+++ b/tests/dGameTests/dEntityTests/EntityTests.cpp
@@ -74,7 +74,7 @@ TEST_F(EntityTest, EntityTimerEdgeCaseTests) {
 	TimerTestFunction(4, "expiredAddedBefore1", 12.0f);
 	TimerTestFunction(5, "expiredAddedBefore2", 13.0f);
 
-	// Last 3 are added afterwards and should be at the end of the vector.
+	// Last 3 are added afterwards and should be at the end of the vector with their default times.
 	TimerTestFunction(6, "addedAfter1", 15.0f);
 	TimerTestFunction(7, "addedAfter2", 16.0f);
 	TimerTestFunction(8, "addedAfter3", 17.0f);
@@ -119,5 +119,5 @@ TEST_F(EntityTest, EntityCallbackTimerTest) {
 	TestingFunction(0, 1.5f, callbackTimerToAddTwoTimers2);
 	TestingFunction(1, 3.5f, callbackToAddCallbackTimer);
 	TestingFunction(2, 0.5f, callbackTimerToAddTwoTimers);
-	TestingFunction(3, 4.5f, emptyLambda);
+	TestingFunction(3, 4.5f, emptyLambda); // Make sure timers after the last one initially in the loop are not updated.
 }

--- a/tests/dGameTests/dEntityTests/EntityTests.cpp
+++ b/tests/dGameTests/dEntityTests/EntityTests.cpp
@@ -1,0 +1,81 @@
+#include "GameDependencies.h"
+#include <gtest/gtest.h>
+#include <functional>
+
+#include "dCommonVars.h"
+#include "Entity.h"
+#include "EntityInfo.h"
+#include "EntityTimer.h"
+#include "EntityCallbackTimer.h"
+#include "ScriptComponent.h"
+
+class EntityMock : public Entity {
+public:
+	EntityMock(const LWOOBJID& objectID, EntityInfo info, Entity* parentEntity = nullptr) : Entity(objectID, info, parentEntity) {}
+	std::vector<EntityTimer>& GetTimers() { return m_Timers; }
+	std::vector<EntityCallbackTimer>& GetCallbackTimers() { return m_CallbackTimers; }
+};
+
+class EntityTest : public GameDependenciesTest {
+protected:
+	EntityMock* entity;
+
+	void SetUp() override {
+		SetUpDependencies();
+		entity = new EntityMock(15, GameDependenciesTest::info);
+		entity->AddComponent<ScriptComponent>("scripts\\02_server\\DLU\\TimerTestScript.lua", false, false);
+	}
+
+	void TearDown() override {
+		delete entity;
+		TearDownDependencies();
+	}
+};
+
+TEST_F(EntityTest, EntityTimerTests) {
+	entity->AddTimer("addTwoTimers", 0.5f);
+	ASSERT_TRUE(entity->HasTimer("addTwoTimers"));
+	ASSERT_TRUE(entity->GetTimers().size() == 1);
+	entity->AddCallbackTimer(1.0f, [](){});
+	ASSERT_TRUE(entity->GetCallbackTimers().size() == 1);
+	entity->Update(1.1f);
+	ASSERT_EQ(entity->GetTimers().size(), 2);
+	ASSERT_TRUE(entity->GetCallbackTimers().empty());
+}
+
+// The attached script has a listener for the timer "testTimer" that adds two timers when it's done, both of time 99.0f
+// then we check that all timers have a time of 99.0
+TEST_F(EntityTest, EntityTimerEdgeCaseTests) {
+	entity->AddTimer("addTwoTimers", 0.5f); // Will be removed and should swap places with addedBefore3.
+	entity->AddTimer("addedBefore1", 100.0f);
+	entity->AddTimer("addedBefore2", 1.0f); // Will be removed and will not swap places with anything.
+	entity->AddTimer("addedBefore3", 12.0f);
+	entity->Update(1.0f);
+	entity->AddTimer("addedAfter1", 15.0f);
+	entity->AddTimer("addedAfter2", 16.0f);
+	entity->AddTimer("addedAfter3", 17.0f);
+
+	ASSERT_EQ(entity->GetTimers().size(), 9);
+	std::function<void(int32_t, std::string, float)> TimerTestFunction = [this](int32_t index, std::string timerName, float time) {
+		ASSERT_EQ(entity->GetTimers().at(index).GetName(), timerName);
+		ASSERT_EQ(entity->GetTimers().at(index).GetTime(), time);
+	};
+
+	// First two are the timers remaining from the update that were added before the call.
+	// Observe that addedBefore3 has been moved to the front and properly decremented.
+	TimerTestFunction(0, "addedBefore3", 11.0f);
+	TimerTestFunction(1, "addedBefore1", 99.0f);
+
+	// Second two timers are the ones added by the script, just here to make sure they are in exactly position 2 and 3 and were not moved forward in the vector.
+	TimerTestFunction(2, "expiredAddTwoTimers1", 10.0f);
+	TimerTestFunction(3, "expiredAddTwoTimers2", 11.0f);
+
+	// The next two are added on the expiration of addedBefore2, and are only here to make sure that timer expired properly since it would be at the end of the updated timers.
+	TimerTestFunction(4, "expiredAddedBefore1", 12.0f);
+	TimerTestFunction(5, "expiredAddedBefore2", 13.0f);
+
+	// Last 3 are added afterwards and should be at the end of the vector.
+	TimerTestFunction(6, "addedAfter1", 15.0f);
+	TimerTestFunction(7, "addedAfter2", 16.0f);
+	TimerTestFunction(8, "addedAfter3", 17.0f);
+}


### PR DESCRIPTION
Can still load into Nimbus Station (on a setup where I couldn't before the newest commit) and fixes the issue where mechs could not move around in avant gardens survival.

