### PR TITLE
chore: Use references instead of pointers in StringifiedEnum.h

### DIFF
--- a/dCommon/dEnums/StringifiedEnum.h
+++ b/dCommon/dEnums/StringifiedEnum.h
@@ -9,15 +9,15 @@ namespace StringifiedEnum {
 	const std::string_view ToString(const T e) {
 		static_assert(std::is_enum_v<T>, "Not an enum"); // Check type
 
-		constexpr auto sv = &magic_enum::enum_entries<T>();
+		constexpr auto& sv = magic_enum::enum_entries<T>();
 
 		const auto it = std::lower_bound(
-			sv->begin(), sv->end(), e,
+			sv.begin(), sv.end(), e,
 			[&](const std::pair<T, std::string_view>& lhs, const T rhs) { return lhs.first < rhs; }
 		);
 
 		std::string_view output;
-		if (it != sv->end() && it->first == e) {
+		if (it != sv.end() && it->first == e) {
 			output = it->second;
 		} else {
 			output = "UNKNOWN";


### PR DESCRIPTION
Another export from the test branch. I'll be honest: I just like reference syntax better than pointer syntax.