### PR TITLE
feat: Add announcement for mismatched fdb

### DIFF
--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -625,6 +625,25 @@ void GameMessages::SendUIMessageServerToSingleClient(Entity* entity, const Syste
 	SEND_PACKET;
 }
 
+void GameMessages::SendUIMessageServerToSingleClient(const std::string& message, AMFBaseValue& args, const SystemAddress& sysAddr) {
+	CBITSTREAM;
+	CMSGHEADER;
+
+	LWOOBJID empty = 0;
+	bitStream.Write(empty);
+	bitStream.Write(eGameMessageType::UI_MESSAGE_SERVER_TO_ALL_CLIENTS); // This is intentional to allow the server to send a ui message to a client via their system address.
+
+	bitStream.Write<AMFBaseValue&>(args);
+	uint32_t strMessageNameLength = message.size();
+	bitStream.Write(strMessageNameLength);
+
+	for (uint32_t k = 0; k < strMessageNameLength; k++) {
+		bitStream.Write<char>(message[k]);
+	}
+
+	SEND_PACKET;
+}
+
 void GameMessages::SendUIMessageServerToAllClients(const std::string& message, AMFBaseValue& args) {
 	CBITSTREAM;
 	CMSGHEADER;

--- a/dGame/dGameMessages/GameMessages.h
+++ b/dGame/dGameMessages/GameMessages.h
@@ -92,6 +92,9 @@ namespace GameMessages {
 
 	void SendModifyLEGOScore(Entity* entity, const SystemAddress& sysAddr, int64_t score, eLootSourceType sourceType);
 	void SendUIMessageServerToSingleClient(Entity* entity, const SystemAddress& sysAddr, const std::string& message, AMFBaseValue& args);
+
+	// Specify sysAddr if you need to send a flash message to a client who you dont know the objectID of.
+	void SendUIMessageServerToSingleClient(const std::string& message, AMFBaseValue& args, const SystemAddress& sysAddr);
 	void SendUIMessageServerToAllClients(const std::string& message, AMFBaseValue& args);
 
 	void SendPlayEmbeddedEffectOnAllClientsNearObject(Entity* entity, std::u16string effectName, const LWOOBJID& fromObjectID, float radius);

--- a/resources/worldconfig.ini
+++ b/resources/worldconfig.ini
@@ -73,3 +73,7 @@ help_4_description=Visit Discussions on the DarkflameServer GitHub page<br/>to a
 
 # Toggleable quality of life feature to allow users to skip most cinematics. 
 allow_players_to_skip_cinematics=0
+
+# Customizable message for what to say when there is a cdclient fdb mismatch
+cdclient_mismatch_title=Version out of date
+cdclient_mismatch_message=We detected that your client is out of date. Please update your client to the latest version.


### PR DESCRIPTION
adds an announcement sent to the system address which had the mismatched FDB to let the developer know they have a mis-matched one.

Tested that if a civilian tries to login without a gm level > developer, they are kicked. Tested that if a GM is found to have a mismatched FDB, they are let in but have an announcement sent to them.