### PR TITLE
fix: Remove Avant Gardens special case patch

### DIFF
--- a/dZoneManager/Level.cpp
+++ b/dZoneManager/Level.cpp
@@ -200,9 +200,6 @@ void Level::ReadFileInfoChunk(std::istream& file, Header& header) {
 	BinaryIO::BinaryRead(file, header.fileInfo.enviromentChunkStart);
 	BinaryIO::BinaryRead(file, header.fileInfo.objectChunkStart);
 	BinaryIO::BinaryRead(file, header.fileInfo.particleChunkStart);
-
-	//PATCH FOR AG: (messed up file?)
-	if (header.fileInfo.revision == 0xCDCDCDCD && m_ParentZone->GetZoneID().GetMapID() == 1100) header.fileInfo.revision = 26;
 }
 
 void Level::ReadSceneObjectDataChunk(std::istream& file, Header& header) {


### PR DESCRIPTION
Tested that revision was never the poison value (0xcd is a poison byte to mark garbage) in any lvl file when starting zone 1100.  The log line at 199 is just before reading the revision and the log line at 201 is just after reading it in, when it could have been 0xcdcdcdcd, but never was. The lvl being parsed was also printed out on line 29 to see which specific file would have the issue, if there was one.
[WorldServer_1100_0_1708823429.log](https://github.com/DarkflameUniverse/DarkflameServer/files/14394905/WorldServer_1100_0_1708823429.log)
