### PR TITLE
chore: Remove anonymous namespace from GeneralUtils.h

### DIFF
--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -171,22 +171,7 @@ namespace GeneralUtils {
 	// MacOS floating-point parse helper function specializations
 	namespace details {
 		template <std::floating_point T>
-		[[nodiscard]] T Parse_(const std::string_view str, size_t& parseNum);
-
-		template <>
-		[[nodiscard]] inline float Parse_<float>(const std::string_view str, size_t& parseNum) {
-			return std::stof(std::string{ str }, &parseNum);
-		}
-
-		template <>
-		[[nodiscard]] inline double Parse_<double>(const std::string_view str, size_t& parseNum) {
-			return std::stod(std::string{ str }, &parseNum);
-		}
-
-		template <>
-		[[nodiscard]] inline long double Parse_<long double>(const std::string_view str, size_t& parseNum) {
-			return std::stold(std::string{ str }, &parseNum);
-		}
+		[[nodiscard]] T _parse(const std::string_view str, size_t& parseNum);
 	}
 
 	/**
@@ -199,7 +184,7 @@ namespace GeneralUtils {
 	[[nodiscard]] std::optional<T> TryParse(const std::string_view str) noexcept
 	try {
 		size_t parseNum;
-		const T result = Parse_<T>(str, parseNum);
+		const T result = details::_parse<T>(str, parseNum);
 		const bool isParsed = str.length() == parseNum;
 
 		return isParsed ? result : std::optional<T>{};

--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -168,25 +168,23 @@ namespace GeneralUtils {
 
 #ifdef DARKFLAME_PLATFORM_MACOS
 
-	// Anonymous namespace containing MacOS floating-point parse function specializations
-	namespace {
-		template <std::floating_point T>
-		[[nodiscard]] T Parse(const std::string_view str, size_t* parseNum);
+	// MacOS floating-point parse function specializations
+	template <std::floating_point T>
+	[[nodiscard]] T Parse_(const std::string_view str, size_t& parseNum);
 
-		template <>
-		[[nodiscard]] float Parse<float>(const std::string_view str, size_t* parseNum) {
-			return std::stof(std::string{ str }, parseNum);
-		}
+	template <>
+	[[nodiscard]] inline float Parse_<float>(const std::string_view str, size_t& parseNum) {
+		return std::stof(std::string{ str }, &parseNum);
+	}
 
-		template <>
-		[[nodiscard]] double Parse<double>(const std::string_view str, size_t* parseNum) {
-			return std::stod(std::string{ str }, parseNum);
-		}
+	template <>
+	[[nodiscard]] inline double Parse_<double>(const std::string_view str, size_t& parseNum) {
+		return std::stod(std::string{ str }, &parseNum);
+	}
 
-		template <>
-		[[nodiscard]] long double Parse<long double>(const std::string_view str, size_t* parseNum) {
-			return std::stold(std::string{ str }, parseNum);
-		}
+	template <>
+	[[nodiscard]] inline long double Parse_<long double>(const std::string_view str, size_t& parseNum) {
+		return std::stold(std::string{ str }, &parseNum);
 	}
 
 	/**
@@ -196,9 +194,10 @@ namespace GeneralUtils {
 	 * @returns An std::optional containing the desired value if it is equivalent to the string
 	*/
 	template <std::floating_point T>
-	[[nodiscard]] std::optional<T> TryParse(const std::string_view str) noexcept try {
+	[[nodiscard]] std::optional<T> TryParse(const std::string_view str) noexcept
+	try {
 		size_t parseNum;
-		const T result = Parse<T>(str, &parseNum);
+		const T result = Parse_<T>(str, parseNum);
 		const bool isParsed = str.length() == parseNum;
 
 		return isParsed ? result : std::optional<T>{};

--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -168,23 +168,25 @@ namespace GeneralUtils {
 
 #ifdef DARKFLAME_PLATFORM_MACOS
 
-	// MacOS floating-point parse function specializations
-	template <std::floating_point T>
-	[[nodiscard]] T Parse_(const std::string_view str, size_t& parseNum);
+	// MacOS floating-point parse helper function specializations
+	namespace details {
+		template <std::floating_point T>
+		[[nodiscard]] T Parse_(const std::string_view str, size_t& parseNum);
 
-	template <>
-	[[nodiscard]] inline float Parse_<float>(const std::string_view str, size_t& parseNum) {
-		return std::stof(std::string{ str }, &parseNum);
-	}
+		template <>
+		[[nodiscard]] inline float Parse_<float>(const std::string_view str, size_t& parseNum) {
+			return std::stof(std::string{ str }, &parseNum);
+		}
 
-	template <>
-	[[nodiscard]] inline double Parse_<double>(const std::string_view str, size_t& parseNum) {
-		return std::stod(std::string{ str }, &parseNum);
-	}
+		template <>
+		[[nodiscard]] inline double Parse_<double>(const std::string_view str, size_t& parseNum) {
+			return std::stod(std::string{ str }, &parseNum);
+		}
 
-	template <>
-	[[nodiscard]] inline long double Parse_<long double>(const std::string_view str, size_t& parseNum) {
-		return std::stold(std::string{ str }, &parseNum);
+		template <>
+		[[nodiscard]] inline long double Parse_<long double>(const std::string_view str, size_t& parseNum) {
+			return std::stold(std::string{ str }, &parseNum);
+		}
 	}
 
 	/**


### PR DESCRIPTION
Anonymous namespaces in header files do not actually prevent access to the enclosed functions in corresponding .cpp files and having one here is therefore pointless