### PR TITLE
fix: EntityManager incorrectly inverted statement

### DIFF
--- a/dGame/EntityManager.cpp
+++ b/dGame/EntityManager.cpp
@@ -575,13 +575,13 @@ void EntityManager::ScheduleForKill(Entity* entity) {
 
 	const auto objectId = entity->GetObjectID();
 
-	if (std::find(m_EntitiesToKill.begin(), m_EntitiesToKill.end(), objectId) != m_EntitiesToKill.end()) {
+	if (std::find(m_EntitiesToKill.begin(), m_EntitiesToKill.end(), objectId) == m_EntitiesToKill.end()) {
 		m_EntitiesToKill.push_back(objectId);
 	}
 }
 
 void EntityManager::ScheduleForDeletion(LWOOBJID entity) {
-	if (std::find(m_EntitiesToDelete.begin(), m_EntitiesToDelete.end(), entity) != m_EntitiesToDelete.end()) {
+	if (std::find(m_EntitiesToDelete.begin(), m_EntitiesToDelete.end(), entity) == m_EntitiesToDelete.end()) {
 		m_EntitiesToDelete.push_back(entity);
 	}
 }


### PR DESCRIPTION
if we DON'T find it, we want to kill/delete it.  not the other way around where if we find it we try to delete it again.

tested that you no longer crash when trying to login
tested that bird monument issues are fixed