### PR TITLE
fix: Remove hard coded groups for spawners

### DIFF
--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -631,6 +631,9 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& command, Entit
 		if (infile.good()) {
 			std::string line;
 			while (std::getline(infile, line)) {
+				// Do this in two separate calls to catch both \n and \r\n
+				line.erase(std::remove(line.begin(), line.end(), '\n'), line.end());
+				line.erase(std::remove(line.begin(), line.end(), '\r'), line.end());
 				SlashCommandHandler::HandleChatCommand(GeneralUtils::ASCIIToUTF16(line), entity, sysAddr);
 			}
 		} else {

--- a/dScripts/02_server/Enemy/AG/BossSpiderQueenEnemyServer.cpp
+++ b/dScripts/02_server/Enemy/AG/BossSpiderQueenEnemyServer.cpp
@@ -179,7 +179,7 @@ void BossSpiderQueenEnemyServer::SpiderWaveManager(Entity* self) {
 
 	std::vector<LWOOBJID> spiderEggs{};
 
-	auto spooders = Game::entityManager->GetEntitiesInGroup("EGG");
+	auto spooders = Game::entityManager->GetEntitiesInGroup("SpiderEggs");
 	for (auto spodder : spooders) {
 		spiderEggs.push_back(spodder->GetObjectID());
 	}

--- a/dScripts/02_server/Map/AG/NpcCowboyServer.cpp
+++ b/dScripts/02_server/Map/AG/NpcCowboyServer.cpp
@@ -1,6 +1,7 @@
 #include "NpcCowboyServer.h"
 #include "eMissionState.h"
 #include "InventoryComponent.h"
+#include "dZoneManager.h"
 
 void NpcCowboyServer::OnMissionDialogueOK(Entity* self, Entity* target, int missionID, eMissionState missionState) {
 	if (missionID != 1880) {
@@ -22,5 +23,18 @@ void NpcCowboyServer::OnMissionDialogueOK(Entity* self, Entity* target, int miss
 		}
 	} else if (missionState == eMissionState::READY_TO_COMPLETE || missionState == eMissionState::COMPLETE_READY_TO_COMPLETE) {
 		inventoryComponent->RemoveItem(14378, 1);
+	}
+
+	// Next up hide or show the samples based on the mission state
+	int32_t visible = 1;
+	if (missionState == eMissionState::READY_TO_COMPLETE || missionState == eMissionState::COMPLETE_READY_TO_COMPLETE) {
+		visible = 0;
+	}
+
+	auto spawners = Game::zoneManager->GetSpawnersByName("PlungerGunTargets");
+	for (auto* spawner : spawners) {
+		for (const auto entity : spawner->GetSpawnedObjectIDs())
+			GameMessages::SendNotifyClientObject(entity, u"SetVisibility", visible, 0,
+				target->GetObjectID(), "", target->GetSystemAddress());
 	}
 }

--- a/dScripts/02_server/Map/AG/NpcWispServer.cpp
+++ b/dScripts/02_server/Map/AG/NpcWispServer.cpp
@@ -1,9 +1,10 @@
 #include "NpcWispServer.h"
 #include "InventoryComponent.h"
-#include "EntityManager.h"
+#include "dZoneManager.h"
 #include "Entity.h"
 #include "GameMessages.h"
 #include "eMissionState.h"
+#include "Spawner.h"
 
 void NpcWispServer::OnMissionDialogueOK(Entity* self, Entity* target, int missionID, eMissionState missionState) {
 	if (missionID != 1849 && missionID != 1883)
@@ -25,7 +26,7 @@ void NpcWispServer::OnMissionDialogueOK(Entity* self, Entity* target, int missio
 	}
 
 	// Next up hide or show the samples based on the mission state
-	auto visible = 1;
+	int32_t visible = 1;
 	if (missionState == eMissionState::READY_TO_COMPLETE || missionState == eMissionState::COMPLETE_READY_TO_COMPLETE) {
 		visible = 0;
 	}
@@ -35,9 +36,10 @@ void NpcWispServer::OnMissionDialogueOK(Entity* self, Entity* target, int missio
 	: std::vector<std::string>{ "MaelstromSamples", "MaelstromSamples2ndary1", "MaelstromSamples2ndary2" };
 
 	for (const auto& group : groups) {
-		auto samples = Game::entityManager->GetEntitiesInGroup(group);
-		for (auto* sample : samples) {
-			GameMessages::SendNotifyClientObject(sample->GetObjectID(), u"SetVisibility", visible, 0,
+		auto spawners = Game::zoneManager->GetSpawnersByName(group);
+		for (const auto* spawner : spawners) {
+			for (const auto objId : spawner->GetSpawnedObjectIDs())
+			GameMessages::SendNotifyClientObject(objId, u"SetVisibility", visible, 0,
 				target->GetObjectID(), "", target->GetSystemAddress());
 		}
 	}

--- a/dZoneManager/Spawner.cpp
+++ b/dZoneManager/Spawner.cpp
@@ -25,16 +25,6 @@ Spawner::Spawner(const SpawnerInfo info) {
 
 	m_Start = m_Info.noTimedSpawn;
 
-	//ssssh...
-	if (m_EntityInfo.lot == 14718) { //AG - MAELSTROM SAMPLE
-		m_Info.groups.emplace_back("MaelstromSamples");
-	}
-
-	if (m_EntityInfo.lot == 14375) //AG - SPIDER BOSS EGG
-	{
-		m_Info.groups.emplace_back("EGG");
-	}
-
 	int timerCount = m_Info.amountMaintained;
 
 	if (m_Info.amountMaintained > m_Info.nodes.size()) {


### PR DESCRIPTION
Tested that the target next to the plunger gun dude now spawns its target without needing to leave the area if it is spawned
Tested that spiders still spawn in Spider Queen battle
Tested that macros work