### PR TITLE
fix: faction changes not allowing updated targets

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -1357,16 +1357,10 @@ void Entity::OnCollisionPhantom(const LWOOBJID otherEntity) {
 	}
 
 	if (!other->GetIsDead()) {
-		auto* combat = GetComponent<BaseCombatAIComponent>();
-
-		if (combat != nullptr) {
+		if (GetComponent<BaseCombatAIComponent>() != nullptr) {
 			const auto index = std::find(m_TargetsInPhantom.begin(), m_TargetsInPhantom.end(), otherEntity);
 
 			if (index != m_TargetsInPhantom.end()) return;
-
-			const auto valid = combat->IsEnemy(otherEntity);
-
-			if (!valid) return;
 
 			m_TargetsInPhantom.push_back(otherEntity);
 		}
@@ -1992,25 +1986,25 @@ void Entity::SetNetworkId(const uint16_t id) {
 	m_NetworkID = id;
 }
 
-std::vector<LWOOBJID>& Entity::GetTargetsInPhantom() {
-	std::vector<LWOOBJID> valid;
-
+std::vector<LWOOBJID> Entity::GetTargetsInPhantom() {
 	// Clean up invalid targets, like disconnected players
-	for (auto i = 0u; i < m_TargetsInPhantom.size(); ++i) {
-		const auto id = m_TargetsInPhantom.at(i);
-
-		auto* entity = Game::entityManager->GetEntity(id);
-
-		if (entity == nullptr) {
+	for (auto i = 0u; i < m_TargetsInPhantom.size(); ) {
+		if (Game::entityManager->GetEntity(m_TargetsInPhantom.at(i))) {
+			i++;
 			continue;
 		}
-
-		valid.push_back(id);
+		m_TargetsInPhantom.erase(m_TargetsInPhantom.begin() + i);
 	}
 
-	m_TargetsInPhantom = valid;
+	std::vector<LWOOBJID> enemies;
+	for (const auto id : m_TargetsInPhantom) {
+		auto* combat = GetComponent<BaseCombatAIComponent>();
+		if (!combat || !combat->IsEnemy(id)) continue;
 
-	return m_TargetsInPhantom;
+		enemies.push_back(id);
+	}
+
+	return enemies;
 }
 
 void Entity::SendNetworkVar(const std::string& data, const SystemAddress& sysAddr) {

--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -1988,13 +1988,9 @@ void Entity::SetNetworkId(const uint16_t id) {
 
 std::vector<LWOOBJID> Entity::GetTargetsInPhantom() {
 	// Clean up invalid targets, like disconnected players
-	for (auto i = 0u; i < m_TargetsInPhantom.size(); ) {
-		if (Game::entityManager->GetEntity(m_TargetsInPhantom.at(i))) {
-			i++;
-			continue;
-		}
-		m_TargetsInPhantom.erase(m_TargetsInPhantom.begin() + i);
-	}
+	m_TargetsInPhantom.erase(std::remove_if(m_TargetsInPhantom.begin(), m_TargetsInPhantom.end(), [](const LWOOBJID id) {
+		return !Game::entityManager->GetEntity(id);
+	}), m_TargetsInPhantom.end());
 
 	std::vector<LWOOBJID> enemies;
 	for (const auto id : m_TargetsInPhantom) {

--- a/dGame/Entity.h
+++ b/dGame/Entity.h
@@ -293,7 +293,7 @@ public:
 	/*
 	 * Collision
 	 */
-	std::vector<LWOOBJID>& GetTargetsInPhantom();
+	std::vector<LWOOBJID> GetTargetsInPhantom();
 
 	Entity* GetScheduledKiller() { return m_ScheduleKiller; }
 


### PR DESCRIPTION
fixes an issue where enemies who would have their faction changed would not update their aggro targets since they will have already been forgotten in the previous iteration.  New version adds all colliding entities, but returns a trimmed list so that an enemy faction can be changed on the fly and not affect targetting for enemies who now have new enemies.
Returning a container not by reference will barely add any overhead since no copy or move is done since ive used copy elision to construct the vector in the previous stack frame instead of this one, so cost increase here is low.  No reference on the id as a LWOOBJID fits in a cpu register so a reference is more expensive than just copying the value.

Tested that stromling mechs and ronin/horsemen in forbidden valley still aggro on spawn as expected.

fixes #1426 