### PR TITLE
chore: Remove transitive include for Detour, remove unused fields

### DIFF
--- a/dNavigation/dNavMesh.cpp
+++ b/dNavigation/dNavMesh.cpp
@@ -11,6 +11,7 @@
 
 #include "dZoneManager.h"
 #include "DluAssert.h"
+#include "DetourExtensions.h"
 
 dNavMesh::dNavMesh(uint32_t zoneId) {
 	m_ZoneId = zoneId;
@@ -30,16 +31,8 @@ dNavMesh::dNavMesh(uint32_t zoneId) {
 dNavMesh::~dNavMesh() {
 	// Clean up Recast information
 
-	if(m_Solid) rcFreeHeightField(m_Solid);
-	if (m_CHF) rcFreeCompactHeightfield(m_CHF);
-	if (m_CSet) rcFreeContourSet(m_CSet);
-	if (m_PMesh) rcFreePolyMesh(m_PMesh);
-	if (m_PMDMesh) rcFreePolyMeshDetail(m_PMDMesh);
 	if (m_NavMesh) dtFreeNavMesh(m_NavMesh);
 	if (m_NavQuery) dtFreeNavMeshQuery(m_NavQuery);
-
-	if (m_Ctx) delete m_Ctx;
-	if (m_Triareas) delete[] m_Triareas;
 }
 
 

--- a/dNavigation/dNavMesh.h
+++ b/dNavigation/dNavMesh.h
@@ -2,13 +2,17 @@
 
 #include <cstdint>
 #include <vector>
-#include <map>
-#include <string>
-#include <cstring>
-
-#include "DetourExtensions.h"
 
 class NiPoint3;
+class rcHeightfield;
+class rcCompactHeightfield;
+class rcContourSet;
+class rcPolyMesh;
+class rcPolyMeshDetail;
+class InputGeom;
+class dtNavMesh;
+class dtNavMeshQuery;
+class rcContext;
 
 class dNavMesh {
 public:
@@ -26,24 +30,14 @@ public:
 	float GetHeightAtPoint(const NiPoint3& location, const float halfExtentsHeight = 32.0f) const;
 	std::vector<NiPoint3> GetPath(const NiPoint3& startPos, const NiPoint3& endPos, float speed = 10.0f);
 
-	class dtNavMesh* GetdtNavMesh() { return m_NavMesh; }
+	bool IsNavmeshLoaded() { return m_NavMesh != nullptr; }
 
 private:
 	void LoadNavmesh();
 
 	uint32_t m_ZoneId;
 
-	uint8_t* m_Triareas = nullptr;
-	rcHeightfield* m_Solid = nullptr;
-	rcCompactHeightfield* m_CHF = nullptr;
-	rcContourSet* m_CSet = nullptr;
-	rcPolyMesh* m_PMesh = nullptr;
-	rcConfig m_Config;
-	rcPolyMeshDetail* m_PMDMesh = nullptr;
-
-	class InputGeom* m_Geometry = nullptr;
-	class dtNavMesh* m_NavMesh = nullptr;
-	class dtNavMeshQuery* m_NavQuery = nullptr;
+	dtNavMesh* m_NavMesh = nullptr;
+	dtNavMeshQuery* m_NavQuery = nullptr;
 	uint8_t m_NavMeshDrawFlags;
-	rcContext* m_Ctx = nullptr;
 };

--- a/dPhysics/dpWorld.cpp
+++ b/dPhysics/dpWorld.cpp
@@ -81,7 +81,7 @@ void dpWorld::Shutdown() {
 }
 
 bool dpWorld::IsLoaded() {
-	return m_NavMesh->GetdtNavMesh() != nullptr;
+	return m_NavMesh->IsNavmeshLoaded();
 }
 
 void dpWorld::StepWorld(float deltaTime) {


### PR DESCRIPTION
Moves DetourExtensions.h to the 1 cpp file that uses it and locks down its header to not even expose the navmesh object since nothing has a use for it.

Still compiles and links.