### PR TITLE
refactor: Rewrite BehaviorMessage classes to use member initialization, preferred member naming conventions, and const-ref getters

### DIFF
--- a/dCommon/Amf3.h
+++ b/dCommon/Amf3.h
@@ -127,12 +127,12 @@ public:
 	/**
 	 * Returns the Associative portion of the object
 	 */
-	[[nodiscard]] inline AMFAssociative& GetAssociative() noexcept { return this->associative; }
+	[[nodiscard]] inline const AMFAssociative& GetAssociative() const noexcept { return this->associative; }
 
 	/**
 	 * Returns the dense portion of the object
 	 */
-	[[nodiscard]] inline AMFDense& GetDense() noexcept { return this->dense; }
+	[[nodiscard]] inline const AMFDense& GetDense() const noexcept { return this->dense; }
 
 	/**
 	 * Inserts an AMFValue into the associative portion with the given key.
@@ -297,7 +297,7 @@ public:
 		if (!this->dense.empty()) Remove(this->dense.size() - 1);
 	}
 
-	[[nodiscard]] AMFArrayValue* GetArray(const std::string& key) {
+	[[nodiscard]] AMFArrayValue* GetArray(const std::string& key) const {
 		AMFAssociative::const_iterator it = this->associative.find(key);
 		if (it != this->associative.end()) {
 			return dynamic_cast<AMFArrayValue*>(it->second);
@@ -305,7 +305,7 @@ public:
 		return nullptr;
 	}
 
-	[[nodiscard]] AMFArrayValue* GetArray(const size_t index) {
+	[[nodiscard]] AMFArrayValue* GetArray(const size_t index) const {
 		return index >= this->dense.size() ? nullptr : dynamic_cast<AMFArrayValue*>(this->dense.at(index));
 	}
 

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -2504,7 +2504,7 @@ void GameMessages::HandleControlBehaviors(RakNet::BitStream* inStream, Entity* e
 	auto owner = PropertyManagementComponent::Instance()->GetOwner();
 	if (!owner) return;
 
-	ControlBehaviors::Instance().ProcessCommand(entity, sysAddr, static_cast<AMFArrayValue*>(amfArguments.get()), command, owner);
+	ControlBehaviors::Instance().ProcessCommand(entity, static_cast<AMFArrayValue*>(amfArguments.get()), command, owner);
 }
 
 void GameMessages::HandleBBBSaveRequest(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {

--- a/dGame/dPropertyBehaviors/BlockDefinition.cpp
+++ b/dGame/dPropertyBehaviors/BlockDefinition.cpp
@@ -2,8 +2,8 @@
 
 BlockDefinition BlockDefinition::blockDefinitionDefault{};
 
-BlockDefinition::BlockDefinition(std::string defaultValue, float minimumValue, float maximumValue) {
-	this->defaultValue = defaultValue;
-	this->minimumValue = minimumValue;
-	this->maximumValue = maximumValue;
+BlockDefinition::BlockDefinition(const std::string& defaultValue, const float minimumValue, const float maximumValue)
+	: m_DefaultValue{ defaultValue }
+	, m_MinimumValue{ minimumValue }
+	, m_MaximumValue{ maximumValue } {
 }

--- a/dGame/dPropertyBehaviors/BlockDefinition.h
+++ b/dGame/dPropertyBehaviors/BlockDefinition.h
@@ -7,19 +7,20 @@ class AMFArrayValue;
 
 class BlockDefinition {
 public:
-	BlockDefinition(std::string defaultValue = "", float minimumValue = 0.0f, float maximumValue = 0.0f);
+	BlockDefinition(const std::string& defaultValue = "", const float minimumValue = 0.0f, const float maximumValue = 0.0f);
 	static BlockDefinition blockDefinitionDefault;
 
-	std::string& GetDefaultValue() { return defaultValue; };
-	float GetMinimumValue() { return minimumValue; };
-	float GetMaximumValue() { return maximumValue; };
-	void SetDefaultValue(std::string value) { defaultValue = value; };
-	void SetMinimumValue(float value) { minimumValue = value; };
-	void SetMaximumValue(float value) { maximumValue = value; };
+	[[nodiscard]] const std::string& GetDefaultValue() const { return m_DefaultValue; }
+	[[nodiscard]] float GetMinimumValue() const noexcept { return m_MinimumValue; }
+	[[nodiscard]] float GetMaximumValue() const noexcept { return m_MaximumValue; }
+	void SetDefaultValue(const std::string& value) { m_DefaultValue = value; }
+	void SetMinimumValue(const float value) noexcept { m_MinimumValue = value; }
+	void SetMaximumValue(const float value) noexcept { m_MaximumValue = value; }
+
 private:
-	std::string defaultValue;
-	float minimumValue;
-	float maximumValue;
+	std::string m_DefaultValue;
+	float m_MinimumValue;
+	float m_MaximumValue;
 };
 
 #endif  //!__BLOCKDEFINITION__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/Action.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/Action.cpp
@@ -1,46 +1,34 @@
 #include "Action.h"
 #include "Amf3.h"
 
-Action::Action() {	
-	type = "";
-	valueParameterName = "";
-	valueParameterString = "";
-	valueParameterDouble = 0.0;
-}
-
-Action::Action(AMFArrayValue* arguments) {
-	type = "";
-	valueParameterName = "";
-	valueParameterString = "";
-	valueParameterDouble = 0.0;
-	for (auto& [paramName, paramValue] : arguments->GetAssociative()) {
+Action::Action(const AMFArrayValue* arguments) {
+	for (const auto& [paramName, paramValue] : arguments->GetAssociative()) {
 		if (paramName == "Type") {
 			if (paramValue->GetValueType() != eAmf::String) continue;
-			type = static_cast<AMFStringValue*>(paramValue)->GetValue();
+			m_Type = static_cast<AMFStringValue*>(paramValue)->GetValue();
 		} else {
-			valueParameterName = paramName;
+			m_ValueParameterName = paramName;
 			// Message is the only known string parameter
-			if (valueParameterName == "Message") {
+			if (m_ValueParameterName == "Message") {
 				if (paramValue->GetValueType() != eAmf::String) continue;
-				valueParameterString = static_cast<AMFStringValue*>(paramValue)->GetValue();
+				m_ValueParameterString = static_cast<AMFStringValue*>(paramValue)->GetValue();
 			} else {
 				if (paramValue->GetValueType() != eAmf::Double) continue;
-				valueParameterDouble = static_cast<AMFDoubleValue*>(paramValue)->GetValue();
+				m_ValueParameterDouble = static_cast<AMFDoubleValue*>(paramValue)->GetValue();
 			}
 		}
 	}
 }
 
 void Action::SendBehaviorBlocksToClient(AMFArrayValue& args) const {
-	auto* actionArgs = args.PushArray();
-	actionArgs->Insert("Type", type);
+	auto* const actionArgs = args.PushArray();
+	actionArgs->Insert("Type", m_Type);
 
-	auto valueParameterName = GetValueParameterName();
-	if (valueParameterName.empty()) return;
+	if (m_ValueParameterName.empty()) return;
 
-	if (valueParameterName == "Message") {
-		actionArgs->Insert(valueParameterName, valueParameterString);
+	if (m_ValueParameterName == "Message") {
+		actionArgs->Insert(m_ValueParameterName, m_ValueParameterString);
 	} else {
-		actionArgs->Insert(valueParameterName, valueParameterDouble);
+		actionArgs->Insert(m_ValueParameterName, m_ValueParameterDouble);
 	}
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/Action.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/Action.h
@@ -11,19 +11,20 @@ class AMFArrayValue;
  */
 class Action {
 public:
-	Action();
-	Action(AMFArrayValue* arguments);
-	const std::string& GetType() const { return type; };
-	const std::string& GetValueParameterName() const { return valueParameterName; };
-	const std::string& GetValueParameterString() const { return valueParameterString; };
-	const double GetValueParameterDouble() const { return valueParameterDouble; };
+	Action() = default;
+	Action(const AMFArrayValue* arguments);
+	[[nodiscard]] const std::string& GetType() const { return m_Type; };
+	[[nodiscard]] const std::string& GetValueParameterName() const { return m_ValueParameterName; };
+	[[nodiscard]] const std::string& GetValueParameterString() const { return m_ValueParameterString; };
+	[[nodiscard]] double GetValueParameterDouble() const noexcept { return m_ValueParameterDouble; };
 
 	void SendBehaviorBlocksToClient(AMFArrayValue& args) const;
+
 private:
-	std::string type;
-	std::string valueParameterName;
-	std::string valueParameterString;
-	double valueParameterDouble;
+	double m_ValueParameterDouble{ 0.0 };
+	std::string m_Type{ "" };
+	std::string m_ValueParameterName{ "" };
+	std::string m_ValueParameterString{ "" };
 };
 
 #endif  //!__ACTION__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/ActionContext.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/ActionContext.cpp
@@ -4,28 +4,21 @@
 
 #include "Amf3.h"
 
