### PR TITLE
fix: Use set for buff removal

### DIFF
--- a/dGame/dComponents/BuffComponent.cpp
+++ b/dGame/dComponents/BuffComponent.cpp
@@ -208,9 +208,8 @@ void BuffComponent::ApplyBuff(const int32_t id, const float duration, const LWOO
 void BuffComponent::RemoveBuff(int32_t id, bool fromUnEquip, bool removeImmunity, bool ignoreRefCount) {
 	const auto& iter = m_Buffs.find(id);
 
-	if (iter == m_Buffs.end()) {
-		return;
-	}
+	// If the buff is already scheduled to be removed, don't do it again
+	if (iter == m_Buffs.end() || m_BuffsToRemove.contains(id)) return;
 
 	if (!ignoreRefCount && !iter->second.cancelOnRemoveBuff) {
 		iter->second.refCount--;
@@ -222,7 +221,7 @@ void BuffComponent::RemoveBuff(int32_t id, bool fromUnEquip, bool removeImmunity
 
 	GameMessages::SendRemoveBuff(m_Parent, fromUnEquip, removeImmunity, id);
 
-	m_BuffsToRemove.push_back(id);
+	m_BuffsToRemove.insert(id);
 
 	RemoveBuffEffect(id);
 }

--- a/dGame/dComponents/BuffComponent.h
+++ b/dGame/dComponents/BuffComponent.h
@@ -141,7 +141,7 @@ private:
 	std::map<int32_t, Buff> m_Buffs;
 
 	// Buffs to remove at the end of the update frame.
-	std::vector<int32_t> m_BuffsToRemove;
+	std::set<int32_t> m_BuffsToRemove;
 
 	/**
 	 * Parameters (=effects) for each buff


### PR DESCRIPTION
Tested that smashes while iterating through buffs or stunning race conditions where you die the same frame the buff is to be removed no longer causes double removals of a buff