-ActionContext::ActionContext() {
-	stripId = 0;
-	stateId = BehaviorState::HOME_STATE;
+ActionContext::ActionContext(const AMFArrayValue* arguments, const std::string& customStateKey, const std::string& customStripKey)
+	: m_StripId{ GetStripIdFromArgument(arguments, customStripKey) }
+	, m_StateId{ GetBehaviorStateFromArgument(arguments, customStateKey) } {
 }
 
-ActionContext::ActionContext(AMFArrayValue* arguments, std::string customStateKey, std::string customStripKey) {
-	stripId = 0;
-	stateId = BehaviorState::HOME_STATE;
-	stripId = GetStripIdFromArgument(arguments, customStripKey);
-	stateId = GetBehaviorStateFromArgument(arguments, customStateKey);
-}
-
-BehaviorState ActionContext::GetBehaviorStateFromArgument(AMFArrayValue* arguments, const std::string& key) {
-	auto* stateIDValue = arguments->Get<double>(key);
-	if (!stateIDValue) throw std::invalid_argument("Unable to find behavior state from argument \"" + key + "\"");
+BehaviorState ActionContext::GetBehaviorStateFromArgument(const AMFArrayValue* arguments, const std::string& key) const {
+	const auto* const stateIDValue = arguments->Get<double>(std::string{ key });
+	if (!stateIDValue) throw std::invalid_argument("Unable to find behavior state from argument \"" + std::string{ key } + "\"");
 
 	return static_cast<BehaviorState>(stateIDValue->GetValue());
 }
 
-StripId ActionContext::GetStripIdFromArgument(AMFArrayValue* arguments, const std::string& key) {
-	auto* stripIdValue = arguments->Get<double>(key);
-	if (!stripIdValue) throw std::invalid_argument("Unable to find strip ID from argument \"" + key + "\"");
+StripId ActionContext::GetStripIdFromArgument(const AMFArrayValue* arguments, const std::string& key) const {
+	const auto* const stripIdValue = arguments->Get<double>(std::string{ key });
+	if (!stripIdValue) throw std::invalid_argument("Unable to find strip ID from argument \"" + std::string{ key } + "\"");
 
 	return static_cast<StripId>(stripIdValue->GetValue());
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/ActionContext.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/ActionContext.cpp
@@ -10,15 +10,15 @@ ActionContext::ActionContext(const AMFArrayValue* arguments, const std::string& 
 }
 
 BehaviorState ActionContext::GetBehaviorStateFromArgument(const AMFArrayValue* arguments, const std::string& key) const {
-	const auto* const stateIDValue = arguments->Get<double>(std::string{ key });
-	if (!stateIDValue) throw std::invalid_argument("Unable to find behavior state from argument \"" + std::string{ key } + "\"");
+	const auto* const stateIDValue = arguments->Get<double>(key);
+	if (!stateIDValue) throw std::invalid_argument("Unable to find behavior state from argument \"" + key + "\"");
 
 	return static_cast<BehaviorState>(stateIDValue->GetValue());
 }
 
 StripId ActionContext::GetStripIdFromArgument(const AMFArrayValue* arguments, const std::string& key) const {
-	const auto* const stripIdValue = arguments->Get<double>(std::string{ key });
-	if (!stripIdValue) throw std::invalid_argument("Unable to find strip ID from argument \"" + std::string{ key } + "\"");
+	const auto* const stripIdValue = arguments->Get<double>(key);
+	if (!stripIdValue) throw std::invalid_argument("Unable to find strip ID from argument \"" + key + "\"");
 
 	return static_cast<StripId>(stripIdValue->GetValue());
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/ActionContext.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/ActionContext.h
@@ -4,8 +4,6 @@
 #include "BehaviorStates.h"
 #include "dCommonVars.h"
 
-#include <string_view>
-
 class AMFArrayValue;
 
 /**

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/ActionContext.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/ActionContext.h
@@ -4,6 +4,8 @@
 #include "BehaviorStates.h"
 #include "dCommonVars.h"
 
+#include <string_view>
+
 class AMFArrayValue;
 
 /**
@@ -12,15 +14,16 @@ class AMFArrayValue;
  */
 class ActionContext {
 public:
-	ActionContext();
-	ActionContext(AMFArrayValue* arguments, std::string customStateKey = "stateID", std::string customStripKey = "stripID");
-	const StripId GetStripId() const { return stripId; };
-	const BehaviorState GetStateId() const { return stateId; };
+	ActionContext() noexcept = default;
+	ActionContext(const AMFArrayValue* arguments, const std::string& customStateKey = "stateID", const std::string& customStripKey = "stripID");
+	[[nodiscard]] StripId GetStripId() const noexcept { return m_StripId; };
+	[[nodiscard]] BehaviorState GetStateId() const noexcept { return m_StateId; };
+
 private:
-	BehaviorState GetBehaviorStateFromArgument(AMFArrayValue* arguments, const std::string& key);
-	StripId GetStripIdFromArgument(AMFArrayValue* arguments, const std::string& key);
-	StripId stripId;
-	BehaviorState stateId;
+	[[nodiscard]] BehaviorState GetBehaviorStateFromArgument(const AMFArrayValue* arguments, const std::string& key) const;
+	[[nodiscard]] StripId GetStripIdFromArgument(const AMFArrayValue* arguments, const std::string& key) const;
+	StripId m_StripId{ 0 };
+	BehaviorState m_StateId{ BehaviorState::HOME_STATE };
 };
 
 #endif  //!__ACTIONCONTEXT__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/AddActionMessage.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/AddActionMessage.cpp
@@ -1,13 +1,14 @@
 #include "AddActionMessage.h"
 
-AddActionMessage::AddActionMessage(AMFArrayValue* arguments) : BehaviorMessageBase(arguments) {
-	actionContext = ActionContext(arguments);
-	actionIndex = GetActionIndexFromArgument(arguments);
+AddActionMessage::AddActionMessage(const AMFArrayValue* arguments)
+	: BehaviorMessageBase{ arguments }
+	, m_ActionIndex{ GetActionIndexFromArgument(arguments) }
+	, m_ActionContext{ arguments } {
 
-	auto* actionValue = arguments->GetArray("action");
+	const auto* const actionValue = arguments->GetArray("action");
 	if (!actionValue) return;
 
-	action = Action(actionValue);
+	m_Action = Action{ actionValue };
 
-	LOG_DEBUG("actionIndex %i stripId %i stateId %i type %s valueParameterName %s valueParameterString %s valueParameterDouble %f behaviorId %i", actionIndex, actionContext.GetStripId(), actionContext.GetStateId(), action.GetType().c_str(), action.GetValueParameterName().c_str(), action.GetValueParameterString().c_str(), action.GetValueParameterDouble(), behaviorId);
+	LOG_DEBUG("actionIndex %i stripId %i stateId %i type %s valueParameterName %s valueParameterString %s valueParameterDouble %f m_BehaviorId %i", m_ActionIndex, m_ActionContext.GetStripId(), m_ActionContext.GetStateId(), m_Action.GetType().c_str(), m_Action.GetValueParameterName().c_str(), m_Action.GetValueParameterString().c_str(), m_Action.GetValueParameterDouble(), m_BehaviorId);
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/AddActionMessage.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/AddActionMessage.h
@@ -13,14 +13,18 @@ class AMFArrayValue;
  */
 class AddActionMessage : public BehaviorMessageBase {
 public:
-	AddActionMessage(AMFArrayValue* arguments);
-	int32_t GetActionIndex() const { return actionIndex; };
-	Action GetAction() const { return action; };
-	ActionContext GetActionContext() const { return actionContext; };
+	AddActionMessage(const AMFArrayValue* arguments);
+
+	[[nodiscard]] int32_t GetActionIndex() const noexcept { return m_ActionIndex; };
+
+	[[nodiscard]] const Action& GetAction() const noexcept { return m_Action; };
+
+	[[nodiscard]] const ActionContext& GetActionContext() const noexcept { return m_ActionContext; };
+
 private:
-	int32_t actionIndex = -1;
-	ActionContext actionContext;
-	Action action;
+	int32_t m_ActionIndex{ -1 };
+	ActionContext m_ActionContext;
+	Action m_Action;
 };
 
 #endif  //!__ADDACTIONMESSAGE__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/AddMessage.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/AddMessage.cpp
@@ -1,11 +1,9 @@
 #include "AddMessage.h"
 
-AddMessage::AddMessage(AMFArrayValue* arguments) : BehaviorMessageBase(arguments) {
-	behaviorIndex = 0;
-	auto* behaviorIndexValue = arguments->Get<double>("BehaviorIndex");
-
+AddMessage::AddMessage(const AMFArrayValue* arguments) : BehaviorMessageBase{ arguments } {
+	const auto* const behaviorIndexValue = arguments->Get<double>("BehaviorIndex");
 	if (!behaviorIndexValue) return;
 
-	behaviorIndex = static_cast<uint32_t>(behaviorIndexValue->GetValue());
-	LOG_DEBUG("behaviorId %i index %i", behaviorId, behaviorIndex);
+	m_BehaviorIndex = static_cast<uint32_t>(behaviorIndexValue->GetValue());
+	LOG_DEBUG("behaviorId %i index %i", m_BehaviorId, m_BehaviorIndex);
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/AddMessage.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/AddMessage.h
@@ -9,10 +9,11 @@
  */
 class AddMessage : public BehaviorMessageBase {
 public:
-	AddMessage(AMFArrayValue* arguments);
-	const uint32_t GetBehaviorIndex() const { return behaviorIndex; };
+	AddMessage(const AMFArrayValue* arguments);
+	[[nodiscard]] uint32_t GetBehaviorIndex() const noexcept { return m_BehaviorIndex; };
+
 private:
-	uint32_t behaviorIndex;
+	uint32_t m_BehaviorIndex{ 0 };
 };
 
 #endif  //!__ADDMESSAGE__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/AddStripMessage.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/AddStripMessage.cpp
@@ -2,27 +2,24 @@
 
 #include "Action.h"
 
-AddStripMessage::AddStripMessage(AMFArrayValue* const arguments) : BehaviorMessageBase{ arguments } {
-	actionContext = ActionContext(arguments);
-	position = StripUiPosition(arguments);
+AddStripMessage::AddStripMessage(const AMFArrayValue* arguments)
+	: BehaviorMessageBase{ arguments }
+	, m_Position{ arguments }
+	, m_ActionContext{ arguments } {
 
-	auto* strip = arguments->GetArray("strip");
+	const auto* const strip = arguments->GetArray("strip");
 	if (!strip) return;
 
-	auto* actions = strip->GetArray("actions");
+	const auto* const actions = strip->GetArray("actions");
 	if (!actions) return;
 
 	for (uint32_t actionNumber = 0; actionNumber < actions->GetDense().size(); actionNumber++) {
-		auto* actionValue = actions->GetArray(actionNumber);
+		const auto* const actionValue = actions->GetArray(actionNumber);
 		if (!actionValue) continue;
 
-		actionsToAdd.push_back(Action(actionValue));
+		m_ActionsToAdd.push_back(Action{ actionValue });
 
-		LOG_DEBUG("xPosition %f yPosition %f stripId %i stateId %i behaviorId %i t %s valueParameterName %s valueParameterString %s valueParameterDouble %f", position.GetX(), position.GetY(), actionContext.GetStripId(), actionContext.GetStateId(), behaviorId, actionsToAdd.back().GetType().c_str(), actionsToAdd.back().GetValueParameterName().c_str(), actionsToAdd.back().GetValueParameterString().c_str(), actionsToAdd.back().GetValueParameterDouble());
+		LOG_DEBUG("xPosition %f yPosition %f stripId %i stateId %i behaviorId %i t %s valueParameterName %s valueParameterString %s valueParameterDouble %f", m_Position.GetX(), m_Position.GetY(), m_ActionContext.GetStripId(), m_ActionContext.GetStateId(), m_BehaviorId, m_ActionsToAdd.back().GetType().c_str(), m_ActionsToAdd.back().GetValueParameterName().c_str(), m_ActionsToAdd.back().GetValueParameterString().c_str(), m_ActionsToAdd.back().GetValueParameterDouble());
 	}
-	LOG_DEBUG("number of actions %i", actionsToAdd.size());
-}
-
-std::vector<Action> AddStripMessage::GetActionsToAdd() const {
-	return actionsToAdd;
+	LOG_DEBUG("number of actions %i", m_ActionsToAdd.size());
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/AddStripMessage.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/AddStripMessage.cpp
@@ -17,7 +17,7 @@ AddStripMessage::AddStripMessage(const AMFArrayValue* arguments)
 		const auto* const actionValue = actions->GetArray(actionNumber);
 		if (!actionValue) continue;
 
-		m_ActionsToAdd.push_back(Action{ actionValue });
+		m_ActionsToAdd.emplace_back(actionValue);
 
 		LOG_DEBUG("xPosition %f yPosition %f stripId %i stateId %i behaviorId %i t %s valueParameterName %s valueParameterString %s valueParameterDouble %f", m_Position.GetX(), m_Position.GetY(), m_ActionContext.GetStripId(), m_ActionContext.GetStateId(), m_BehaviorId, m_ActionsToAdd.back().GetType().c_str(), m_ActionsToAdd.back().GetValueParameterName().c_str(), m_ActionsToAdd.back().GetValueParameterString().c_str(), m_ActionsToAdd.back().GetValueParameterDouble());
 	}

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/AddStripMessage.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/AddStripMessage.h
@@ -18,14 +18,18 @@ class AMFArrayValue;
  */
 class AddStripMessage : public BehaviorMessageBase {
 public:
-	AddStripMessage(AMFArrayValue* const arguments);
-	StripUiPosition GetPosition() const { return position; };
-	ActionContext GetActionContext() const { return actionContext; };
-	std::vector<Action> GetActionsToAdd() const;
+	AddStripMessage(const AMFArrayValue* arguments);
+
+	[[nodiscard]] const StripUiPosition& GetPosition() const noexcept { return m_Position; }
+
+	[[nodiscard]] const ActionContext& GetActionContext() const noexcept { return m_ActionContext; }
+
+	[[nodiscard]] const std::vector<Action>& GetActionsToAdd() const noexcept { return m_ActionsToAdd; }
+
 private:
-	StripUiPosition position;
-	ActionContext actionContext;
-	std::vector<Action> actionsToAdd;
+	StripUiPosition m_Position;
+	ActionContext m_ActionContext;
+	std::vector<Action> m_ActionsToAdd;
 };
 
 #endif  //!__ADDSTRIPMESSAGE__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/BehaviorMessageBase.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/BehaviorMessageBase.cpp
@@ -4,25 +4,22 @@
 #include "BehaviorStates.h"
 #include "dCommonVars.h"
 
-BehaviorMessageBase::BehaviorMessageBase(AMFArrayValue* arguments) {
-	this->behaviorId = GetBehaviorIdFromArgument(arguments);
-}
-
-int32_t BehaviorMessageBase::GetBehaviorIdFromArgument(AMFArrayValue* const arguments) {
-	const char* const key = "BehaviorID";
+int32_t BehaviorMessageBase::GetBehaviorIdFromArgument(const AMFArrayValue* arguments) {
+	static constexpr const char* key = "BehaviorID";
 	const auto* const behaviorIDValue = arguments->Get<std::string>(key);
+	int32_t behaviorId = DefaultBehaviorId;
 
 	if (behaviorIDValue && behaviorIDValue->GetValueType() == eAmf::String) {
-		this->behaviorId =
-			GeneralUtils::TryParse<int32_t>(behaviorIDValue->GetValue()).value_or(this->behaviorId);
+		behaviorId =
+			GeneralUtils::TryParse<int32_t>(behaviorIDValue->GetValue()).value_or(behaviorId);
 	} else if (arguments->Get(key) && arguments->Get(key)->GetValueType() != eAmf::Undefined) {
 		throw std::invalid_argument("Unable to find behavior ID");
 	}
 
-	return this->behaviorId;
+	return behaviorId;
 }
 
-int32_t BehaviorMessageBase::GetActionIndexFromArgument(AMFArrayValue* const arguments, const std::string& keyName) const {
+int32_t BehaviorMessageBase::GetActionIndexFromArgument(const AMFArrayValue* arguments, const std::string& keyName) const {
 	const auto* const actionIndexAmf = arguments->Get<double>(keyName);
 	if (!actionIndexAmf) throw std::invalid_argument("Unable to find actionIndex");
 

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/BehaviorMessageBase.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/BehaviorMessageBase.h
@@ -15,14 +15,15 @@ enum class BehaviorState : uint32_t;
  */
 class BehaviorMessageBase {
 public:
-	static constexpr int32_t DefaultBehaviorId = -1;
-	[[nodiscard]] int32_t GetBehaviorId() const { return behaviorId; };
-	[[nodiscard]] bool IsDefaultBehaviorId() { return behaviorId == DefaultBehaviorId; };
-	BehaviorMessageBase(AMFArrayValue* const arguments);
+	static constexpr int32_t DefaultBehaviorId{ -1 };
+	BehaviorMessageBase(const AMFArrayValue* arguments) : m_BehaviorId{ GetBehaviorIdFromArgument(arguments) } {}
+	[[nodiscard]] int32_t GetBehaviorId() const noexcept { return m_BehaviorId; }
+	[[nodiscard]] bool IsDefaultBehaviorId() const noexcept { return m_BehaviorId == DefaultBehaviorId; }
+
 protected:
-	[[nodiscard]] int32_t GetBehaviorIdFromArgument(AMFArrayValue* const arguments);
-	[[nodiscard]] int32_t GetActionIndexFromArgument(AMFArrayValue* const arguments, const std::string& keyName = "actionIndex") const;
-	int32_t behaviorId = DefaultBehaviorId;
+	[[nodiscard]] int32_t GetBehaviorIdFromArgument(const AMFArrayValue* arguments);
+	[[nodiscard]] int32_t GetActionIndexFromArgument(const AMFArrayValue* arguments, const std::string& keyName = "actionIndex") const;
+	int32_t m_BehaviorId{ DefaultBehaviorId };
 };
 
 #endif  //!__BEHAVIORMESSAGEBASE__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/MergeStripsMessage.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/MergeStripsMessage.cpp
@@ -1,11 +1,11 @@
 #include "MergeStripsMessage.h"
 
-MergeStripsMessage::MergeStripsMessage(AMFArrayValue* arguments) : BehaviorMessageBase(arguments) {
-	sourceActionContext = ActionContext(arguments, "srcStateID", "srcStripID");
+MergeStripsMessage::MergeStripsMessage(const AMFArrayValue* arguments)
+	: BehaviorMessageBase{ arguments }
+	, m_DstActionIndex{ GetActionIndexFromArgument(arguments, "dstActionIndex") }
+	, m_SourceActionContext{ arguments, "srcStateID", "srcStripID" }
+	, m_DestinationActionContext{ arguments, "dstStateID", "dstStripID" } {
 
-	destinationActionContext = ActionContext(arguments, "dstStateID", "dstStripID");
-	dstActionIndex = GetActionIndexFromArgument(arguments, "dstActionIndex");
-
-	LOG_DEBUG("srcstripId %i dststripId %i srcstateId %i dststateId %i dstactionIndex %i behaviorId %i", sourceActionContext.GetStripId(), destinationActionContext.GetStripId(), sourceActionContext.GetStateId(), destinationActionContext.GetStateId(), dstActionIndex, behaviorId);
+	LOG_DEBUG("srcstripId %i dststripId %i srcstateId %i dststateId %i dstactionIndex %i behaviorId %i", m_SourceActionContext.GetStripId(), m_DestinationActionContext.GetStripId(), m_SourceActionContext.GetStateId(), m_DestinationActionContext.GetStateId(), m_DstActionIndex, m_BehaviorId);
 }
 

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/MergeStripsMessage.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/MergeStripsMessage.h
@@ -13,17 +13,23 @@ class AMFArrayValue;
  */
 class MergeStripsMessage : public BehaviorMessageBase {
 public:
-	MergeStripsMessage(AMFArrayValue* arguments);
-	int32_t GetDstActionIndex() const { return dstActionIndex; };
-	ActionContext GetSourceActionContext() const { return sourceActionContext; };
-	ActionContext GetDestinationActionContext() const { return destinationActionContext; };
-	const std::vector<Action>& GetMigratedActions() const { return migratedActions; };
-	void SetMigratedActions(std::vector<Action>::const_iterator start, std::vector<Action>::const_iterator end) { migratedActions.assign(start, end); };
+	MergeStripsMessage(const AMFArrayValue* arguments);
+
+	[[nodiscard]] int32_t GetDstActionIndex() const noexcept { return m_DstActionIndex; }
+
+	[[nodiscard]] const ActionContext& GetSourceActionContext() const noexcept { return m_SourceActionContext; }
+
+	[[nodiscard]] const ActionContext& GetDestinationActionContext() const noexcept { return m_DestinationActionContext; }
+
+	[[nodiscard]] const std::vector<Action>& GetMigratedActions() const noexcept { return m_MigratedActions; }
+
+	void SetMigratedActions(std::vector<Action>::const_iterator start, std::vector<Action>::const_iterator end) { m_MigratedActions.assign(start, end); };
+
 private:
-	std::vector<Action> migratedActions;
-	ActionContext sourceActionContext;
-	ActionContext destinationActionContext;
-	int32_t dstActionIndex;
+	int32_t m_DstActionIndex;
+	std::vector<Action> m_MigratedActions;
+	ActionContext m_SourceActionContext;
+	ActionContext m_DestinationActionContext;
 };
 
 #endif  //!__MERGESTRIPSMESSAGE__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/MigrateActionsMessage.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/MigrateActionsMessage.cpp
@@ -1,11 +1,11 @@
 #include "MigrateActionsMessage.h"
 
-MigrateActionsMessage::MigrateActionsMessage(AMFArrayValue* arguments) : BehaviorMessageBase(arguments) {
-	sourceActionContext = ActionContext(arguments, "srcStateID", "srcStripID");
-	srcActionIndex = GetActionIndexFromArgument(arguments, "srcActionIndex");
+MigrateActionsMessage::MigrateActionsMessage(const AMFArrayValue* arguments)
+	: BehaviorMessageBase{ arguments }
+	, m_SrcActionIndex{ GetActionIndexFromArgument(arguments, "srcActionIndex") }
+	, m_DstActionIndex{ GetActionIndexFromArgument(arguments, "dstActionIndex") }
+	, m_SourceActionContext{ arguments, "srcStateID", "srcStripID" }
+	, m_DestinationActionContext{ arguments, "dstStateID", "dstStripID" } {
 
-	destinationActionContext = ActionContext(arguments, "dstStateID", "dstStripID");
-	dstActionIndex = GetActionIndexFromArgument(arguments, "dstActionIndex");
-
-	LOG_DEBUG("srcactionIndex %i dstactionIndex %i srcstripId %i dststripId %i srcstateId %i dststateId %i behaviorId %i", srcActionIndex, dstActionIndex, sourceActionContext.GetStripId(), destinationActionContext.GetStripId(), sourceActionContext.GetStateId(), destinationActionContext.GetStateId(), behaviorId);
+	LOG_DEBUG("srcactionIndex %i dstactionIndex %i srcstripId %i dststripId %i srcstateId %i dststateId %i behaviorId %i", m_SrcActionIndex, m_DstActionIndex, m_SourceActionContext.GetStripId(), m_DestinationActionContext.GetStripId(), m_SourceActionContext.GetStateId(), m_DestinationActionContext.GetStateId(), m_BehaviorId);
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/MigrateActionsMessage.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/MigrateActionsMessage.h
@@ -13,19 +13,26 @@ class AMFArrayValue;
  */
 class MigrateActionsMessage : public BehaviorMessageBase {
 public:
-	MigrateActionsMessage(AMFArrayValue* arguments);
-	int32_t GetSrcActionIndex() const { return srcActionIndex; };
-	int32_t GetDstActionIndex() const { return dstActionIndex; };
-	ActionContext GetSourceActionContext() const { return sourceActionContext; };
-	ActionContext GetDestinationActionContext() const { return destinationActionContext; };
-	const std::vector<Action>& GetMigratedActions() const { return migratedActions; };
-	void SetMigratedActions(std::vector<Action>::const_iterator start, std::vector<Action>::const_iterator end) { migratedActions.assign(start, end); };
+	MigrateActionsMessage(const AMFArrayValue* arguments);
+
+	[[nodiscard]] int32_t GetSrcActionIndex() const noexcept { return m_SrcActionIndex; }
+
+	[[nodiscard]] int32_t GetDstActionIndex() const noexcept { return m_DstActionIndex; }
+
+	[[nodiscard]] const ActionContext& GetSourceActionContext() const noexcept { return m_SourceActionContext; }
+
+	[[nodiscard]] const ActionContext& GetDestinationActionContext() const noexcept { return m_DestinationActionContext; }
+
+	[[nodiscard]] const std::vector<Action>& GetMigratedActions() const noexcept { return m_MigratedActions; }
+
+	void SetMigratedActions(std::vector<Action>::const_iterator start, std::vector<Action>::const_iterator end) { m_MigratedActions.assign(start, end); }
+
 private:
-	std::vector<Action> migratedActions;
-	ActionContext sourceActionContext;
-	ActionContext destinationActionContext;
-	int32_t srcActionIndex;
-	int32_t dstActionIndex;
+	int32_t m_SrcActionIndex;
+	int32_t m_DstActionIndex;
+	std::vector<Action> m_MigratedActions;
+	ActionContext m_SourceActionContext;
+	ActionContext m_DestinationActionContext;
 };
 
 #endif  //!__MIGRATEACTIONSMESSAGE__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/MoveToInventoryMessage.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/MoveToInventoryMessage.cpp
@@ -1,9 +1,9 @@
 #include "MoveToInventoryMessage.h"
 
-MoveToInventoryMessage::MoveToInventoryMessage(AMFArrayValue* arguments) : BehaviorMessageBase(arguments) {
-	auto* behaviorIndexValue = arguments->Get<double>("BehaviorIndex");
+MoveToInventoryMessage::MoveToInventoryMessage(const AMFArrayValue* arguments) : BehaviorMessageBase{ arguments } {
+	const auto* const behaviorIndexValue = arguments->Get<double>("BehaviorIndex");
 	if (!behaviorIndexValue) return;
 
-	behaviorIndex = static_cast<uint32_t>(behaviorIndexValue->GetValue());
-	LOG_DEBUG("behaviorId %i behaviorIndex %i", behaviorId, behaviorIndex);
+	m_BehaviorIndex = static_cast<uint32_t>(behaviorIndexValue->GetValue());
+	LOG_DEBUG("behaviorId %i behaviorIndex %i", m_BehaviorId, m_BehaviorIndex);
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/MoveToInventoryMessage.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/MoveToInventoryMessage.h
@@ -7,15 +7,15 @@ class AMFArrayValue;
 
 /**
  * @brief Sent when a player moves a Behavior A at position B to their inventory. 
- * 
  */
 #pragma warning("This Control Behavior Message does not have a test yet. Non-developers can ignore this warning.")
 class MoveToInventoryMessage : public BehaviorMessageBase {
 public:
-	MoveToInventoryMessage(AMFArrayValue* arguments);
-	const uint32_t GetBehaviorIndex() const { return behaviorIndex; };
+	MoveToInventoryMessage(const AMFArrayValue* arguments);
+	[[nodiscard]] uint32_t GetBehaviorIndex() const noexcept { return m_BehaviorIndex; };
+
 private:
-	uint32_t behaviorIndex;
+	uint32_t m_BehaviorIndex;
 };
 
 #endif  //!__MOVETOINVENTORYMESSAGE__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/RearrangeStripMessage.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/RearrangeStripMessage.cpp
@@ -1,10 +1,10 @@
 #include "RearrangeStripMessage.h"
 
-RearrangeStripMessage::RearrangeStripMessage(AMFArrayValue* arguments) : BehaviorMessageBase(arguments) {
-	actionContext = ActionContext(arguments);
-	srcActionIndex = GetActionIndexFromArgument(arguments, "srcActionIndex");
+RearrangeStripMessage::RearrangeStripMessage(const AMFArrayValue* arguments)
+	: BehaviorMessageBase{ arguments }
+	, m_SrcActionIndex{ GetActionIndexFromArgument(arguments, "srcActionIndex") }
+	, m_DstActionIndex{ GetActionIndexFromArgument(arguments, "dstActionIndex") }
+	, m_ActionContext{ arguments } {
 
-	dstActionIndex = GetActionIndexFromArgument(arguments, "dstActionIndex");
-
-	LOG_DEBUG("srcactionIndex %i dstactionIndex %i stripId %i behaviorId %i stateId %i", srcActionIndex, dstActionIndex, actionContext.GetStripId(), behaviorId, actionContext.GetStateId());
+	LOG_DEBUG("srcactionIndex %i dstactionIndex %i stripId %i behaviorId %i stateId %i", m_SrcActionIndex, m_DstActionIndex, m_ActionContext.GetStripId(), m_BehaviorId, m_ActionContext.GetStateId());
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/RearrangeStripMessage.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/RearrangeStripMessage.h
@@ -10,14 +10,17 @@
  */
 class RearrangeStripMessage : public BehaviorMessageBase {
 public:
-	RearrangeStripMessage(AMFArrayValue* arguments);
-	int32_t GetSrcActionIndex() const { return srcActionIndex; };
-	int32_t GetDstActionIndex() const { return dstActionIndex; };
-	ActionContext GetActionContext() const { return actionContext; };
+	RearrangeStripMessage(const AMFArrayValue* arguments);
+
+	[[nodiscard]] int32_t GetSrcActionIndex() const noexcept { return m_SrcActionIndex; }
+	[[nodiscard]] int32_t GetDstActionIndex() const noexcept { return m_DstActionIndex; }
+
+	[[nodiscard]] const ActionContext& GetActionContext() const noexcept { return m_ActionContext; }
+
 private:
-	ActionContext actionContext;
-	int32_t srcActionIndex;
-	int32_t dstActionIndex;
+	int32_t m_SrcActionIndex;
+	int32_t m_DstActionIndex;
+	ActionContext m_ActionContext;
 };
 
 #endif  //!__REARRANGESTRIPMESSAGE__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/RemoveActionsMessage.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/RemoveActionsMessage.cpp
@@ -1,8 +1,9 @@
 #include "RemoveActionsMessage.h"
 
-RemoveActionsMessage::RemoveActionsMessage(AMFArrayValue* arguments) : BehaviorMessageBase(arguments) {
-	actionContext = ActionContext(arguments);
-	actionIndex = GetActionIndexFromArgument(arguments);
+RemoveActionsMessage::RemoveActionsMessage(const AMFArrayValue* arguments)
+	: BehaviorMessageBase{ arguments }
+	, m_ActionIndex{ GetActionIndexFromArgument(arguments) }
+	, m_ActionContext{ arguments } {
 
-	LOG_DEBUG("behaviorId %i actionIndex %i stripId %i stateId %i", behaviorId, actionIndex, actionContext.GetStripId(), actionContext.GetStateId());
+	LOG_DEBUG("behaviorId %i actionIndex %i stripId %i stateId %i", m_BehaviorId, m_ActionIndex, m_ActionContext.GetStripId(), m_ActionContext.GetStateId());
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/RemoveActionsMessage.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/RemoveActionsMessage.h
@@ -12,12 +12,15 @@ class AMFArrayValue;
  */
 class RemoveActionsMessage : public BehaviorMessageBase {
 public:
-	RemoveActionsMessage(AMFArrayValue* arguments);
-	int32_t GetActionIndex() const { return actionIndex; };
-	ActionContext GetActionContext() const { return actionContext; };
+	RemoveActionsMessage(const AMFArrayValue* arguments);
+
+	[[nodiscard]] int32_t GetActionIndex() const noexcept { return m_ActionIndex; }
+
+	[[nodiscard]] const ActionContext& GetActionContext() const noexcept { return m_ActionContext; }
+
 private:
-	ActionContext actionContext;
-	int32_t actionIndex;
+	int32_t m_ActionIndex;
+	ActionContext m_ActionContext;
 };
 
 #endif  //!__REMOVEACTIONSMESSAGE__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/RemoveStripMessage.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/RemoveStripMessage.cpp
@@ -1,7 +1,8 @@
 #include "RemoveStripMessage.h"
 
-RemoveStripMessage::RemoveStripMessage(AMFArrayValue* arguments) : BehaviorMessageBase(arguments) {
-	actionContext = ActionContext(arguments);
+RemoveStripMessage::RemoveStripMessage(const AMFArrayValue* arguments)
+	: BehaviorMessageBase{ arguments }
+	, m_ActionContext{ arguments } {
 
-	LOG_DEBUG("stripId %i stateId %i behaviorId %i", actionContext.GetStripId(), actionContext.GetStateId(), behaviorId);
+	LOG_DEBUG("stripId %i stateId %i behaviorId %i", m_ActionContext.GetStripId(), m_ActionContext.GetStateId(), m_BehaviorId);
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/RemoveStripMessage.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/RemoveStripMessage.h
@@ -10,10 +10,12 @@
  */
 class RemoveStripMessage : public BehaviorMessageBase {
 public:
-	RemoveStripMessage(AMFArrayValue* arguments);
-	ActionContext GetActionContext() const { return actionContext; };
+	RemoveStripMessage(const AMFArrayValue* arguments);
+	
+	const ActionContext& GetActionContext() const noexcept { return m_ActionContext; }
+
 private:
-	ActionContext actionContext;
+	ActionContext m_ActionContext;
 };
 
 #endif  //!__REMOVESTRIPMESSAGE__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/RenameMessage.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/RenameMessage.cpp
@@ -1,9 +1,9 @@
 #include "RenameMessage.h"
 
-RenameMessage::RenameMessage(AMFArrayValue* arguments) : BehaviorMessageBase(arguments) {
-	auto* nameAmf = arguments->Get<std::string>("Name");
+RenameMessage::RenameMessage(const AMFArrayValue* arguments) : BehaviorMessageBase{ arguments } {
+	const auto* const nameAmf = arguments->Get<std::string>("Name");
 	if (!nameAmf) return;
 
-	name = nameAmf->GetValue();
-	LOG_DEBUG("behaviorId %i n %s", behaviorId, name.c_str());
+	m_Name = nameAmf->GetValue();
+	LOG_DEBUG("behaviorId %i n %s", m_BehaviorId, m_Name.c_str());
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/RenameMessage.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/RenameMessage.h
@@ -7,14 +7,14 @@ class AMFArrayValue;
 
 /**
  * @brief Sent when a player renames this behavior
- * 
  */
 class RenameMessage : public BehaviorMessageBase {
 public:
-	RenameMessage(AMFArrayValue* arguments);
-	const std::string& GetName() const { return name; };
+	RenameMessage(const AMFArrayValue* arguments);
+	[[nodiscard]] const std::string& GetName() const { return m_Name; };
+
 private:
-	std::string name;
+	std::string m_Name;
 };
 
 #endif  //!__RENAMEMESSAGE__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/SplitStripMessage.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/SplitStripMessage.cpp
@@ -1,11 +1,11 @@
 #include "SplitStripMessage.h"
 
-SplitStripMessage::SplitStripMessage(AMFArrayValue* arguments) : BehaviorMessageBase(arguments) {
-	sourceActionContext = ActionContext(arguments, "srcStateID", "srcStripID");
-	srcActionIndex = GetActionIndexFromArgument(arguments, "srcActionIndex");
+SplitStripMessage::SplitStripMessage(const AMFArrayValue* arguments)
+	: BehaviorMessageBase{ arguments }
+	, m_SrcActionIndex{ GetActionIndexFromArgument(arguments, "srcActionIndex") }
+	, m_SourceActionContext{ arguments, "srcStateID", "srcStripID" }
+	, m_DestinationActionContext{ arguments, "dstStateID", "dstStripID" }
+	, m_DestinationPosition{ arguments, "dstStripUI" } {
 
-	destinationActionContext = ActionContext(arguments, "dstStateID", "dstStripID");
-	destinationPosition = StripUiPosition(arguments, "dstStripUI");
-
-	LOG_DEBUG("behaviorId %i xPosition %f yPosition %f sourceStrip %i destinationStrip %i sourceState %i destinationState %i srcActindex %i", behaviorId, destinationPosition.GetX(), destinationPosition.GetY(), sourceActionContext.GetStripId(), destinationActionContext.GetStripId(), sourceActionContext.GetStateId(), destinationActionContext.GetStateId(), srcActionIndex);
+	LOG_DEBUG("behaviorId %i xPosition %f yPosition %f sourceStrip %i destinationStrip %i sourceState %i destinationState %i srcActindex %i", m_BehaviorId, m_DestinationPosition.GetX(), m_DestinationPosition.GetY(), m_SourceActionContext.GetStripId(), m_DestinationActionContext.GetStripId(), m_SourceActionContext.GetStateId(), m_DestinationActionContext.GetStateId(), m_SrcActionIndex);
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/SplitStripMessage.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/SplitStripMessage.h
@@ -14,20 +14,27 @@ class AMFArrayValue;
  */
 class SplitStripMessage : public BehaviorMessageBase {
 public:
-	SplitStripMessage(AMFArrayValue* arguments);
-	ActionContext GetSourceActionContext() const { return sourceActionContext; };
-	ActionContext GetDestinationActionContext() const { return destinationActionContext; };
-	int32_t GetSrcActionIndex() const { return srcActionIndex; };
-	StripUiPosition GetPosition() const { return destinationPosition; };
-	const std::vector<Action>& GetTransferredActions() const { return transferredActions; };
-	void SetTransferredActions(std::vector<Action>::const_iterator begin, std::vector<Action>::const_iterator end) { transferredActions.assign(begin, end); };
-private:
-	ActionContext sourceActionContext;
-	ActionContext destinationActionContext;
-	int32_t srcActionIndex;
-	StripUiPosition destinationPosition;
+	SplitStripMessage(const AMFArrayValue* arguments);
+	
+	[[nodiscard]] int32_t GetSrcActionIndex() const noexcept { return m_SrcActionIndex; }
 
-	std::vector<Action> transferredActions;
+	[[nodiscard]] const ActionContext& GetSourceActionContext() const noexcept { return m_SourceActionContext; }
+
+	[[nodiscard]] const ActionContext& GetDestinationActionContext() const noexcept { return m_DestinationActionContext; }
+
+	[[nodiscard]] const StripUiPosition& GetPosition() const noexcept { return m_DestinationPosition; }
+	
+	[[nodiscard]] const std::vector<Action>& GetTransferredActions() const noexcept { return m_TransferredActions; }
+
+	void SetTransferredActions(std::vector<Action>::const_iterator begin, std::vector<Action>::const_iterator end) { m_TransferredActions.assign(begin, end); };
+
+private:
+	int32_t m_SrcActionIndex;
+	ActionContext m_SourceActionContext;
+	ActionContext m_DestinationActionContext;
+	StripUiPosition m_DestinationPosition;
+
+	std::vector<Action> m_TransferredActions;
 };
 
 #endif  //!__SPLITSTRIPMESSAGE__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/StripUiPosition.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/StripUiPosition.cpp
@@ -2,27 +2,22 @@
 
 #include "Amf3.h"
 
-StripUiPosition::StripUiPosition() {
-	xPosition = 0.0;
-	yPosition = 0.0;
-}
-
-StripUiPosition::StripUiPosition(AMFArrayValue* arguments, std::string uiKeyName) {
-	xPosition = 0.0;
-	yPosition = 0.0;
-	auto* uiArray = arguments->GetArray(uiKeyName);
+StripUiPosition::StripUiPosition(const AMFArrayValue* arguments, const std::string& uiKeyName) {
+	const auto* const uiArray = arguments->GetArray(uiKeyName);
 	if (!uiArray) return;
 
-	auto* xPositionValue = uiArray->Get<double>("x");
-	auto* yPositionValue = uiArray->Get<double>("y");
-	if (!xPositionValue || !yPositionValue) return;
+	const auto* const xPositionValue = uiArray->Get<double>("x");
+	if (!xPositionValue) return;
 
-	yPosition = yPositionValue->GetValue();
-	xPosition = xPositionValue->GetValue();
+	const auto* const yPositionValue = uiArray->Get<double>("y");
+	if (!yPositionValue) return;
+
+	m_YPosition = yPositionValue->GetValue();
+	m_XPosition = xPositionValue->GetValue();
 }
 
 void StripUiPosition::SendBehaviorBlocksToClient(AMFArrayValue& args) const {
-	auto* uiArgs = args.InsertArray("ui");
-	uiArgs->Insert("x", xPosition);
-	uiArgs->Insert("y", yPosition);
+	auto* const uiArgs = args.InsertArray("ui");
+	uiArgs->Insert("x", m_XPosition);
+	uiArgs->Insert("y", m_YPosition);
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/StripUiPosition.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/StripUiPosition.h
@@ -9,14 +9,15 @@ class AMFArrayValue;
  */
 class StripUiPosition {
 public:
-	StripUiPosition();
-	StripUiPosition(AMFArrayValue* arguments, std::string uiKeyName = "ui");
+	StripUiPosition() noexcept = default;
+	StripUiPosition(const AMFArrayValue* arguments, const std::string& uiKeyName = "ui");
 	void SendBehaviorBlocksToClient(AMFArrayValue& args) const;
-	double GetX() const { return xPosition; };
-	double GetY() const { return yPosition; };
+	[[nodiscard]] double GetX() const noexcept { return m_XPosition; }
+	[[nodiscard]] double GetY() const noexcept { return m_YPosition; }
+
 private:
-	double xPosition;
-	double yPosition;
+	double m_XPosition{ 0.0 };
+	double m_YPosition{ 0.0 };
 };
 
 #endif  //!__STRIPUIPOSITION__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/UpdateActionMessage.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/UpdateActionMessage.cpp
@@ -2,14 +2,15 @@
 
 #include "Action.h"
 
-UpdateActionMessage::UpdateActionMessage(AMFArrayValue* arguments) : BehaviorMessageBase(arguments) {
-	actionContext = ActionContext(arguments);
+UpdateActionMessage::UpdateActionMessage(const AMFArrayValue* arguments)
+	: BehaviorMessageBase{ arguments }
+	, m_ActionIndex{ GetActionIndexFromArgument(arguments) }
+	, m_ActionContext{ arguments } {
 
-	auto* actionValue = arguments->GetArray("action");
+	const auto* const actionValue = arguments->GetArray("action");
 	if (!actionValue) return;
+	
+	m_Action = Action{ actionValue };
 
-	action = Action(actionValue);
-	actionIndex = GetActionIndexFromArgument(arguments);
-
-	LOG_DEBUG("type %s valueParameterName %s valueParameterString %s valueParameterDouble %f behaviorId %i actionIndex %i stripId %i stateId %i", action.GetType().c_str(), action.GetValueParameterName().c_str(), action.GetValueParameterString().c_str(), action.GetValueParameterDouble(), behaviorId, actionIndex, actionContext.GetStripId(), actionContext.GetStateId());
+	LOG_DEBUG("type %s valueParameterName %s valueParameterString %s valueParameterDouble %f behaviorId %i actionIndex %i stripId %i stateId %i", m_Action.GetType().c_str(), m_Action.GetValueParameterName().c_str(), m_Action.GetValueParameterString().c_str(), m_Action.GetValueParameterDouble(), m_BehaviorId, m_ActionIndex, m_ActionContext.GetStripId(), m_ActionContext.GetStateId());
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/UpdateActionMessage.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/UpdateActionMessage.h
@@ -13,14 +13,18 @@ class AMFArrayValue;
  */
 class UpdateActionMessage : public BehaviorMessageBase {
 public:
-	UpdateActionMessage(AMFArrayValue* arguments);
-	int32_t GetActionIndex() const { return actionIndex; };
-	ActionContext GetActionContext() const { return actionContext; };
-	Action GetAction() const { return action; };
+	UpdateActionMessage(const AMFArrayValue* arguments);
+
+	[[nodiscard]] int32_t GetActionIndex() const noexcept { return m_ActionIndex; }
+
+	[[nodiscard]] const ActionContext& GetActionContext() const noexcept { return m_ActionContext; }
+
+	[[nodiscard]] const Action& GetAction() const noexcept { return m_Action; }
+
 private:
-	int32_t actionIndex;
-	ActionContext actionContext;
-	Action action;
+	int32_t m_ActionIndex;
+	ActionContext m_ActionContext;
+	Action m_Action;
 }; 
 
 #endif  //!__UPDATEACTIONMESSAGE__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/UpdateStripUiMessage.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/UpdateStripUiMessage.cpp
@@ -1,8 +1,9 @@
 #include "UpdateStripUiMessage.h"
 
-UpdateStripUiMessage::UpdateStripUiMessage(AMFArrayValue* arguments) : BehaviorMessageBase(arguments) {
-	position = StripUiPosition(arguments);
-	actionContext = ActionContext(arguments);
+UpdateStripUiMessage::UpdateStripUiMessage(const AMFArrayValue* arguments)
+	: BehaviorMessageBase{ arguments } 
+	, m_Position{ arguments }
+	, m_ActionContext{ arguments } {
 
-	LOG_DEBUG("xPosition %f yPosition %f stripId %i stateId %i behaviorId %i", position.GetX(), position.GetY(), actionContext.GetStripId(), actionContext.GetStateId(), behaviorId);
+	LOG_DEBUG("xPosition %f yPosition %f stripId %i stateId %i behaviorId %i", m_Position.GetX(), m_Position.GetY(), m_ActionContext.GetStripId(), m_ActionContext.GetStateId(), m_BehaviorId);
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviorMessages/UpdateStripUiMessage.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviorMessages/UpdateStripUiMessage.h
@@ -13,12 +13,15 @@ class AMFArrayValue;
  */
 class UpdateStripUiMessage : public BehaviorMessageBase {
 public:
-	UpdateStripUiMessage(AMFArrayValue* arguments);
-	StripUiPosition GetPosition() const { return position; };
-	ActionContext GetActionContext() const { return actionContext; };
+	UpdateStripUiMessage(const AMFArrayValue* arguments);
+
+	[[nodiscard]] const StripUiPosition& GetPosition() const noexcept { return m_Position; };
+
+	[[nodiscard]] const ActionContext& GetActionContext() const noexcept { return m_ActionContext; };
+
 private:
-	StripUiPosition position;
-	ActionContext actionContext;
+	StripUiPosition m_Position;
+	ActionContext m_ActionContext;
 };
 
 #endif  //!__UPDATESTRIPUIMESSAGE__H__

--- a/dGame/dPropertyBehaviors/ControlBehaviors.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviors.cpp
@@ -96,7 +96,7 @@ void ControlBehaviors::UpdateAction(const AMFArrayValue* arguments) {
 }
 
 void ControlBehaviors::ProcessCommand(Entity* modelEntity, AMFArrayValue* arguments, std::string& command, Entity* modelOwner) {
-	if (!isInitialized || !modelEntity || !modelOwner) return;
+	if (!isInitialized || !modelEntity || !modelOwner || !arguments) return;
 	auto* const modelComponent = modelEntity->GetComponent<ModelComponent>();
 
 	if (!modelComponent) return;

--- a/dGame/dPropertyBehaviors/ControlBehaviors.cpp
+++ b/dGame/dPropertyBehaviors/ControlBehaviors.cpp
@@ -63,7 +63,7 @@ void ControlBehaviors::SendBehaviorListToClient(const ControlBehaviorContext& co
 // TODO This is also supposed to serialize the state of the behaviors in progress but those aren't implemented yet
 void ControlBehaviors::SendBehaviorBlocksToClient(ControlBehaviorContext& context) {
 	if (!context) return;
-	BehaviorMessageBase behaviorMsg(context.arguments);
+	BehaviorMessageBase behaviorMsg{ context.arguments };
 
 	context.modelComponent->VerifyBehaviors();
 	AMFArrayValue behavior;
@@ -71,8 +71,8 @@ void ControlBehaviors::SendBehaviorBlocksToClient(ControlBehaviorContext& contex
 	GameMessages::SendUIMessageServerToSingleClient(context.modelOwner, context.modelOwner->GetSystemAddress(), "UpdateBehaviorBlocks", behavior);
 }
 
-void ControlBehaviors::UpdateAction(AMFArrayValue* arguments) {
-	UpdateActionMessage updateActionMessage(arguments);
+void ControlBehaviors::UpdateAction(const AMFArrayValue* arguments) {
+	UpdateActionMessage updateActionMessage{ arguments };
 	auto blockDefinition = GetBlockInfo(updateActionMessage.GetAction().GetType());
 
 	if (!blockDefinition) {
@@ -95,18 +95,18 @@ void ControlBehaviors::UpdateAction(AMFArrayValue* arguments) {
 	}
 }
 
-void ControlBehaviors::ProcessCommand(Entity* modelEntity, const SystemAddress& sysAddr, AMFArrayValue* arguments, std::string command, Entity* modelOwner) {
-	if (!isInitialized || !modelEntity || !modelOwner || !arguments) return;
-	auto* modelComponent = modelEntity->GetComponent<ModelComponent>();
+void ControlBehaviors::ProcessCommand(Entity* modelEntity, AMFArrayValue* arguments, std::string& command, Entity* modelOwner) {
+	if (!isInitialized || !modelEntity || !modelOwner) return;
+	auto* const modelComponent = modelEntity->GetComponent<ModelComponent>();
 
 	if (!modelComponent) return;
 
-	ControlBehaviorContext context(arguments, modelComponent, modelOwner);
+	ControlBehaviorContext context{ arguments, modelComponent, modelOwner };
 
 	if (command == "sendBehaviorListToClient") {
 		SendBehaviorListToClient(context);
 	} else if (command == "modelTypeChanged") {
-		auto* modelType = arguments->Get<double>("ModelType");
+		auto* const modelType = arguments->Get<double>("ModelType");
 		if (!modelType) return;
 
 		modelEntity->SetVar<int>(u"modelType", modelType->GetValue());
@@ -131,7 +131,7 @@ void ControlBehaviors::ProcessCommand(Entity* modelEntity, const SystemAddress& 
 	} else if (command == "rearrangeStrip") {
 		context.modelComponent->HandleControlBehaviorsMsg<RearrangeStripMessage>(arguments);
 	} else if (command == "add") {
-		AddMessage msg(context.arguments);
+		AddMessage msg{ context.arguments };
 		context.modelComponent->AddBehavior(msg);
 		SendBehaviorListToClient(context);
 	} else if (command == "removeActions") {
@@ -144,7 +144,7 @@ void ControlBehaviors::ProcessCommand(Entity* modelEntity, const SystemAddress& 
 	} else if (command == "sendBehaviorBlocksToClient") {
 		SendBehaviorBlocksToClient(context);
 	} else if (command == "moveToInventory") {
-		MoveToInventoryMessage msg(arguments);
+		MoveToInventoryMessage msg{ arguments };
 		context.modelComponent->MoveToInventory(msg);
 		auto* characterComponent = modelOwner->GetComponent<CharacterComponent>();
 		if (!characterComponent) return;
@@ -239,7 +239,7 @@ ControlBehaviors::ControlBehaviors() {
 					if (values) {
 						auto* value = values->FirstChildElement("Value");
 						while (value) {
-							if (value->GetText() == blockDefinition.GetDefaultValue()) blockDefinition.GetDefaultValue() = std::to_string(blockDefinition.GetMaximumValue());
+							if (value->GetText() == blockDefinition.GetDefaultValue()) blockDefinition.SetDefaultValue(std::to_string(blockDefinition.GetMaximumValue()));
 							blockDefinition.SetMaximumValue(blockDefinition.GetMaximumValue() + 1);
 							value = value->NextSiblingElement("Value");
 						}
@@ -283,7 +283,7 @@ ControlBehaviors::ControlBehaviors() {
 	}
 }
 
-std::optional<BlockDefinition> ControlBehaviors::GetBlockInfo(const BlockName& blockName) {
+std::optional<BlockDefinition> ControlBehaviors::GetBlockInfo(const std::string& blockName) {
 	auto blockDefinition = blockTypes.find(blockName);
 	return blockDefinition != blockTypes.end() ? std::optional(blockDefinition->second) : std::nullopt;
 }

--- a/dGame/dPropertyBehaviors/ControlBehaviors.h
+++ b/dGame/dPropertyBehaviors/ControlBehaviors.h
@@ -19,15 +19,17 @@ class SystemAddress;
 typedef std::string BlockName;					//! A block name
 
 struct ControlBehaviorContext {
-	ControlBehaviorContext(AMFArrayValue* args, ModelComponent* modelComponent, Entity* modelOwner) : arguments(args), modelComponent(modelComponent), modelOwner(modelOwner) {};
+	ControlBehaviorContext(AMFArrayValue* args, ModelComponent* modelComponent, Entity* modelOwner) noexcept
+		: arguments{ args }, modelComponent{ modelComponent }, modelOwner{ modelOwner } {
+	};
 
 	operator bool() const {
 		return arguments != nullptr && modelComponent != nullptr && modelOwner != nullptr;
 	}
 
 	AMFArrayValue* arguments;
-	Entity* modelOwner;
 	ModelComponent* modelComponent;
+	Entity* modelOwner;
 };
 
 class ControlBehaviors: public Singleton<ControlBehaviors> {
@@ -37,12 +39,11 @@ public:
 	 * @brief Main driver for processing Property Behavior commands
 	 *
 	 * @param modelEntity The model that sent this command
-	 * @param sysAddr The SystemAddress to respond to
 	 * @param arguments The arguments formatted as an AMFArrayValue
 	 * @param command The command to perform
 	 * @param modelOwner The owner of the model which sent this command
 	 */
-	void ProcessCommand(Entity* modelEntity, const SystemAddress& sysAddr, AMFArrayValue* arguments, std::string command, Entity* modelOwner);
+	void ProcessCommand(Entity* modelEntity, AMFArrayValue* arguments, std::string& command, Entity* modelOwner);
 
 	/**
 	 * @brief Gets a blocks parameter values by the name
@@ -52,13 +53,13 @@ public:
 	 * 
 	 * @return A pair of the block parameter name to its typing
 	 */
-	std::optional<BlockDefinition> GetBlockInfo(const BlockName& blockName);
+	[[nodiscard]] std::optional<BlockDefinition> GetBlockInfo(const std::string& blockName);
 private:
 	void RequestUpdatedID(ControlBehaviorContext& context);
 	void SendBehaviorListToClient(const ControlBehaviorContext& context);
 	void SendBehaviorBlocksToClient(ControlBehaviorContext& context);
-	void UpdateAction(AMFArrayValue* arguments);
-	std::map<BlockName, BlockDefinition> blockTypes{};
+	void UpdateAction(const AMFArrayValue* arguments);
+	std::map<BlockName, BlockDefinition, std::less<>> blockTypes{};
 
 	// If false, property behaviors will not be able to be edited.
 	bool isInitialized = false;

--- a/dGame/dPropertyBehaviors/PropertyBehavior.cpp
+++ b/dGame/dPropertyBehaviors/PropertyBehavior.cpp
@@ -83,10 +83,6 @@ void PropertyBehavior::HandleMsg(AddMessage& msg) {
 	isLoot = m_BehaviorId != 7965;
 };
 
-void PropertyBehavior::SetBehaviorId(int32_t behaviorId) {
-	m_BehaviorId = behaviorId;
-}
-
 void PropertyBehavior::SendBehaviorListToClient(AMFArrayValue& args) const {
 	args.Insert("id", std::to_string(m_BehaviorId));
 	args.Insert("name", m_Name);
@@ -111,19 +107,18 @@ void PropertyBehavior::VerifyLastEditedState() {
 }
 
 void PropertyBehavior::SendBehaviorBlocksToClient(AMFArrayValue& args) const {
-	auto* stateArray = args.InsertArray("states");
+	auto* const stateArray = args.InsertArray("states");
 
-	auto lastState = BehaviorState::HOME_STATE;
-	for (auto& [stateId, state] : m_States) {
+	for (const auto& [stateId, state] : m_States) {
 		if (state.IsEmpty()) continue;
 
 		LOG_DEBUG("Serializing state %i", stateId);
-		auto* stateArgs = stateArray->PushArray();
+		auto* const stateArgs = stateArray->PushArray();
 		stateArgs->Insert("id", static_cast<double>(stateId));
 		state.SendBehaviorBlocksToClient(*stateArgs);
 	}
 
-	auto* executionState = args.InsertArray("executionState");
+	auto* const executionState = args.InsertArray("executionState");
 	executionState->Insert("stateID", static_cast<double>(m_LastEditedState));
 	executionState->InsertArray("strips");
 

--- a/dGame/dPropertyBehaviors/PropertyBehavior.h
+++ b/dGame/dPropertyBehaviors/PropertyBehavior.h
@@ -13,7 +13,8 @@ class AMFArrayValue;
 class PropertyBehavior {
 public:
 	PropertyBehavior();
-	template<typename Msg>
+
+	template <typename Msg>
 	void HandleMsg(Msg& msg);
 
 	// If the last edited state has no strips, this method will set the last edited state to the first state that has strips.
@@ -21,8 +22,9 @@ public:
 	void SendBehaviorListToClient(AMFArrayValue& args) const;
 	void SendBehaviorBlocksToClient(AMFArrayValue& args) const;
 
-	int32_t GetBehaviorId() const { return m_BehaviorId; }
-	void SetBehaviorId(int32_t id);
+	[[nodiscard]] int32_t GetBehaviorId() const noexcept { return m_BehaviorId; }
+	void SetBehaviorId(int32_t id) noexcept { m_BehaviorId = id; }
+
 private:
 
 	// The states this behavior has.

--- a/dGame/dPropertyBehaviors/State.cpp
+++ b/dGame/dPropertyBehaviors/State.cpp
@@ -3,7 +3,7 @@
 #include "Amf3.h"
 #include "ControlBehaviorMsgs.h"
 
-template<>
+template <>
 void State::HandleMsg(AddStripMessage& msg) {
 	if (m_Strips.size() <= msg.GetActionContext().GetStripId()) {
 		m_Strips.resize(msg.GetActionContext().GetStripId() + 1);
@@ -11,7 +11,7 @@ void State::HandleMsg(AddStripMessage& msg) {
 	m_Strips.at(msg.GetActionContext().GetStripId()).HandleMsg(msg);
 };
 
-template<>
+template <>
 void State::HandleMsg(AddActionMessage& msg) {
 	if (m_Strips.size() <= msg.GetActionContext().GetStripId()) {
 		return;
@@ -20,7 +20,7 @@ void State::HandleMsg(AddActionMessage& msg) {
 	m_Strips.at(msg.GetActionContext().GetStripId()).HandleMsg(msg);
 };
 
-template<>
+template <>
 void State::HandleMsg(UpdateStripUiMessage& msg) {
 	if (m_Strips.size() <= msg.GetActionContext().GetStripId()) {
 		return;
@@ -29,7 +29,7 @@ void State::HandleMsg(UpdateStripUiMessage& msg) {
 	m_Strips.at(msg.GetActionContext().GetStripId()).HandleMsg(msg);
 };
 
-template<>
+template <>
 void State::HandleMsg(RemoveActionsMessage& msg) {
 	if (m_Strips.size() <= msg.GetActionContext().GetStripId()) {
 		return;
@@ -38,7 +38,7 @@ void State::HandleMsg(RemoveActionsMessage& msg) {
 	m_Strips.at(msg.GetActionContext().GetStripId()).HandleMsg(msg);
 };
 
-template<>
+template <>
 void State::HandleMsg(RearrangeStripMessage& msg) {
 	if (m_Strips.size() <= msg.GetActionContext().GetStripId()) {
 		return;
@@ -47,7 +47,7 @@ void State::HandleMsg(RearrangeStripMessage& msg) {
 	m_Strips.at(msg.GetActionContext().GetStripId()).HandleMsg(msg);
 };
 
-template<>
+template <>
 void State::HandleMsg(UpdateActionMessage& msg) {
 	if (m_Strips.size() <= msg.GetActionContext().GetStripId()) {
 		return;
@@ -56,7 +56,7 @@ void State::HandleMsg(UpdateActionMessage& msg) {
 	m_Strips.at(msg.GetActionContext().GetStripId()).HandleMsg(msg);
 };
 
-template<>
+template <>
 void State::HandleMsg(RemoveStripMessage& msg) {
 	if (m_Strips.size() <= msg.GetActionContext().GetStripId()) {
 		return;
@@ -65,7 +65,7 @@ void State::HandleMsg(RemoveStripMessage& msg) {
 	m_Strips.at(msg.GetActionContext().GetStripId()).HandleMsg(msg);
 };
 
-template<>
+template <>
 void State::HandleMsg(SplitStripMessage& msg) {
 	if (msg.GetTransferredActions().empty()) {
 		if (m_Strips.size() <= msg.GetSourceActionContext().GetStripId()) {
@@ -82,7 +82,7 @@ void State::HandleMsg(SplitStripMessage& msg) {
 	}
 };
 
-template<>
+template <>
 void State::HandleMsg(MergeStripsMessage& msg) {
 	if (msg.GetMigratedActions().empty()) {
 		if (m_Strips.size() <= msg.GetSourceActionContext().GetStripId()) {
@@ -99,7 +99,7 @@ void State::HandleMsg(MergeStripsMessage& msg) {
 	}
 };
 
-template<>
+template <>
 void State::HandleMsg(MigrateActionsMessage& msg) {
 	if (msg.GetMigratedActions().empty()) {
 		if (m_Strips.size() <= msg.GetSourceActionContext().GetStripId()) {
@@ -117,19 +117,19 @@ void State::HandleMsg(MigrateActionsMessage& msg) {
 };
 
 bool State::IsEmpty() const {
-	for (auto& strip : m_Strips) {
+	for (const auto& strip : m_Strips) {
 		if (!strip.IsEmpty()) return false;
 	}
 	return true;
 }
 
 void State::SendBehaviorBlocksToClient(AMFArrayValue& args) const {
-	auto* strips = args.InsertArray("strips");
-	for (int32_t stripId = 0; stripId < m_Strips.size(); stripId++) {
-		auto& strip = m_Strips.at(stripId);
+	auto* const strips = args.InsertArray("strips");
+	for (size_t stripId = 0; stripId < m_Strips.size(); ++stripId) {
+		const auto& strip = m_Strips.at(stripId);
 		if (strip.IsEmpty()) continue;
 
-		auto* stripArgs = strips->PushArray();
+		auto* const stripArgs = strips->PushArray();
 		stripArgs->Insert("id", static_cast<double>(stripId));
 
 		strip.SendBehaviorBlocksToClient(*stripArgs);

--- a/dGame/dPropertyBehaviors/State.h
+++ b/dGame/dPropertyBehaviors/State.h
@@ -7,11 +7,12 @@ class AMFArrayValue;
 
 class State {
 public:
-	template<typename Msg>
+	template <typename Msg>
 	void HandleMsg(Msg& msg);
 
 	void SendBehaviorBlocksToClient(AMFArrayValue& args) const;
 	bool IsEmpty() const;
+
 private:
 	std::vector<Strip> m_Strips;
 };

--- a/dGame/dPropertyBehaviors/Strip.cpp
+++ b/dGame/dPropertyBehaviors/Strip.cpp
@@ -3,48 +3,47 @@
 #include "Amf3.h"
 #include "ControlBehaviorMsgs.h"
 
-template<>
+template <>
 void Strip::HandleMsg(AddStripMessage& msg) {
 	m_Actions = msg.GetActionsToAdd();
 	m_Position = msg.GetPosition();
 };
 
-template<>
+template <>
 void Strip::HandleMsg(AddActionMessage& msg) {
 	if (msg.GetActionIndex() == -1) return;
-
 	m_Actions.insert(m_Actions.begin() + msg.GetActionIndex(), msg.GetAction());
 };
 
-template<>
+template <>
 void Strip::HandleMsg(UpdateStripUiMessage& msg) {
 	m_Position = msg.GetPosition();
 };
 
-template<>
+template <>
 void Strip::HandleMsg(RemoveStripMessage& msg) {
 	m_Actions.clear();
 };
 
-template<>
+template <>
 void Strip::HandleMsg(RemoveActionsMessage& msg) {
 	if (msg.GetActionIndex() >= m_Actions.size()) return;
 	m_Actions.erase(m_Actions.begin() + msg.GetActionIndex(), m_Actions.end());
 };
 
-template<>
+template <>
 void Strip::HandleMsg(UpdateActionMessage& msg) {
 	if (msg.GetActionIndex() >= m_Actions.size()) return;
 	m_Actions.at(msg.GetActionIndex()) = msg.GetAction();
 };
 
-template<>
+template <>
 void Strip::HandleMsg(RearrangeStripMessage& msg) {
 	if (msg.GetDstActionIndex() >= m_Actions.size() || msg.GetSrcActionIndex() >= m_Actions.size() || msg.GetSrcActionIndex() <= msg.GetDstActionIndex()) return;
 	std::rotate(m_Actions.begin() + msg.GetDstActionIndex(), m_Actions.begin() + msg.GetSrcActionIndex(), m_Actions.end());
 };
 
-template<>
+template <>
 void Strip::HandleMsg(SplitStripMessage& msg) {
 	if (msg.GetTransferredActions().empty() && !m_Actions.empty()) {
 		auto startToMove = m_Actions.begin() + msg.GetSrcActionIndex();
@@ -56,7 +55,7 @@ void Strip::HandleMsg(SplitStripMessage& msg) {
 	}
 };
 
-template<>
+template <>
 void Strip::HandleMsg(MergeStripsMessage& msg) {
 	if (msg.GetMigratedActions().empty() && !m_Actions.empty()) {
 		msg.SetMigratedActions(m_Actions.begin(), m_Actions.end());
@@ -66,7 +65,7 @@ void Strip::HandleMsg(MergeStripsMessage& msg) {
 	}
 };
 
-template<>
+template <>
 void Strip::HandleMsg(MigrateActionsMessage& msg) {
 	if (msg.GetMigratedActions().empty() && !m_Actions.empty()) {
 		auto startToMove = m_Actions.begin() + msg.GetSrcActionIndex();
@@ -80,8 +79,8 @@ void Strip::HandleMsg(MigrateActionsMessage& msg) {
 void Strip::SendBehaviorBlocksToClient(AMFArrayValue& args) const {
 	m_Position.SendBehaviorBlocksToClient(args);
 
-	auto* actions = args.InsertArray("actions");
-	for (auto& action : m_Actions) {
+	auto* const actions = args.InsertArray("actions");
+	for (const auto& action : m_Actions) {
 		action.SendBehaviorBlocksToClient(*actions);
 	}
 };

--- a/dGame/dPropertyBehaviors/Strip.h
+++ b/dGame/dPropertyBehaviors/Strip.h
@@ -10,11 +10,12 @@ class AMFArrayValue;
 
 class Strip {
 public:
-	template<typename Msg>
+	template <typename Msg>
 	void HandleMsg(Msg& msg);
 
 	void SendBehaviorBlocksToClient(AMFArrayValue& args) const;
-	bool IsEmpty() const { return m_Actions.empty(); }
+	bool IsEmpty() const noexcept { return m_Actions.empty(); }
+
 private:
 	std::vector<Action> m_Actions;
 	StripUiPosition m_Position;


### PR DESCRIPTION
Changes split out from #1452 for more focused PR.