### PR TITLE
chore: Convert game message bit stream raw pointers to references

### DIFF
--- a/dCommon/AMFDeserialize.cpp
+++ b/dCommon/AMFDeserialize.cpp
@@ -9,12 +9,11 @@
  * AMF3 Deserializer written by EmosewaMC
  */
 
-AMFBaseValue* AMFDeserialize::Read(RakNet::BitStream* inStream) {
-	if (!inStream) return nullptr;
+AMFBaseValue* AMFDeserialize::Read(RakNet::BitStream& inStream) {
 	AMFBaseValue* returnValue = nullptr;
 	// Read in the value type from the bitStream
 	eAmf marker;
-	inStream->Read(marker);
+	inStream.Read(marker);
 	// Based on the typing, create the value associated with that and return the base value class
 	switch (marker) {
 	case eAmf::Undefined: {
@@ -79,13 +78,13 @@ AMFBaseValue* AMFDeserialize::Read(RakNet::BitStream* inStream) {
 	return returnValue;
 }
 
-uint32_t AMFDeserialize::ReadU29(RakNet::BitStream* inStream) {
+uint32_t AMFDeserialize::ReadU29(RakNet::BitStream& inStream) {
 	bool byteFlag = true;
 	uint32_t actualNumber{};
 	uint8_t numberOfBytesRead{};
 	while (byteFlag && numberOfBytesRead < 4) {
 		uint8_t byte{};
-		inStream->Read(byte);
+		inStream.Read(byte);
 		// Parse the byte
 		if (numberOfBytesRead < 3) {
 			byteFlag = byte & static_cast<uint8_t>(1 << 7);
@@ -101,7 +100,7 @@ uint32_t AMFDeserialize::ReadU29(RakNet::BitStream* inStream) {
 	return actualNumber;
 }
 
-const std::string AMFDeserialize::ReadString(RakNet::BitStream* inStream) {
+const std::string AMFDeserialize::ReadString(RakNet::BitStream& inStream) {
 	auto length = ReadU29(inStream);
 	// Check if this is a reference
 	bool isReference = length % 2 == 1;
@@ -109,7 +108,7 @@ const std::string AMFDeserialize::ReadString(RakNet::BitStream* inStream) {
 	length = length >> 1;
 	if (isReference) {
 		std::string value(length, 0);
-		inStream->Read(&value[0], length);
+		inStream.Read(&value[0], length);
 		// Empty strings are never sent by reference
 		if (!value.empty()) accessedElements.push_back(value);
 		return value;
@@ -119,13 +118,13 @@ const std::string AMFDeserialize::ReadString(RakNet::BitStream* inStream) {
 	}
 }
 
-AMFBaseValue* AMFDeserialize::ReadAmfDouble(RakNet::BitStream* inStream) {
+AMFBaseValue* AMFDeserialize::ReadAmfDouble(RakNet::BitStream& inStream) {
 	double value;
-	inStream->Read<double>(value);
+	inStream.Read<double>(value);
 	return new AMFDoubleValue(value);
 }
 
-AMFBaseValue* AMFDeserialize::ReadAmfArray(RakNet::BitStream* inStream) {
+AMFBaseValue* AMFDeserialize::ReadAmfArray(RakNet::BitStream& inStream) {
 	auto arrayValue = new AMFArrayValue();
 
 	// Read size of dense array
@@ -144,10 +143,10 @@ AMFBaseValue* AMFDeserialize::ReadAmfArray(RakNet::BitStream* inStream) {
 	return arrayValue;
 }
 
-AMFBaseValue* AMFDeserialize::ReadAmfString(RakNet::BitStream* inStream) {
+AMFBaseValue* AMFDeserialize::ReadAmfString(RakNet::BitStream& inStream) {
 	return new AMFStringValue(ReadString(inStream));
 }
 
-AMFBaseValue* AMFDeserialize::ReadAmfInteger(RakNet::BitStream* inStream) {
+AMFBaseValue* AMFDeserialize::ReadAmfInteger(RakNet::BitStream& inStream) {
 	return new AMFIntValue(ReadU29(inStream));
 }

--- a/dCommon/AMFDeserialize.h
+++ b/dCommon/AMFDeserialize.h
@@ -15,7 +15,7 @@ public:
 	 * @param inStream inStream to read value from.
 	 * @return Returns an AMFValue with all the information from the bitStream in it.
 	 */
-	AMFBaseValue* Read(RakNet::BitStream* inStream);
+	AMFBaseValue* Read(RakNet::BitStream& inStream);
 private:
 	/**
 	 * @brief Private method to read a U29 integer from a bitstream
@@ -23,7 +23,7 @@ private:
 	 * @param inStream bitstream to read data from
 	 * @return The number as an unsigned 29 bit integer
 	 */
-	uint32_t ReadU29(RakNet::BitStream* inStream);
+	uint32_t ReadU29(RakNet::BitStream& inStream);
 
 	/**
 	 * @brief Reads a string from a bitstream
@@ -31,7 +31,7 @@ private:
 	 * @param inStream bitStream to read data from
 	 * @return The read string
 	 */
-	const std::string ReadString(RakNet::BitStream* inStream);
+	const std::string ReadString(RakNet::BitStream& inStream);
 
 	/**
 	 * @brief Read an AMFDouble value from a bitStream
@@ -39,7 +39,7 @@ private:
 	 * @param inStream bitStream to read data from
 	 * @return Double value represented as an AMFValue
 	 */
-	AMFBaseValue* ReadAmfDouble(RakNet::BitStream* inStream);
+	AMFBaseValue* ReadAmfDouble(RakNet::BitStream& inStream);
 
 	/**
 	 * @brief Read an AMFArray from a bitStream
@@ -47,7 +47,7 @@ private:
 	 * @param inStream bitStream to read data from
 	 * @return Array value represented as an AMFValue
 	 */
-	AMFBaseValue* ReadAmfArray(RakNet::BitStream* inStream);
+	AMFBaseValue* ReadAmfArray(RakNet::BitStream& inStream);
 
 	/**
 	 * @brief Read an AMFString from a bitStream
@@ -55,7 +55,7 @@ private:
 	 * @param inStream bitStream to read data from
 	 * @return String value represented as an AMFValue
 	 */
-	AMFBaseValue* ReadAmfString(RakNet::BitStream* inStream);
+	AMFBaseValue* ReadAmfString(RakNet::BitStream& inStream);
 
 	/**
 	 * @brief Read an AMFInteger from a bitStream
@@ -63,7 +63,7 @@ private:
 	 * @param inStream bitStream to read data from
 	 * @return Integer value represented as an AMFValue
 	 */
-	AMFBaseValue* ReadAmfInteger(RakNet::BitStream* inStream);
+	AMFBaseValue* ReadAmfInteger(RakNet::BitStream& inStream);
 
 	/**
 	 * List of strings read so far saved to be read by reference.

--- a/dCommon/GeneralUtils.cpp
+++ b/dCommon/GeneralUtils.cpp
@@ -278,14 +278,14 @@ std::vector<std::string> GeneralUtils::SplitString(const std::string& str, char 
 	return vector;
 }
 
-std::u16string GeneralUtils::ReadWString(RakNet::BitStream* inStream) {
+std::u16string GeneralUtils::ReadWString(RakNet::BitStream& inStream) {
 	uint32_t length;
-	inStream->Read<uint32_t>(length);
+	inStream.Read<uint32_t>(length);
 
 	std::u16string string;
 	for (auto i = 0; i < length; i++) {
 		uint16_t c;
-		inStream->Read(c);
+		inStream.Read(c);
 		string.push_back(c);
 	}
 

--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -116,7 +116,7 @@ namespace GeneralUtils {
 
 	bool ReplaceInString(std::string& str, const std::string& from, const std::string& to);
 
-	std::u16string ReadWString(RakNet::BitStream* inStream);
+	std::u16string ReadWString(RakNet::BitStream& inStream);
 
 	std::vector<std::wstring> SplitString(std::wstring& str, wchar_t delimiter);
 

--- a/dGame/dGameMessages/GameMessageHandler.cpp
+++ b/dGame/dGameMessages/GameMessageHandler.cpp
@@ -39,7 +39,7 @@
 #include "GhostComponent.h"
 #include "StringifiedEnum.h"
 
-void GameMessageHandler::HandleMessage(RakNet::BitStream* inStream, const SystemAddress& sysAddr, LWOOBJID objectID, eGameMessageType messageID) {
+void GameMessageHandler::HandleMessage(RakNet::BitStream& inStream, const SystemAddress& sysAddr, LWOOBJID objectID, eGameMessageType messageID) {
 
 	CBITSTREAM;
 

--- a/dGame/dGameMessages/GameMessageHandler.h
+++ b/dGame/dGameMessages/GameMessageHandler.h
@@ -22,7 +22,7 @@
 #include "eGameMessageType.h"
 
 namespace GameMessageHandler {
-	void HandleMessage(RakNet::BitStream* inStream, const SystemAddress& sysAddr, LWOOBJID objectID, eGameMessageType messageID);
+	void HandleMessage(RakNet::BitStream& inStream, const SystemAddress& sysAddr, LWOOBJID objectID, eGameMessageType messageID);
 };
 
 #endif // GAMEMESSAGEHANDLER_H

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -1643,17 +1643,17 @@ void GameMessages::SendNotifyClientShootingGalleryScore(LWOOBJID objectId, const
 }
 
 
-void GameMessages::HandleUpdateShootingGalleryRotation(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleUpdateShootingGalleryRotation(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	float angle = 0.0f;
 	NiPoint3 facing = NiPoint3Constant::ZERO;
 	NiPoint3 muzzlePos = NiPoint3Constant::ZERO;
-	inStream->Read(angle);
-	inStream->Read(facing);
-	inStream->Read(muzzlePos);
+	inStream.Read(angle);
+	inStream.Read(facing);
+	inStream.Read(muzzlePos);
 }
 
 
-void GameMessages::HandleActivitySummaryLeaderboardData(RakNet::BitStream* instream, Entity* entity,
+void GameMessages::HandleActivitySummaryLeaderboardData(RakNet::BitStream& inStream, Entity* entity,
 	const SystemAddress& sysAddr) {
 	LOG("We got mail!");
 }
@@ -1669,44 +1669,44 @@ void GameMessages::SendActivitySummaryLeaderboardData(const LWOOBJID& objectID, 
 	SEND_PACKET;
 }
 
-void GameMessages::HandleRequestActivitySummaryLeaderboardData(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleRequestActivitySummaryLeaderboardData(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	int32_t gameID = 0;
-	if (inStream->ReadBit()) inStream->Read(gameID);
+	if (inStream.ReadBit()) inStream.Read(gameID);
 
 	Leaderboard::InfoType queryType = Leaderboard::InfoType::MyStanding;
-	if (inStream->ReadBit()) inStream->Read<Leaderboard::InfoType>(queryType);
+	if (inStream.ReadBit()) inStream.Read<Leaderboard::InfoType>(queryType);
 
 	int32_t resultsEnd = 10;
-	if (inStream->ReadBit()) inStream->Read(resultsEnd);
+	if (inStream.ReadBit()) inStream.Read(resultsEnd);
 
 	int32_t resultsStart = 0;
-	if (inStream->ReadBit()) inStream->Read(resultsStart);
+	if (inStream.ReadBit()) inStream.Read(resultsStart);
 
 	LWOOBJID target{};
-	inStream->Read(target);
+	inStream.Read(target);
 
-	bool weekly = inStream->ReadBit();
+	bool weekly = inStream.ReadBit();
 
 	LeaderboardManager::SendLeaderboard(gameID, queryType, weekly, entity->GetObjectID(), entity->GetObjectID(), resultsStart, resultsEnd);
 }
 
-void GameMessages::HandleActivityStateChangeRequest(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleActivityStateChangeRequest(RakNet::BitStream& inStream, Entity* entity) {
 	LWOOBJID objectID;
-	inStream->Read<LWOOBJID>(objectID);
+	inStream.Read<LWOOBJID>(objectID);
 
 	int32_t value1;
-	inStream->Read<int32_t>(value1);
+	inStream.Read<int32_t>(value1);
 
 	int32_t value2;
-	inStream->Read<int32_t>(value2);
+	inStream.Read<int32_t>(value2);
 
 	uint32_t stringValueLength;
-	inStream->Read<uint32_t>(stringValueLength);
+	inStream.Read<uint32_t>(stringValueLength);
 
 	std::u16string stringValue;
 	for (uint32_t i = 0; i < stringValueLength; ++i) {
 		uint16_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 		stringValue.push_back(character);
 	}
 
@@ -2159,17 +2159,17 @@ void GameMessages::SendUGCEquipPostDeleteBasedOnEditMode(LWOOBJID objectId, cons
 	SEND_PACKET;
 }
 
-void GameMessages::HandleSetPropertyAccess(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleSetPropertyAccess(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	uint8_t accessType{};
 	int32_t renew{};
 
 	bool accessTypeIsDefault{};
-	inStream->Read(accessTypeIsDefault);
-	if (accessTypeIsDefault != 0) inStream->Read(accessType);
+	inStream.Read(accessTypeIsDefault);
+	if (accessTypeIsDefault != 0) inStream.Read(accessType);
 
 	bool renewIsDefault{};
-	inStream->Read(renewIsDefault);
-	if (renewIsDefault != 0) inStream->Read(renew);
+	inStream.Read(renewIsDefault);
+	if (renewIsDefault != 0) inStream.Read(renew);
 
 	LOG("Set privacy option to: %i", accessType);
 
@@ -2178,11 +2178,11 @@ void GameMessages::HandleSetPropertyAccess(RakNet::BitStream* inStream, Entity* 
 	PropertyManagementComponent::Instance()->SetPrivacyOption(static_cast<PropertyPrivacyOption>(accessType));
 }
 
-void GameMessages::HandleUnUseModel(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleUnUseModel(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	bool unknown{};
 	LWOOBJID objIdToAddToInventory{};
-	inStream->Read(unknown);
-	inStream->Read(objIdToAddToInventory);
+	inStream.Read(unknown);
+	inStream.Read(objIdToAddToInventory);
 	auto* inventoryComponent = entity->GetComponent<InventoryComponent>();
 	if (inventoryComponent) {
 		auto* inventory = inventoryComponent->GetInventory(eInventoryType::MODELS_IN_BBB);
@@ -2204,7 +2204,7 @@ void GameMessages::HandleUnUseModel(RakNet::BitStream* inStream, Entity* entity,
 	}
 }
 
-void GameMessages::HandleUpdatePropertyOrModelForFilterCheck(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleUpdatePropertyOrModelForFilterCheck(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	bool isProperty{};
 	LWOOBJID objectId{};
 	LWOOBJID playerId{};
@@ -2214,29 +2214,29 @@ void GameMessages::HandleUpdatePropertyOrModelForFilterCheck(RakNet::BitStream* 
 	uint32_t descriptionLength{};
 	std::u16string description{};
 
-	inStream->Read(isProperty);
-	inStream->Read(objectId);
-	inStream->Read(playerId);
-	inStream->Read(worldId);
+	inStream.Read(isProperty);
+	inStream.Read(objectId);
+	inStream.Read(playerId);
+	inStream.Read(worldId);
 
-	inStream->Read(descriptionLength);
+	inStream.Read(descriptionLength);
 	for (uint32_t i = 0; i < descriptionLength; ++i) {
 		uint16_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 		description.push_back(character);
 	}
 
-	inStream->Read(nameLength);
+	inStream.Read(nameLength);
 	for (uint32_t i = 0; i < nameLength; ++i) {
 		uint16_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 		name.push_back(character);
 	}
 
 	PropertyManagementComponent::Instance()->UpdatePropertyDetails(GeneralUtils::UTF16ToWTF8(name), GeneralUtils::UTF16ToWTF8(description));
 }
 
-void GameMessages::HandleQueryPropertyData(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleQueryPropertyData(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	LOG("Entity (%i) requesting data", entity->GetLOT());
 
 	/*
@@ -2264,7 +2264,7 @@ void GameMessages::HandleQueryPropertyData(RakNet::BitStream* inStream, Entity* 
 	}
 }
 
-void GameMessages::HandleSetBuildMode(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleSetBuildMode(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	bool start{};
 	int32_t distanceType = -1;
 	bool modePaused{};
@@ -2272,20 +2272,20 @@ void GameMessages::HandleSetBuildMode(RakNet::BitStream* inStream, Entity* entit
 	LWOOBJID playerId{};
 	NiPoint3 startPosition = NiPoint3Constant::ZERO;
 
-	inStream->Read(start);
+	inStream.Read(start);
 
-	if (inStream->ReadBit())
-		inStream->Read(distanceType);
+	if (inStream.ReadBit())
+		inStream.Read(distanceType);
 
-	inStream->Read(modePaused);
+	inStream.Read(modePaused);
 
-	if (inStream->ReadBit())
-		inStream->Read(modeValue);
+	if (inStream.ReadBit())
+		inStream.Read(modeValue);
 
-	inStream->Read(playerId);
+	inStream.Read(playerId);
 
-	if (inStream->ReadBit())
-		inStream->Read(startPosition);
+	if (inStream.ReadBit())
+		inStream.Read(startPosition);
 
 	auto* player = Game::entityManager->GetEntity(playerId);
 
@@ -2300,7 +2300,7 @@ void GameMessages::HandleSetBuildMode(RakNet::BitStream* inStream, Entity* entit
 	SendSetBuildModeConfirmed(entity->GetObjectID(), UNASSIGNED_SYSTEM_ADDRESS, start, false, modePaused, modeValue, playerId, startPosition);
 }
 
-void GameMessages::HandleStartBuildingWithItem(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleStartBuildingWithItem(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	if (!entity->HasComponent(eReplicaComponentType::PROPERTY_MANAGEMENT)) {
 		return;
 	}
@@ -2316,16 +2316,16 @@ void GameMessages::HandleStartBuildingWithItem(RakNet::BitStream* inStream, Enti
 	NiPoint3 targetPosition{};
 	int32_t targetType{};
 
-	inStream->Read(firstTime);
-	inStream->Read(success);
-	inStream->Read(sourceBag);
-	inStream->Read(sourceId);
-	inStream->Read(sourceLot);
-	inStream->Read(sourceType);
-	inStream->Read(targetId);
-	inStream->Read(targetLot);
-	inStream->Read(targetPosition);
-	inStream->Read(targetType);
+	inStream.Read(firstTime);
+	inStream.Read(success);
+	inStream.Read(sourceBag);
+	inStream.Read(sourceId);
+	inStream.Read(sourceLot);
+	inStream.Read(sourceType);
+	inStream.Read(targetId);
+	inStream.Read(targetLot);
+	inStream.Read(targetPosition);
+	inStream.Read(targetType);
 
 	if (sourceType == 1) {
 		sourceType = 4;
@@ -2354,19 +2354,19 @@ void GameMessages::HandleStartBuildingWithItem(RakNet::BitStream* inStream, Enti
 	);
 }
 
-void GameMessages::HandlePropertyEditorBegin(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandlePropertyEditorBegin(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	PropertyManagementComponent::Instance()->OnStartBuilding();
 
 	Game::zoneManager->GetZoneControlObject()->OnZonePropertyEditBegin();
 }
 
-void GameMessages::HandlePropertyEditorEnd(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandlePropertyEditorEnd(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	PropertyManagementComponent::Instance()->OnFinishBuilding();
 
 	Game::zoneManager->GetZoneControlObject()->OnZonePropertyEditEnd();
 }
 
-void GameMessages::HandlePropertyContentsFromClient(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandlePropertyContentsFromClient(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 
 	Entity* player = Game::entityManager->GetEntity(user->GetLoggedInChar());
@@ -2374,52 +2374,52 @@ void GameMessages::HandlePropertyContentsFromClient(RakNet::BitStream* inStream,
 	SendGetModelsOnProperty(player->GetObjectID(), PropertyManagementComponent::Instance()->GetModels(), UNASSIGNED_SYSTEM_ADDRESS);
 }
 
-void GameMessages::HandlePropertyModelEquipped(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandlePropertyModelEquipped(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	Game::zoneManager->GetZoneControlObject()->OnZonePropertyModelEquipped();
 }
 
-void GameMessages::HandlePlacePropertyModel(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandlePlacePropertyModel(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	LWOOBJID model;
 
-	inStream->Read(model);
+	inStream.Read(model);
 
 	PropertyManagementComponent::Instance()->UpdateModelPosition(model, NiPoint3Constant::ZERO, NiQuaternionConstant::IDENTITY);
 }
 
-void GameMessages::HandleUpdatePropertyModel(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleUpdatePropertyModel(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	LWOOBJID model;
 	NiPoint3 position;
 	NiQuaternion rotation = NiQuaternionConstant::IDENTITY;
 
-	inStream->Read(model);
-	inStream->Read(position);
+	inStream.Read(model);
+	inStream.Read(position);
 
-	if (inStream->ReadBit()) {
-		inStream->Read(rotation);
+	if (inStream.ReadBit()) {
+		inStream.Read(rotation);
 	}
 
 	PropertyManagementComponent::Instance()->UpdateModelPosition(model, position, rotation);
 }
 
-void GameMessages::HandleDeletePropertyModel(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleDeletePropertyModel(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	LWOOBJID model = LWOOBJID_EMPTY;
 	int deleteReason = 0;
 
-	if (inStream->ReadBit()) {
-		inStream->Read(model);
+	if (inStream.ReadBit()) {
+		inStream.Read(model);
 	}
 
-	if (inStream->ReadBit()) {
-		inStream->Read(deleteReason);
+	if (inStream.ReadBit()) {
+		inStream.Read(deleteReason);
 
 	}
 
 	PropertyManagementComponent::Instance()->DeleteModel(model, deleteReason);
 }
 
-void GameMessages::HandleBBBLoadItemRequest(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleBBBLoadItemRequest(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	LWOOBJID previousItemID = LWOOBJID_EMPTY;
-	inStream->Read(previousItemID);
+	inStream.Read(previousItemID);
 
 	LOG("Load item request for: %lld", previousItemID);
 	LWOOBJID newId = previousItemID;
@@ -2486,18 +2486,18 @@ void GameMessages::SendUnSmash(Entity* entity, LWOOBJID builderID, float duratio
 	SEND_PACKET_BROADCAST;
 }
 
-void GameMessages::HandleControlBehaviors(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleControlBehaviors(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	AMFDeserialize reader;
 	std::unique_ptr<AMFBaseValue> amfArguments(reader.Read(inStream));
 	if (amfArguments->GetValueType() != eAmf::Array) return;
 
 	uint32_t commandLength{};
-	inStream->Read(commandLength);
+	inStream.Read(commandLength);
 
 	std::string command;
 	for (uint32_t i = 0; i < commandLength; i++) {
 		unsigned char character;
-		inStream->Read(character);
+		inStream.Read(character);
 		command.push_back(character);
 	}
 
@@ -2507,7 +2507,7 @@ void GameMessages::HandleControlBehaviors(RakNet::BitStream* inStream, Entity* e
 	ControlBehaviors::Instance().ProcessCommand(entity, static_cast<AMFArrayValue*>(amfArguments.get()), command, owner);
 }
 
-void GameMessages::HandleBBBSaveRequest(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleBBBSaveRequest(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	/*
 								  ___            ___
 		  /\  /\___ _ __ ___     / __\ ___      /   \_ __ __ _  __ _  ___  _ __  ___
@@ -2538,18 +2538,18 @@ void GameMessages::HandleBBBSaveRequest(RakNet::BitStream* inStream, Entity* ent
 	*/
 	LWOOBJID localId;
 
-	inStream->Read(localId);
+	inStream.Read(localId);
 
 	uint32_t sd0Size;
-	inStream->Read(sd0Size);
+	inStream.Read(sd0Size);
 	std::shared_ptr<char[]> sd0Data(new char[sd0Size]);
 
 	if (sd0Data == nullptr) return;
 
-	inStream->ReadAlignedBytes(reinterpret_cast<unsigned char*>(sd0Data.get()), sd0Size);
+	inStream.ReadAlignedBytes(reinterpret_cast<unsigned char*>(sd0Data.get()), sd0Size);
 
 	uint32_t timeTaken;
-	inStream->Read(timeTaken);
+	inStream.Read(timeTaken);
 
 	/*
 		Disabled this, as it's kinda silly to do this roundabout way of storing plaintext lxfml, then recompressing
@@ -2686,7 +2686,7 @@ void GameMessages::HandleBBBSaveRequest(RakNet::BitStream* inStream, Entity* ent
 		});
 }
 
-void GameMessages::HandlePropertyEntranceSync(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandlePropertyEntranceSync(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	bool includeNullAddress{};
 	bool includeNullDescription{};
 	bool playerOwn{};
@@ -2698,19 +2698,19 @@ void GameMessages::HandlePropertyEntranceSync(RakNet::BitStream* inStream, Entit
 	uint32_t filterTextLength{};
 	std::string filterText{};
 
-	inStream->Read(includeNullAddress);
-	inStream->Read(includeNullDescription);
-	inStream->Read(playerOwn);
-	inStream->Read(updateUi);
-	inStream->Read(numResults);
-	inStream->Read(reputation);
-	inStream->Read(sortMethod);
-	inStream->Read(startIndex);
-	inStream->Read(filterTextLength);
+	inStream.Read(includeNullAddress);
+	inStream.Read(includeNullDescription);
+	inStream.Read(playerOwn);
+	inStream.Read(updateUi);
+	inStream.Read(numResults);
+	inStream.Read(reputation);
+	inStream.Read(sortMethod);
+	inStream.Read(startIndex);
+	inStream.Read(filterTextLength);
 
 	for (auto i = 0u; i < filterTextLength; i++) {
 		char c;
-		inStream->Read(c);
+		inStream.Read(c);
 		filterText.push_back(c);
 	}
 
@@ -2734,12 +2734,12 @@ void GameMessages::HandlePropertyEntranceSync(RakNet::BitStream* inStream, Entit
 	);
 }
 
-void GameMessages::HandleEnterProperty(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleEnterProperty(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	uint32_t index{};
 	bool returnToZone{};
 
-	inStream->Read(index);
-	inStream->Read(returnToZone);
+	inStream.Read(index);
+	inStream.Read(returnToZone);
 
 	auto* player = PlayerManager::GetPlayer(sysAddr);
 
@@ -2755,10 +2755,10 @@ void GameMessages::HandleEnterProperty(RakNet::BitStream* inStream, Entity* enti
 	}
 }
 
-void GameMessages::HandleSetConsumableItem(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleSetConsumableItem(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	LOT lot;
 
-	inStream->Read(lot);
+	inStream.Read(lot);
 
 	auto* inventory = entity->GetComponent<InventoryComponent>();
 
@@ -2830,43 +2830,43 @@ void GameMessages::SendEndCinematic(LWOOBJID objectId, std::u16string pathName, 
 	SEND_PACKET;
 }
 
-void GameMessages::HandleCinematicUpdate(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleCinematicUpdate(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	eCinematicEvent event;
-	if (!inStream->ReadBit()) {
+	if (!inStream.ReadBit()) {
 		event = eCinematicEvent::STARTED;
 	} else {
-		inStream->Read<eCinematicEvent>(event);
+		inStream.Read<eCinematicEvent>(event);
 	}
 
 	float_t overallTime;
-	if (!inStream->ReadBit()) {
+	if (!inStream.ReadBit()) {
 		overallTime = -1.0f;
 	} else {
-		inStream->Read<float_t>(overallTime);
+		inStream.Read<float_t>(overallTime);
 	}
 
 	uint32_t pathNameLength;
-	inStream->Read(pathNameLength);
+	inStream.Read(pathNameLength);
 
 	std::u16string pathName;
 	for (size_t i = 0; i < pathNameLength; i++) {
 		char16_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 		pathName.push_back(character);
 	}
 
 	float_t pathTime;
-	if (!inStream->ReadBit()) {
+	if (!inStream.ReadBit()) {
 		pathTime = -1.0f;
 	} else {
-		inStream->Read<float_t>(pathTime);
+		inStream.Read<float_t>(pathTime);
 	}
 
 	int32_t waypoint;
-	if (!inStream->ReadBit()) {
+	if (!inStream.ReadBit()) {
 		waypoint = -1;
 	} else {
-		inStream->Read<int32_t>(waypoint);
+		inStream.Read<int32_t>(waypoint);
 	}
 
 	std::vector<Entity*> scriptedActs = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SCRIPT);
@@ -3087,23 +3087,23 @@ void GameMessages::SendNotifyObject(LWOOBJID objectId, LWOOBJID objIDSender, std
 	SEND_PACKET;
 }
 
-void GameMessages::HandleVerifyAck(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleVerifyAck(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	bool bDifferent;
 	std::string sBitStream;
 	uint32_t uiHandle = 0;
 
-	bDifferent = inStream->ReadBit();
+	bDifferent = inStream.ReadBit();
 
 	uint32_t sBitStreamLength = 0;
-	inStream->Read(sBitStreamLength);
+	inStream.Read(sBitStreamLength);
 	for (uint64_t k = 0; k < sBitStreamLength; k++) {
 		uint8_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 		sBitStream.push_back(character);
 	}
 
-	if (inStream->ReadBit()) {
-		inStream->Read(uiHandle);
+	if (inStream.ReadBit()) {
+		inStream.Read(uiHandle);
 	}
 }
 
@@ -3230,7 +3230,7 @@ void GameMessages::SendServerTradeUpdate(LWOOBJID objectId, uint64_t coins, cons
 	SEND_PACKET;
 }
 
-void GameMessages::HandleClientTradeRequest(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleClientTradeRequest(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	// Check if the player has restricted trade access
 	auto* character = entity->GetCharacter();
 
@@ -3244,10 +3244,10 @@ void GameMessages::HandleClientTradeRequest(RakNet::BitStream* inStream, Entity*
 		return;
 	}
 
-	bool bNeedInvitePopUp = inStream->ReadBit();
+	bool bNeedInvitePopUp = inStream.ReadBit();
 	LWOOBJID i64Invitee;
 
-	inStream->Read(i64Invitee);
+	inStream.Read(i64Invitee);
 
 	auto* invitee = Game::entityManager->GetEntity(i64Invitee);
 
@@ -3288,7 +3288,7 @@ void GameMessages::HandleClientTradeRequest(RakNet::BitStream* inStream, Entity*
 	}
 }
 
-void GameMessages::HandleClientTradeCancel(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleClientTradeCancel(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	auto* trade = TradingManager::Instance()->GetPlayerTrade(entity->GetObjectID());
 
 	if (trade == nullptr) return;
@@ -3298,8 +3298,8 @@ void GameMessages::HandleClientTradeCancel(RakNet::BitStream* inStream, Entity* 
 	TradingManager::Instance()->CancelTrade(entity->GetObjectID(), trade->GetTradeId());
 }
 
-void GameMessages::HandleClientTradeAccept(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
-	bool bFirst = inStream->ReadBit();
+void GameMessages::HandleClientTradeAccept(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
+	bool bFirst = inStream.ReadBit();
 
 	LOG("Trade accepted from (%llu) -> (%d)", entity->GetObjectID(), bFirst);
 
@@ -3310,12 +3310,12 @@ void GameMessages::HandleClientTradeAccept(RakNet::BitStream* inStream, Entity* 
 	trade->SetAccepted(entity->GetObjectID(), bFirst);
 }
 
-void GameMessages::HandleClientTradeUpdate(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleClientTradeUpdate(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	uint64_t currency;
 	uint32_t itemCount;
 
-	inStream->Read(currency);
-	inStream->Read(itemCount);
+	inStream.Read(currency);
+	inStream.Read(itemCount);
 
 	LOG("Trade update from (%llu) -> (%llu), (%i)", entity->GetObjectID(), currency, itemCount);
 
@@ -3325,8 +3325,8 @@ void GameMessages::HandleClientTradeUpdate(RakNet::BitStream* inStream, Entity* 
 		LWOOBJID itemId;
 		LWOOBJID itemId2;
 
-		inStream->Read(itemId);
-		inStream->Read(itemId2);
+		inStream.Read(itemId);
+		inStream.Read(itemId2);
 
 		LOT lot = 0;
 		LWOOBJID unknown1 = 0;
@@ -3336,32 +3336,32 @@ void GameMessages::HandleClientTradeUpdate(RakNet::BitStream* inStream, Entity* 
 		uint32_t ldfSize = 0;
 		bool unknown4;
 
-		inStream->Read(lot);
-		if (inStream->ReadBit()) {
-			inStream->Read(unknown1);
+		inStream.Read(lot);
+		if (inStream.ReadBit()) {
+			inStream.Read(unknown1);
 		}
-		if (inStream->ReadBit()) {
-			inStream->Read(unknown2);
+		if (inStream.ReadBit()) {
+			inStream.Read(unknown2);
 		}
-		if (inStream->ReadBit()) {
-			inStream->Read(slot);
+		if (inStream.ReadBit()) {
+			inStream.Read(slot);
 		}
-		if (inStream->ReadBit()) {
-			inStream->Read(unknown3);
+		if (inStream.ReadBit()) {
+			inStream.Read(unknown3);
 		}
-		if (inStream->ReadBit()) // No
+		if (inStream.ReadBit()) // No
 		{
-			inStream->Read(ldfSize);
-			bool compressed = inStream->ReadBit();
+			inStream.Read(ldfSize);
+			bool compressed = inStream.ReadBit();
 			if (compressed) {
 				uint32_t ldfCompressedSize = 0;
-				inStream->Read(ldfCompressedSize);
-				inStream->IgnoreBytes(ldfCompressedSize);
+				inStream.Read(ldfCompressedSize);
+				inStream.IgnoreBytes(ldfCompressedSize);
 			} else {
-				inStream->IgnoreBytes(ldfSize);
+				inStream.IgnoreBytes(ldfSize);
 			}
 		}
-		unknown4 = inStream->ReadBit();
+		unknown4 = inStream.ReadBit();
 
 		items.push_back({ itemId, lot, unknown2 });
 
@@ -3656,8 +3656,8 @@ void GameMessages::SendPetNameChanged(LWOOBJID objectId, int32_t moderationStatu
 }
 
 
-void GameMessages::HandleClientExitTamingMinigame(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
-	bool bVoluntaryExit = inStream->ReadBit();
+void GameMessages::HandleClientExitTamingMinigame(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
+	bool bVoluntaryExit = inStream.ReadBit();
 
 	auto* petComponent = PetComponent::GetTamingPet(entity->GetObjectID());
 
@@ -3668,7 +3668,7 @@ void GameMessages::HandleClientExitTamingMinigame(RakNet::BitStream* inStream, E
 	petComponent->ClientExitTamingMinigame(bVoluntaryExit);
 }
 
-void GameMessages::HandleStartServerPetMinigameTimer(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleStartServerPetMinigameTimer(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	auto* petComponent = PetComponent::GetTamingPet(entity->GetObjectID());
 
 	if (petComponent == nullptr) {
@@ -3678,24 +3678,24 @@ void GameMessages::HandleStartServerPetMinigameTimer(RakNet::BitStream* inStream
 	petComponent->StartTimer();
 }
 
-void GameMessages::HandlePetTamingTryBuild(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandlePetTamingTryBuild(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	uint32_t brickCount;
 	std::vector<Brick> bricks;
 	bool clientFailed;
 
-	inStream->Read(brickCount);
+	inStream.Read(brickCount);
 
 	bricks.reserve(brickCount);
 
 	for (uint32_t i = 0; i < brickCount; i++) {
 		Brick brick;
 
-		inStream->Read(brick);
+		inStream.Read(brick);
 
 		bricks.push_back(brick);
 	}
 
-	clientFailed = inStream->ReadBit();
+	clientFailed = inStream.ReadBit();
 
 	auto* petComponent = PetComponent::GetTamingPet(entity->GetObjectID());
 
@@ -3706,10 +3706,10 @@ void GameMessages::HandlePetTamingTryBuild(RakNet::BitStream* inStream, Entity* 
 	petComponent->TryBuild(bricks.size(), clientFailed);
 }
 
-void GameMessages::HandleNotifyTamingBuildSuccess(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleNotifyTamingBuildSuccess(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	NiPoint3 position;
 
-	inStream->Read(position);
+	inStream.Read(position);
 
 	auto* petComponent = PetComponent::GetTamingPet(entity->GetObjectID());
 
@@ -3720,15 +3720,15 @@ void GameMessages::HandleNotifyTamingBuildSuccess(RakNet::BitStream* inStream, E
 	petComponent->NotifyTamingBuildSuccess(position);
 }
 
-void GameMessages::HandleRequestSetPetName(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleRequestSetPetName(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	uint32_t nameLength;
 	std::u16string name;
 
-	inStream->Read(nameLength);
+	inStream.Read(nameLength);
 
 	for (size_t i = 0; i < nameLength; i++) {
 		char16_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 		name.push_back(character);
 	}
 
@@ -3745,18 +3745,18 @@ void GameMessages::HandleRequestSetPetName(RakNet::BitStream* inStream, Entity* 
 	petComponent->RequestSetPetName(name);
 }
 
-void GameMessages::HandleCommandPet(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleCommandPet(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	NiPoint3 genericPosInfo;
 	LWOOBJID objIdSource;
 	int32_t iPetCommandType;
 	int32_t iTypeID;
 	bool overrideObey;
 
-	inStream->Read(genericPosInfo);
-	inStream->Read(objIdSource);
-	inStream->Read(iPetCommandType);
-	inStream->Read(iTypeID);
-	overrideObey = inStream->ReadBit();
+	inStream.Read(genericPosInfo);
+	inStream.Read(objIdSource);
+	inStream.Read(iPetCommandType);
+	inStream.Read(iTypeID);
+	overrideObey = inStream.ReadBit();
 
 	auto* petComponent = entity->GetComponent<PetComponent>();
 
@@ -3767,10 +3767,10 @@ void GameMessages::HandleCommandPet(RakNet::BitStream* inStream, Entity* entity,
 	petComponent->Command(genericPosInfo, objIdSource, iPetCommandType, iTypeID, overrideObey);
 }
 
-void GameMessages::HandleDespawnPet(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleDespawnPet(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	bool bDeletePet;
 
-	bDeletePet = inStream->ReadBit();
+	bDeletePet = inStream.ReadBit();
 
 	auto* petComponent = PetComponent::GetActivePet(entity->GetObjectID());
 
@@ -3785,26 +3785,26 @@ void GameMessages::HandleDespawnPet(RakNet::BitStream* inStream, Entity* entity,
 	}
 }
 
-void GameMessages::HandleMessageBoxResponse(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleMessageBoxResponse(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	int32_t iButton;
 	uint32_t identifierLength;
 	std::u16string identifier;
 	uint32_t userDataLength;
 	std::u16string userData;
 
-	inStream->Read(iButton);
+	inStream.Read(iButton);
 
-	inStream->Read(identifierLength);
+	inStream.Read(identifierLength);
 	for (size_t i = 0; i < identifierLength; i++) {
 		char16_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 		identifier.push_back(character);
 	}
 
-	inStream->Read(userDataLength);
+	inStream.Read(userDataLength);
 	for (size_t i = 0; i < userDataLength; i++) {
 		char16_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 		userData.push_back(character);
 	}
 
@@ -3841,26 +3841,26 @@ void GameMessages::HandleMessageBoxResponse(RakNet::BitStream* inStream, Entity*
 	}
 }
 
-void GameMessages::HandleChoiceBoxRespond(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleChoiceBoxRespond(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	int32_t iButton;
 	uint32_t buttonIdentifierLength;
 	std::u16string buttonIdentifier;
 	uint32_t identifierLength;
 	std::u16string identifier;
 
-	inStream->Read(buttonIdentifierLength);
+	inStream.Read(buttonIdentifierLength);
 	for (size_t i = 0; i < buttonIdentifierLength; i++) {
 		char16_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 		buttonIdentifier.push_back(character);
 	}
 
-	inStream->Read(iButton);
+	inStream.Read(iButton);
 
-	inStream->Read(identifierLength);
+	inStream.Read(identifierLength);
 	for (size_t i = 0; i < identifierLength; i++) {
 		char16_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 		identifier.push_back(character);
 	}
 
@@ -3989,10 +3989,10 @@ void GameMessages::SendSetMountInventoryID(Entity* entity, const LWOOBJID& objec
 }
 
 
-void GameMessages::HandleDismountComplete(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleDismountComplete(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	// Get the objectID from the bitstream
 	LWOOBJID objectId{};
-	inStream->Read(objectId);
+	inStream.Read(objectId);
 
 	// If we aren't possessing somethings, the don't do anything
 	if (objectId != LWOOBJID_EMPTY) {
@@ -4031,17 +4031,17 @@ void GameMessages::HandleDismountComplete(RakNet::BitStream* inStream, Entity* e
 }
 
 
-void GameMessages::HandleAcknowledgePossession(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleAcknowledgePossession(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	Game::entityManager->SerializeEntity(entity);
 	LWOOBJID objectId{};
-	inStream->Read(objectId);
+	inStream.Read(objectId);
 	auto* mount = Game::entityManager->GetEntity(objectId);
 	if (mount) Game::entityManager->SerializeEntity(mount);
 }
 
 //Racing
 
-void GameMessages::HandleModuleAssemblyQueryData(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleModuleAssemblyQueryData(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	auto* moduleAssemblyComponent = entity->GetComponent<ModuleAssemblyComponent>();
 
 	LOG("Got Query from %i", entity->GetLOT());
@@ -4054,23 +4054,23 @@ void GameMessages::HandleModuleAssemblyQueryData(RakNet::BitStream* inStream, En
 }
 
 
-void GameMessages::HandleModularAssemblyNIFCompleted(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleModularAssemblyNIFCompleted(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	LWOOBJID objectID;
 
-	inStream->Read(objectID);
+	inStream.Read(objectID);
 }
 
 
-void GameMessages::HandleVehicleSetWheelLockState(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
-	bool bExtraFriction = inStream->ReadBit();
-	bool bLocked = inStream->ReadBit();
+void GameMessages::HandleVehicleSetWheelLockState(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
+	bool bExtraFriction = inStream.ReadBit();
+	bool bLocked = inStream.ReadBit();
 }
 
 
-void GameMessages::HandleRacingClientReady(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleRacingClientReady(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	LWOOBJID playerID;
 
-	inStream->Read(playerID);
+	inStream.Read(playerID);
 
 	auto* player = Game::entityManager->GetEntity(playerID);
 
@@ -4088,7 +4088,7 @@ void GameMessages::HandleRacingClientReady(RakNet::BitStream* inStream, Entity* 
 }
 
 
-void GameMessages::HandleRequestDie(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleRequestDie(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	bool bClientDeath;
 	bool bSpawnLoot;
 	std::u16string deathType;
@@ -4099,31 +4099,31 @@ void GameMessages::HandleRequestDie(RakNet::BitStream* inStream, Entity* entity,
 	LWOOBJID killerID;
 	LWOOBJID lootOwnerID = LWOOBJID_EMPTY;
 
-	bClientDeath = inStream->ReadBit();
-	bSpawnLoot = inStream->ReadBit();
+	bClientDeath = inStream.ReadBit();
+	bSpawnLoot = inStream.ReadBit();
 
 	uint32_t deathTypeLength = 0;
-	inStream->Read(deathTypeLength);
+	inStream.Read(deathTypeLength);
 
 	for (size_t i = 0; i < deathTypeLength; i++) {
 		char16_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 
 		deathType.push_back(character);
 	}
 
-	inStream->Read(directionRelativeAngleXZ);
-	inStream->Read(directionRelativeAngleY);
-	inStream->Read(directionRelativeForce);
+	inStream.Read(directionRelativeAngleXZ);
+	inStream.Read(directionRelativeAngleY);
+	inStream.Read(directionRelativeForce);
 
-	if (inStream->ReadBit()) {
-		inStream->Read(killType);
+	if (inStream.ReadBit()) {
+		inStream.Read(killType);
 	}
 
-	inStream->Read(killerID);
+	inStream.Read(killerID);
 
-	if (inStream->ReadBit()) {
-		inStream->Read(lootOwnerID);
+	if (inStream.ReadBit()) {
+		inStream.Read(lootOwnerID);
 	}
 
 	auto* zoneController = Game::zoneManager->GetZoneControlObject();
@@ -4154,20 +4154,20 @@ void GameMessages::HandleRequestDie(RakNet::BitStream* inStream, Entity* entity,
 }
 
 
-void GameMessages::HandleVehicleNotifyServerAddPassiveBoostAction(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleVehicleNotifyServerAddPassiveBoostAction(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	//SendVehicleAddPassiveBoostAction(entity->GetObjectID(), sysAddr);
 }
 
 
-void GameMessages::HandleVehicleNotifyServerRemovePassiveBoostAction(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleVehicleNotifyServerRemovePassiveBoostAction(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	//SendVehicleRemovePassiveBoostAction(entity->GetObjectID(), sysAddr);
 }
 
 
-void GameMessages::HandleRacingPlayerInfoResetFinished(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleRacingPlayerInfoResetFinished(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	LWOOBJID playerID;
 
-	inStream->Read(playerID);
+	inStream.Read(playerID);
 
 	auto* player = Game::entityManager->GetEntity(playerID);
 
@@ -4198,10 +4198,10 @@ void GameMessages::SendUpdateReputation(const LWOOBJID objectId, const int64_t r
 	SEND_PACKET;
 }
 
-void GameMessages::HandleUpdatePropertyPerformanceCost(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleUpdatePropertyPerformanceCost(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	float performanceCost = 0.0f;
 
-	if (inStream->ReadBit()) inStream->Read(performanceCost);
+	if (inStream.ReadBit()) inStream.Read(performanceCost);
 
 	if (performanceCost == 0.0f) return;
 
@@ -4214,16 +4214,16 @@ void GameMessages::HandleUpdatePropertyPerformanceCost(RakNet::BitStream* inStre
 	Database::Get()->UpdatePerformanceCost(zone->GetZoneID(), performanceCost);
 }
 
-void GameMessages::HandleVehicleNotifyHitImaginationServer(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleVehicleNotifyHitImaginationServer(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	LWOOBJID pickupObjID = LWOOBJID_EMPTY;
 	LWOOBJID pickupSpawnerID = LWOOBJID_EMPTY;
 	int32_t pickupSpawnerIndex = -1;
 	NiPoint3 vehiclePosition = NiPoint3Constant::ZERO;
 
-	if (inStream->ReadBit()) inStream->Read(pickupObjID);
-	if (inStream->ReadBit()) inStream->Read(pickupSpawnerID);
-	if (inStream->ReadBit()) inStream->Read(pickupSpawnerIndex);
-	if (inStream->ReadBit()) inStream->Read(vehiclePosition);
+	if (inStream.ReadBit()) inStream.Read(pickupObjID);
+	if (inStream.ReadBit()) inStream.Read(pickupSpawnerID);
+	if (inStream.ReadBit()) inStream.Read(pickupSpawnerIndex);
+	if (inStream.ReadBit()) inStream.Read(vehiclePosition);
 
 	auto* pickup = Game::entityManager->GetEntity(pickupObjID);
 
@@ -4545,7 +4545,7 @@ void GameMessages::SendAddBuff(LWOOBJID& objectID, const LWOOBJID& casterID, uin
 
 // NT
 
-void GameMessages::HandleRequestMoveItemBetweenInventoryTypes(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleRequestMoveItemBetweenInventoryTypes(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	bool bAllowPartial{};
 	int32_t destSlot = -1;
 	int32_t iStackCount = 1;
@@ -4556,15 +4556,15 @@ void GameMessages::HandleRequestMoveItemBetweenInventoryTypes(RakNet::BitStream*
 	LWOOBJID subkey = LWOOBJID_EMPTY;
 	LOT itemLOT = 0;
 
-	bAllowPartial = inStream->ReadBit();
-	if (inStream->ReadBit()) inStream->Read(destSlot);
-	if (inStream->ReadBit()) inStream->Read(iStackCount);
-	if (inStream->ReadBit()) inStream->Read(invTypeDst);
-	if (inStream->ReadBit()) inStream->Read(invTypeSrc);
-	if (inStream->ReadBit()) inStream->Read(itemID);
-	showFlyingLoot = inStream->ReadBit();
-	if (inStream->ReadBit()) inStream->Read(subkey);
-	if (inStream->ReadBit()) inStream->Read(itemLOT);
+	bAllowPartial = inStream.ReadBit();
+	if (inStream.ReadBit()) inStream.Read(destSlot);
+	if (inStream.ReadBit()) inStream.Read(iStackCount);
+	if (inStream.ReadBit()) inStream.Read(invTypeDst);
+	if (inStream.ReadBit()) inStream.Read(invTypeSrc);
+	if (inStream.ReadBit()) inStream.Read(itemID);
+	showFlyingLoot = inStream.ReadBit();
+	if (inStream.ReadBit()) inStream.Read(subkey);
+	if (inStream.ReadBit()) inStream.Read(itemLOT);
 
 	if (invTypeDst == invTypeSrc) {
 		return;
@@ -4617,10 +4617,10 @@ void GameMessages::SendShowActivityCountdown(LWOOBJID objectId, bool bPlayAdditi
 //------------------------------------------------------------------- Handlers ------------------------------------------------------------------
 //-----------------------------------------------------------------------------------------------------------------------------------------------
 
-void GameMessages::HandleToggleGhostReferenceOverride(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleToggleGhostReferenceOverride(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	bool bOverride = false;
 
-	inStream->Read(bOverride);
+	inStream.Read(bOverride);
 
 	auto* player = PlayerManager::GetPlayer(sysAddr);
 
@@ -4633,10 +4633,10 @@ void GameMessages::HandleToggleGhostReferenceOverride(RakNet::BitStream* inStrea
 }
 
 
-void GameMessages::HandleSetGhostReferencePosition(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleSetGhostReferencePosition(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	NiPoint3 position;
 
-	inStream->Read(position);
+	inStream.Read(position);
 
 	auto* player = PlayerManager::GetPlayer(sysAddr);
 
@@ -4649,16 +4649,16 @@ void GameMessages::HandleSetGhostReferencePosition(RakNet::BitStream* inStream, 
 }
 
 
-void GameMessages::HandleBuyFromVendor(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleBuyFromVendor(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	bool bConfirmed{}; // This doesn't appear to do anything.  Further research is needed.
 	bool countIsDefault{};
 	int count = 1;
 	LOT item;
 
-	inStream->Read(bConfirmed);
-	inStream->Read(countIsDefault);
-	if (countIsDefault) inStream->Read(count);
-	inStream->Read(item);
+	inStream.Read(bConfirmed);
+	inStream.Read(countIsDefault);
+	if (countIsDefault) inStream.Read(count);
+	inStream.Read(item);
 
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 	if (!user) return;
@@ -4754,14 +4754,14 @@ void GameMessages::HandleBuyFromVendor(RakNet::BitStream* inStream, Entity* enti
 	GameMessages::SendVendorTransactionResult(entity, sysAddr);
 }
 
-void GameMessages::HandleSellToVendor(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleSellToVendor(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	bool countIsDefault{};
 	int count = 1;
 	LWOOBJID iObjID;
 
-	inStream->Read(countIsDefault);
-	if (countIsDefault) inStream->Read(count);
-	inStream->Read(iObjID);
+	inStream.Read(countIsDefault);
+	if (countIsDefault) inStream.Read(count);
+	inStream.Read(iObjID);
 
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 	if (!user) return;
@@ -4800,16 +4800,16 @@ void GameMessages::HandleSellToVendor(RakNet::BitStream* inStream, Entity* entit
 	GameMessages::SendVendorTransactionResult(entity, sysAddr);
 }
 
-void GameMessages::HandleBuybackFromVendor(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleBuybackFromVendor(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	bool confirmed = false;
 	bool countIsDefault{};
 	int count = 1;
 	LWOOBJID iObjID;
 
-	inStream->Read(confirmed);
-	inStream->Read(countIsDefault);
-	if (countIsDefault) inStream->Read(count);
-	inStream->Read(iObjID);
+	inStream.Read(confirmed);
+	inStream.Read(countIsDefault);
+	if (countIsDefault) inStream.Read(count);
+	inStream.Read(iObjID);
 
 	//if (!confirmed) return; they always built in this confirmed garbage... but never used it?
 
@@ -4859,16 +4859,16 @@ void GameMessages::HandleBuybackFromVendor(RakNet::BitStream* inStream, Entity* 
 	GameMessages::SendVendorTransactionResult(entity, sysAddr);
 }
 
-void GameMessages::HandleParseChatMessage(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleParseChatMessage(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	std::u16string wsString;
 	int iClientState;
-	inStream->Read(iClientState);
+	inStream.Read(iClientState);
 
 	uint32_t wsStringLength;
-	inStream->Read(wsStringLength);
+	inStream.Read(wsStringLength);
 	for (uint32_t i = 0; i < wsStringLength; ++i) {
 		uint16_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 		wsString.push_back(character);
 	}
 
@@ -4877,7 +4877,7 @@ void GameMessages::HandleParseChatMessage(RakNet::BitStream* inStream, Entity* e
 	}
 }
 
-void GameMessages::HandleFireEventServerSide(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleFireEventServerSide(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	uint32_t argsLength{};
 	std::u16string args{};
 	bool param1IsDefault{};
@@ -4888,19 +4888,19 @@ void GameMessages::HandleFireEventServerSide(RakNet::BitStream* inStream, Entity
 	int param3 = -1;
 	LWOOBJID senderID{};
 
-	inStream->Read(argsLength);
+	inStream.Read(argsLength);
 	for (uint32_t i = 0; i < argsLength; ++i) {
 		uint16_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 		args.push_back(character);
 	}
-	inStream->Read(param1IsDefault);
-	if (param1IsDefault) inStream->Read(param1);
-	inStream->Read(param2IsDefault);
-	if (param2IsDefault) inStream->Read(param2);
-	inStream->Read(param3IsDefault);
-	if (param3IsDefault) inStream->Read(param3);
-	inStream->Read(senderID);
+	inStream.Read(param1IsDefault);
+	if (param1IsDefault) inStream.Read(param1);
+	inStream.Read(param2IsDefault);
+	if (param2IsDefault) inStream.Read(param2);
+	inStream.Read(param3IsDefault);
+	if (param3IsDefault) inStream.Read(param3);
+	inStream.Read(senderID);
 
 	auto* sender = Game::entityManager->GetEntity(senderID);
 	auto* player = PlayerManager::GetPlayer(sysAddr);
@@ -4961,17 +4961,17 @@ void GameMessages::HandleFireEventServerSide(RakNet::BitStream* inStream, Entity
 	entity->OnFireEventServerSide(sender, GeneralUtils::UTF16ToWTF8(args), param1, param2, param3);
 }
 
-void GameMessages::HandleRequestPlatformResync(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleRequestPlatformResync(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	if (entity->GetLOT() == 6267 || entity->GetLOT() == 16141) return;
 	GameMessages::SendPlatformResync(entity, sysAddr);
 }
 
-void GameMessages::HandleQuickBuildCancel(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleQuickBuildCancel(RakNet::BitStream& inStream, Entity* entity) {
 	bool bEarlyRelease;
 	LWOOBJID userID;
 
-	inStream->Read(bEarlyRelease);
-	inStream->Read(userID);
+	inStream.Read(bEarlyRelease);
+	inStream.Read(userID);
 
 	auto* quickBuildComponent = static_cast<QuickBuildComponent*>(entity->GetComponent(eReplicaComponentType::QUICK_BUILD));;
 	if (!quickBuildComponent) return;
@@ -4979,18 +4979,18 @@ void GameMessages::HandleQuickBuildCancel(RakNet::BitStream* inStream, Entity* e
 	quickBuildComponent->CancelQuickBuild(Game::entityManager->GetEntity(userID), eQuickBuildFailReason::CANCELED_EARLY);
 }
 
-void GameMessages::HandleRequestUse(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleRequestUse(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	bool bIsMultiInteractUse = false;
 	unsigned int multiInteractID;
 	int multiInteractType;
 	bool secondary;
 	LWOOBJID objectID;
 
-	inStream->Read(bIsMultiInteractUse);
-	inStream->Read(multiInteractID);
-	inStream->Read(multiInteractType);
-	inStream->Read(objectID);
-	inStream->Read(secondary);
+	inStream.Read(bIsMultiInteractUse);
+	inStream.Read(multiInteractID);
+	inStream.Read(multiInteractType);
+	inStream.Read(objectID);
+	inStream.Read(secondary);
 
 	Entity* interactedObject = Game::entityManager->GetEntity(objectID);
 
@@ -5027,12 +5027,12 @@ void GameMessages::HandleRequestUse(RakNet::BitStream* inStream, Entity* entity,
 	missionComponent->Progress(eMissionTaskType::INTERACT, interactedObject->GetLOT(), interactedObject->GetObjectID());
 }
 
-void GameMessages::HandlePlayEmote(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandlePlayEmote(RakNet::BitStream& inStream, Entity* entity) {
 	int emoteID;
 	LWOOBJID targetID;
 
-	inStream->Read(emoteID);
-	inStream->Read(targetID);
+	inStream.Read(emoteID);
+	inStream.Read(targetID);
 
 	LOG_DEBUG("Emote (%i) (%llu)", emoteID, targetID);
 
@@ -5076,10 +5076,10 @@ void GameMessages::HandlePlayEmote(RakNet::BitStream* inStream, Entity* entity) 
 	}
 }
 
-void GameMessages::HandleModularBuildConvertModel(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleModularBuildConvertModel(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	LWOOBJID modelID;
 
-	inStream->Read(modelID);
+	inStream.Read(modelID);
 
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 	if (!user) return;
@@ -5103,29 +5103,29 @@ void GameMessages::HandleModularBuildConvertModel(RakNet::BitStream* inStream, E
 	item->SetCount(item->GetCount() - 1, false, false, true, eLootSourceType::QUICKBUILD);
 }
 
-void GameMessages::HandleSetFlag(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleSetFlag(RakNet::BitStream& inStream, Entity* entity) {
 	bool bFlag{};
 	int32_t iFlagID{};
 
-	inStream->Read(bFlag);
-	inStream->Read(iFlagID);
+	inStream.Read(bFlag);
+	inStream.Read(iFlagID);
 
 	auto character = entity->GetCharacter();
 	if (character) character->SetPlayerFlag(iFlagID, bFlag);
 }
 
-void GameMessages::HandleRespondToMission(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleRespondToMission(RakNet::BitStream& inStream, Entity* entity) {
 	int missionID{};
 	LWOOBJID playerID{};
 	LWOOBJID receiverID{};
 	bool isDefaultReward{};
 	LOT reward = LOT_NULL;
 
-	inStream->Read(missionID);
-	inStream->Read(playerID);
-	inStream->Read(receiverID);
-	inStream->Read(isDefaultReward);
-	if (isDefaultReward) inStream->Read(reward);
+	inStream.Read(missionID);
+	inStream.Read(playerID);
+	inStream.Read(receiverID);
+	inStream.Read(isDefaultReward);
+	if (isDefaultReward) inStream.Read(reward);
 
 	MissionComponent* missionComponent = static_cast<MissionComponent*>(entity->GetComponent(eReplicaComponentType::MISSION));
 	if (!missionComponent) {
@@ -5152,17 +5152,17 @@ void GameMessages::HandleRespondToMission(RakNet::BitStream* inStream, Entity* e
 	}
 }
 
-void GameMessages::HandleMissionDialogOK(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleMissionDialogOK(RakNet::BitStream& inStream, Entity* entity) {
 	bool bIsComplete{};
 	eMissionState iMissionState{};
 	int missionID{};
 	LWOOBJID responder{};
 	Entity* player = nullptr;
 
-	inStream->Read(bIsComplete);
-	inStream->Read(iMissionState);
-	inStream->Read(missionID);
-	inStream->Read(responder);
+	inStream.Read(bIsComplete);
+	inStream.Read(iMissionState);
+	inStream.Read(missionID);
+	inStream.Read(responder);
 	player = Game::entityManager->GetEntity(responder);
 
 	for (CppScripts::Script* script : CppScripts::GetEntityScripts(entity)) {
@@ -5191,14 +5191,14 @@ void GameMessages::HandleMissionDialogOK(RakNet::BitStream* inStream, Entity* en
 	});
 }
 
-void GameMessages::HandleRequestLinkedMission(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleRequestLinkedMission(RakNet::BitStream& inStream, Entity* entity) {
 	LWOOBJID playerId{};
 	int missionId{};
 	bool bMissionOffered{};
 
-	inStream->Read(playerId);
-	inStream->Read(missionId);
-	inStream->Read(bMissionOffered);
+	inStream.Read(playerId);
+	inStream.Read(missionId);
+	inStream.Read(bMissionOffered);
 
 	auto* player = Game::entityManager->GetEntity(playerId);
 
@@ -5209,9 +5209,9 @@ void GameMessages::HandleRequestLinkedMission(RakNet::BitStream* inStream, Entit
 	}
 }
 
-void GameMessages::HandleHasBeenCollected(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleHasBeenCollected(RakNet::BitStream& inStream, Entity* entity) {
 	LWOOBJID playerID;
-	inStream->Read(playerID);
+	inStream.Read(playerID);
 
 	Entity* player = Game::entityManager->GetEntity(playerID);
 	if (!player || !entity || entity->GetCollectibleID() == 0) return;
@@ -5222,7 +5222,7 @@ void GameMessages::HandleHasBeenCollected(RakNet::BitStream* inStream, Entity* e
 	}
 }
 
-void GameMessages::HandleNotifyServerLevelProcessingComplete(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleNotifyServerLevelProcessingComplete(RakNet::BitStream& inStream, Entity* entity) {
 	auto* levelComp = entity->GetComponent<LevelProgressionComponent>();
 	if (!levelComp) return;
 	auto* character = entity->GetComponent<CharacterComponent>();
@@ -5261,9 +5261,9 @@ void GameMessages::HandleNotifyServerLevelProcessingComplete(RakNet::BitStream* 
 	GameMessages::SendBroadcastTextToChatbox(entity, UNASSIGNED_SYSTEM_ADDRESS, attrs, wsText);
 }
 
-void GameMessages::HandlePickupCurrency(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandlePickupCurrency(RakNet::BitStream& inStream, Entity* entity) {
 	unsigned int currency;
-	inStream->Read(currency);
+	inStream.Read(currency);
 
 	if (currency == 0) return;
 
@@ -5273,7 +5273,7 @@ void GameMessages::HandlePickupCurrency(RakNet::BitStream* inStream, Entity* ent
 	}
 }
 
-void GameMessages::HandleRequestDie(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleRequestDie(RakNet::BitStream& inStream, Entity* entity) {
 	LWOOBJID killerID;
 	LWOOBJID lootOwnerID;
 	bool bDieAccepted = false;
@@ -5286,38 +5286,38 @@ void GameMessages::HandleRequestDie(RakNet::BitStream* inStream, Entity* entity)
 	bool bSpawnLoot = true;
 	float coinSpawnTime = -1.0f;
 
-	inStream->Read(bClientDeath);
-	inStream->Read(bDieAccepted);
-	inStream->Read(bSpawnLoot);
+	inStream.Read(bClientDeath);
+	inStream.Read(bDieAccepted);
+	inStream.Read(bSpawnLoot);
 
 	bool coinSpawnTimeIsDefault{};
-	inStream->Read(coinSpawnTimeIsDefault);
-	if (coinSpawnTimeIsDefault != 0) inStream->Read(coinSpawnTime);
+	inStream.Read(coinSpawnTimeIsDefault);
+	if (coinSpawnTimeIsDefault != 0) inStream.Read(coinSpawnTime);
 
 	/*uint32_t deathTypeLength = deathType.size();
-	inStream->Read(deathTypeLength);
+	inStream.Read(deathTypeLength);
 	for (uint32_t k = 0; k < deathTypeLength; k++) {
-		inStream->Read<uint16_t>(deathType[k]);
+		inStream.Read<uint16_t>(deathType[k]);
 	}*/
 
-	inStream->Read(directionRelative_AngleXZ);
-	inStream->Read(directionRelative_AngleY);
-	inStream->Read(directionRelative_Force);
+	inStream.Read(directionRelative_AngleXZ);
+	inStream.Read(directionRelative_AngleY);
+	inStream.Read(directionRelative_Force);
 
 	bool killTypeIsDefault{};
-	inStream->Read(killTypeIsDefault);
-	if (killTypeIsDefault != 0) inStream->Read(killType);
+	inStream.Read(killTypeIsDefault);
+	if (killTypeIsDefault != 0) inStream.Read(killType);
 
-	inStream->Read(lootOwnerID);
-	inStream->Read(killerID);
+	inStream.Read(lootOwnerID);
+	inStream.Read(killerID);
 }
 
-void GameMessages::HandleEquipItem(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleEquipItem(RakNet::BitStream& inStream, Entity* entity) {
 	bool immediate;
 	LWOOBJID objectID;
-	inStream->Read(immediate);
-	inStream->Read(immediate); //twice?
-	inStream->Read(objectID);
+	inStream.Read(immediate);
+	inStream.Read(immediate); //twice?
+	inStream.Read(objectID);
 
 	InventoryComponent* inv = static_cast<InventoryComponent*>(entity->GetComponent(eReplicaComponentType::INVENTORY));
 	if (!inv) return;
@@ -5330,13 +5330,13 @@ void GameMessages::HandleEquipItem(RakNet::BitStream* inStream, Entity* entity) 
 	Game::entityManager->SerializeEntity(entity);
 }
 
-void GameMessages::HandleUnequipItem(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleUnequipItem(RakNet::BitStream& inStream, Entity* entity) {
 	bool immediate;
 	LWOOBJID objectID;
-	inStream->Read(immediate);
-	inStream->Read(immediate);
-	inStream->Read(immediate);
-	inStream->Read(objectID);
+	inStream.Read(immediate);
+	inStream.Read(immediate);
+	inStream.Read(immediate);
+	inStream.Read(objectID);
 
 	InventoryComponent* inv = static_cast<InventoryComponent*>(entity->GetComponent(eReplicaComponentType::INVENTORY));
 	if (!inv) return;
@@ -5350,7 +5350,7 @@ void GameMessages::HandleUnequipItem(RakNet::BitStream* inStream, Entity* entity
 	Game::entityManager->SerializeEntity(entity);
 }
 
-void GameMessages::HandleRemoveItemFromInventory(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleRemoveItemFromInventory(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	// this is used for a lot more than just inventory trashing (trades, vendors, etc.) but for now since it's just used for that, that's all im going to implement
 	bool bConfirmed = false;
 	bool bDeleteItem = true;
@@ -5378,40 +5378,40 @@ void GameMessages::HandleRemoveItemFromInventory(RakNet::BitStream* inStream, En
 	bool iTradeIDIsDefault = false;
 	LWOOBJID iTradeID = LWOOBJID_EMPTY;
 
-	inStream->Read(bConfirmed);
-	inStream->Read(bDeleteItem);
-	inStream->Read(bOutSuccess);
-	inStream->Read(eInvTypeIsDefault);
-	if (eInvTypeIsDefault) inStream->Read(eInvType);
-	inStream->Read(eLootTypeSourceIsDefault);
-	if (eLootTypeSourceIsDefault) inStream->Read(eLootTypeSource);
-	inStream->Read(extraInfo.length);
+	inStream.Read(bConfirmed);
+	inStream.Read(bDeleteItem);
+	inStream.Read(bOutSuccess);
+	inStream.Read(eInvTypeIsDefault);
+	if (eInvTypeIsDefault) inStream.Read(eInvType);
+	inStream.Read(eLootTypeSourceIsDefault);
+	if (eLootTypeSourceIsDefault) inStream.Read(eLootTypeSource);
+	inStream.Read(extraInfo.length);
 	if (extraInfo.length > 0) {
 		for (uint32_t i = 0; i < extraInfo.length; ++i) {
 			uint16_t character;
-			inStream->Read(character);
+			inStream.Read(character);
 			extraInfo.name.push_back(character);
 		}
 		uint16_t nullTerm;
-		inStream->Read(nullTerm);
+		inStream.Read(nullTerm);
 	}
-	inStream->Read(forceDeletion);
-	inStream->Read(iLootTypeSourceIsDefault);
-	if (iLootTypeSourceIsDefault) inStream->Read(iLootTypeSource);
-	inStream->Read(iObjIDIsDefault);
-	if (iObjIDIsDefault) inStream->Read(iObjID);
-	inStream->Read(iObjTemplateIsDefault);
-	if (iObjTemplateIsDefault) inStream->Read(iObjTemplate);
-	inStream->Read(iRequestingObjIDIsDefault);
-	if (iRequestingObjIDIsDefault) inStream->Read(iRequestingObjID);
-	inStream->Read(iStackCountIsDefault);
-	if (iStackCountIsDefault) inStream->Read(iStackCount);
-	inStream->Read(iStackRemainingIsDefault);
-	if (iStackRemainingIsDefault) inStream->Read(iStackRemaining);
-	inStream->Read(iSubkeyIsDefault);
-	if (iSubkeyIsDefault) inStream->Read(iSubkey);
-	inStream->Read(iTradeIDIsDefault);
-	if (iTradeIDIsDefault) inStream->Read(iTradeID);
+	inStream.Read(forceDeletion);
+	inStream.Read(iLootTypeSourceIsDefault);
+	if (iLootTypeSourceIsDefault) inStream.Read(iLootTypeSource);
+	inStream.Read(iObjIDIsDefault);
+	if (iObjIDIsDefault) inStream.Read(iObjID);
+	inStream.Read(iObjTemplateIsDefault);
+	if (iObjTemplateIsDefault) inStream.Read(iObjTemplate);
+	inStream.Read(iRequestingObjIDIsDefault);
+	if (iRequestingObjIDIsDefault) inStream.Read(iRequestingObjID);
+	inStream.Read(iStackCountIsDefault);
+	if (iStackCountIsDefault) inStream.Read(iStackCount);
+	inStream.Read(iStackRemainingIsDefault);
+	if (iStackRemainingIsDefault) inStream.Read(iStackRemaining);
+	inStream.Read(iSubkeyIsDefault);
+	if (iSubkeyIsDefault) inStream.Read(iSubkey);
+	inStream.Read(iTradeIDIsDefault);
+	if (iTradeIDIsDefault) inStream.Read(iTradeID);
 
 	InventoryComponent* inv = static_cast<InventoryComponent*>(entity->GetComponent(eReplicaComponentType::INVENTORY));
 	if (!inv) return;
@@ -5452,19 +5452,19 @@ void GameMessages::SendSetGravityScale(const LWOOBJID& target, const float effec
 	SEND_PACKET;
 }
 
-void GameMessages::HandleMoveItemInInventory(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleMoveItemInInventory(RakNet::BitStream& inStream, Entity* entity) {
 	bool destInvTypeIsDefault = false;
 	int32_t destInvType = eInventoryType::INVALID;
 	LWOOBJID iObjID;
 	int inventoryType;
 	int responseCode;
 	int slot;
-	inStream->Read(destInvTypeIsDefault);
-	if (destInvTypeIsDefault) { inStream->Read(destInvType); }
-	inStream->Read(iObjID);
-	inStream->Read(inventoryType);
-	inStream->Read(responseCode);
-	inStream->Read(slot);
+	inStream.Read(destInvTypeIsDefault);
+	if (destInvTypeIsDefault) { inStream.Read(destInvType); }
+	inStream.Read(iObjID);
+	inStream.Read(inventoryType);
+	inStream.Read(responseCode);
+	inStream.Read(slot);
 
 	InventoryComponent* inv = static_cast<InventoryComponent*>(entity->GetComponent(eReplicaComponentType::INVENTORY));
 	if (!inv) return;
@@ -5479,7 +5479,7 @@ void GameMessages::HandleMoveItemInInventory(RakNet::BitStream* inStream, Entity
 	Game::entityManager->SerializeEntity(entity);
 }
 
-void GameMessages::HandleMoveItemBetweenInventoryTypes(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleMoveItemBetweenInventoryTypes(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	eInventoryType inventoryTypeA;
 	eInventoryType inventoryTypeB;
 	LWOOBJID objectID;
@@ -5489,14 +5489,14 @@ void GameMessages::HandleMoveItemBetweenInventoryTypes(RakNet::BitStream* inStre
 	bool templateIDIsDefault = false;
 	LOT templateID = LOT_NULL;
 
-	inStream->Read(inventoryTypeA);
-	inStream->Read(inventoryTypeB);
-	inStream->Read(objectID);
-	inStream->Read(showFlyingLoot);
-	inStream->Read(stackCountIsDefault);
-	if (stackCountIsDefault) inStream->Read(stackCount);
-	inStream->Read(templateIDIsDefault);
-	if (templateIDIsDefault) inStream->Read(templateID);
+	inStream.Read(inventoryTypeA);
+	inStream.Read(inventoryTypeB);
+	inStream.Read(objectID);
+	inStream.Read(showFlyingLoot);
+	inStream.Read(stackCountIsDefault);
+	if (stackCountIsDefault) inStream.Read(stackCount);
+	inStream.Read(templateIDIsDefault);
+	if (templateIDIsDefault) inStream.Read(templateID);
 
 	auto inv = entity->GetComponent<InventoryComponent>();
 	if (!inv) return;
@@ -5525,10 +5525,10 @@ void GameMessages::HandleMoveItemBetweenInventoryTypes(RakNet::BitStream* inStre
 	Game::entityManager->SerializeEntity(entity);
 }
 
-void GameMessages::HandleBuildModeSet(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleBuildModeSet(RakNet::BitStream& inStream, Entity* entity) {
 	bool bStart = false;
 
-	inStream->Read(bStart);
+	inStream.Read(bStart);
 	// there's more here but we don't need it (for now?)
 
 	LOG("Set build mode to (%d) for (%llu)", bStart, entity->GetObjectID());
@@ -5538,7 +5538,7 @@ void GameMessages::HandleBuildModeSet(RakNet::BitStream* inStream, Entity* entit
 	}
 }
 
-void GameMessages::HandleModularBuildFinish(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleModularBuildFinish(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 	if (!user) return;
 	Entity* character = Game::entityManager->GetEntity(user->GetLoggedInChar());
@@ -5549,7 +5549,7 @@ void GameMessages::HandleModularBuildFinish(RakNet::BitStream* inStream, Entity*
 
 	uint8_t count; // 3 for rockets, 7 for cars
 
-	inStream->Read(count);
+	inStream.Read(count);
 
 	auto* temp = inv->GetInventory(TEMP_MODELS);
 	std::vector<LOT> modList;
@@ -5560,7 +5560,7 @@ void GameMessages::HandleModularBuildFinish(RakNet::BitStream* inStream, Entity*
 
 		for (uint32_t k = 0; k < count; k++) {
 			uint32_t mod;
-			inStream->Read(mod);
+			inStream.Read(mod);
 			modList.push_back(mod);
 			auto modToStr = GeneralUtils::to_u16string(mod);
 			modules += u"1:" + (modToStr);
@@ -5638,7 +5638,7 @@ void GameMessages::HandleModularBuildFinish(RakNet::BitStream* inStream, Entity*
 	}
 }
 
-void GameMessages::HandleDoneArrangingWithItem(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleDoneArrangingWithItem(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 	if (!user) return;
 	Entity* character = Game::entityManager->GetEntity(user->GetLoggedInChar());
@@ -5673,18 +5673,18 @@ void GameMessages::HandleDoneArrangingWithItem(RakNet::BitStream* inStream, Enti
 	LOT oldItemLOT = 0;
 	int oldItemTYPE = 0;
 
-	inStream->Read(newSourceBAG);
-	inStream->Read(newSourceID);
-	inStream->Read(newSourceLOT);
-	inStream->Read(newSourceTYPE);
-	inStream->Read(newTargetID);
-	inStream->Read(newTargetLOT);
-	inStream->Read(newTargetTYPE);
-	inStream->Read(newTargetPOS);
-	inStream->Read(oldItemBAG);
-	inStream->Read(oldItemID);
-	inStream->Read(oldItemLOT);
-	inStream->Read(oldItemTYPE);
+	inStream.Read(newSourceBAG);
+	inStream.Read(newSourceID);
+	inStream.Read(newSourceLOT);
+	inStream.Read(newSourceTYPE);
+	inStream.Read(newTargetID);
+	inStream.Read(newTargetLOT);
+	inStream.Read(newTargetTYPE);
+	inStream.Read(newTargetPOS);
+	inStream.Read(oldItemBAG);
+	inStream.Read(oldItemID);
+	inStream.Read(oldItemLOT);
+	inStream.Read(oldItemTYPE);
 
 	/*
 	LOG("GameMessages",
@@ -5749,7 +5749,7 @@ void GameMessages::HandleDoneArrangingWithItem(RakNet::BitStream* inStream, Enti
 	}
 }
 
-void GameMessages::HandleModularBuildMoveAndEquip(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleModularBuildMoveAndEquip(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	User* user = UserManager::Instance()->GetUser(sysAddr);
 	if (!user) return;
 	Entity* character = Game::entityManager->GetEntity(user->GetLoggedInChar());
@@ -5759,7 +5759,7 @@ void GameMessages::HandleModularBuildMoveAndEquip(RakNet::BitStream* inStream, E
 
 	LOT templateID;
 
-	inStream->Read(templateID);
+	inStream.Read(templateID);
 
 	InventoryComponent* inv = static_cast<InventoryComponent*>(character->GetComponent(eReplicaComponentType::INVENTORY));
 	if (!inv) return;
@@ -5773,11 +5773,11 @@ void GameMessages::HandleModularBuildMoveAndEquip(RakNet::BitStream* inStream, E
 	inv->MoveItemToInventory(item, eInventoryType::MODELS, 1, false, true);
 }
 
-void GameMessages::HandlePickupItem(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandlePickupItem(RakNet::BitStream& inStream, Entity* entity) {
 	LWOOBJID lootObjectID;
 	LWOOBJID playerID;
-	inStream->Read(lootObjectID);
-	inStream->Read(playerID);
+	inStream.Read(lootObjectID);
+	inStream.Read(playerID);
 
 	entity->PickupItem(lootObjectID);
 
@@ -5794,8 +5794,8 @@ void GameMessages::HandlePickupItem(RakNet::BitStream* inStream, Entity* entity)
 	}
 }
 
-void GameMessages::HandleResurrect(RakNet::BitStream* inStream, Entity* entity) {
-	bool immediate = inStream->ReadBit();
+void GameMessages::HandleResurrect(RakNet::BitStream& inStream, Entity* entity) {
+	bool immediate = inStream.ReadBit();
 
 	Entity* zoneControl = Game::entityManager->GetZoneControlEntity();
 	for (CppScripts::Script* script : CppScripts::GetEntityScripts(zoneControl)) {
@@ -5812,13 +5812,13 @@ void GameMessages::HandleResurrect(RakNet::BitStream* inStream, Entity* entity) 
 	}
 }
 
-void GameMessages::HandlePushEquippedItemsState(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandlePushEquippedItemsState(RakNet::BitStream& inStream, Entity* entity) {
 	InventoryComponent* inv = static_cast<InventoryComponent*>(entity->GetComponent(eReplicaComponentType::INVENTORY));
 	if (!inv) return;
 	inv->PushEquippedItems();
 }
 
-void GameMessages::HandlePopEquippedItemsState(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandlePopEquippedItemsState(RakNet::BitStream& inStream, Entity* entity) {
 	InventoryComponent* inv = static_cast<InventoryComponent*>(entity->GetComponent(eReplicaComponentType::INVENTORY));
 	if (!inv) return;
 	inv->PopEquippedItems();
@@ -5826,10 +5826,10 @@ void GameMessages::HandlePopEquippedItemsState(RakNet::BitStream* inStream, Enti
 }
 
 
-void GameMessages::HandleClientItemConsumed(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleClientItemConsumed(RakNet::BitStream& inStream, Entity* entity) {
 	LWOOBJID itemConsumed;
 
-	inStream->Read(itemConsumed);
+	inStream.Read(itemConsumed);
 
 	auto* inventory = static_cast<InventoryComponent*>(entity->GetComponent(eReplicaComponentType::INVENTORY));
 
@@ -5852,10 +5852,10 @@ void GameMessages::HandleClientItemConsumed(RakNet::BitStream* inStream, Entity*
 }
 
 
-void GameMessages::HandleUseNonEquipmentItem(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleUseNonEquipmentItem(RakNet::BitStream& inStream, Entity* entity) {
 	LWOOBJID itemConsumed;
 
-	inStream->Read(itemConsumed);
+	inStream.Read(itemConsumed);
 
 	auto* inv = static_cast<InventoryComponent*>(entity->GetComponent(eReplicaComponentType::INVENTORY));
 
@@ -5866,7 +5866,7 @@ void GameMessages::HandleUseNonEquipmentItem(RakNet::BitStream* inStream, Entity
 	if (item) item->UseNonEquip(item);
 }
 
-void GameMessages::HandleMatchRequest(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleMatchRequest(RakNet::BitStream& inStream, Entity* entity) {
 	LWOOBJID activator;
 	//std::map<LWOOBJID, LWONameValue> additionalPlayers;
 	uint32_t playerChoicesLen;
@@ -5874,19 +5874,19 @@ void GameMessages::HandleMatchRequest(RakNet::BitStream* inStream, Entity* entit
 	int type;
 	int value;
 
-	inStream->Read(activator);
-	inStream->Read(playerChoicesLen);
+	inStream.Read(activator);
+	inStream.Read(playerChoicesLen);
 	for (uint32_t i = 0; i < playerChoicesLen; ++i) {
 		uint16_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 		playerChoices.push_back(character);
 	}
 	if (playerChoicesLen > 0) {
 		uint16_t nullTerm;
-		inStream->Read(nullTerm);
+		inStream.Read(nullTerm);
 	}
-	inStream->Read(type);
-	inStream->Read(value);
+	inStream.Read(type);
+	inStream.Read(value);
 
 	std::vector<Entity*> scriptedActs = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SCRIPTED_ACTIVITY);
 	if (type == 0) { // join
@@ -5912,11 +5912,11 @@ void GameMessages::HandleMatchRequest(RakNet::BitStream* inStream, Entity* entit
 	}
 }
 
-void GameMessages::HandleGetHotPropertyData(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleGetHotPropertyData(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	SendGetHotPropertyData(inStream, entity, sysAddr);
 }
 
-void GameMessages::SendGetHotPropertyData(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::SendGetHotPropertyData(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	CBITSTREAM;
 	CMSGHEADER;
 	/**
@@ -5957,17 +5957,17 @@ void GameMessages::SendGetHotPropertyData(RakNet::BitStream* inStream, Entity* e
 	 SEND_PACKET*/
 }
 
-void GameMessages::HandleReportBug(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleReportBug(RakNet::BitStream& inStream, Entity* entity) {
 	//Definitely not stolen from autogenerated code, no sir:
 	IBugReports::Info reportInfo;
 
 	//Reading:
 	uint32_t messageLength;
-	inStream->Read(messageLength);
+	inStream.Read(messageLength);
 
 	for (uint32_t i = 0; i < (messageLength); ++i) {
 		uint16_t character;
-		inStream->Read(character);
+		inStream.Read(character);
 		reportInfo.body.push_back(static_cast<char>(character));
 	}
 
@@ -5975,26 +5975,26 @@ void GameMessages::HandleReportBug(RakNet::BitStream* inStream, Entity* entity) 
 	if (character) reportInfo.characterId = character->GetID();
 
 	uint32_t clientVersionLength;
-	inStream->Read(clientVersionLength);
+	inStream.Read(clientVersionLength);
 	for (unsigned int k = 0; k < clientVersionLength; k++) {
 		unsigned char character;
-		inStream->Read(character);
+		inStream.Read(character);
 		reportInfo.clientVersion.push_back(character);
 	}
 
 	uint32_t nOtherPlayerIDLength;
-	inStream->Read(nOtherPlayerIDLength);
+	inStream.Read(nOtherPlayerIDLength);
 	for (unsigned int k = 0; k < nOtherPlayerIDLength; k++) {
 		unsigned char character;
-		inStream->Read(character);
+		inStream.Read(character);
 		reportInfo.otherPlayer.push_back(character);
 	}
 
 	uint32_t selectionLength;
-	inStream->Read(selectionLength);
+	inStream.Read(selectionLength);
 	for (unsigned int k = 0; k < selectionLength; k++) {
 		unsigned char character;
-		inStream->Read(character);
+		inStream.Read(character);
 		reportInfo.selection.push_back(character);
 	}
 
@@ -6002,7 +6002,7 @@ void GameMessages::HandleReportBug(RakNet::BitStream* inStream, Entity* entity) 
 }
 
 void
-GameMessages::HandleClientRailMovementReady(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+GameMessages::HandleClientRailMovementReady(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	const auto possibleRails = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::RAIL_ACTIVATOR);
 	for (const auto* possibleRail : possibleRails) {
 		const auto* rail = possibleRail->GetComponent<RailActivatorComponent>();
@@ -6012,8 +6012,8 @@ GameMessages::HandleClientRailMovementReady(RakNet::BitStream* inStream, Entity*
 	}
 }
 
-void GameMessages::HandleCancelRailMovement(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
-	const auto immediate = inStream->ReadBit();
+void GameMessages::HandleCancelRailMovement(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
+	const auto immediate = inStream.ReadBit();
 
 	const auto possibleRails = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::RAIL_ACTIVATOR);
 	for (const auto* possibleRail : possibleRails) {
@@ -6024,20 +6024,20 @@ void GameMessages::HandleCancelRailMovement(RakNet::BitStream* inStream, Entity*
 	}
 }
 
-void GameMessages::HandlePlayerRailArrivedNotification(RakNet::BitStream* inStream, Entity* entity,
+void GameMessages::HandlePlayerRailArrivedNotification(RakNet::BitStream& inStream, Entity* entity,
 	const SystemAddress& sysAddr) {
 	uint32_t pathNameLength;
-	inStream->Read(pathNameLength);
+	inStream.Read(pathNameLength);
 
 	std::u16string pathName;
 	for (auto k = 0; k < pathNameLength; k++) {
 		uint16_t c;
-		inStream->Read(c);
+		inStream.Read(c);
 		pathName.push_back(c);
 	}
 
 	int32_t waypointNumber;
-	inStream->Read(waypointNumber);
+	inStream.Read(waypointNumber);
 
 	const auto possibleRails = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::RAIL_ACTIVATOR);
 	for (auto* possibleRail : possibleRails) {
@@ -6047,20 +6047,20 @@ void GameMessages::HandlePlayerRailArrivedNotification(RakNet::BitStream* inStre
 	}
 }
 
-void GameMessages::HandleModifyPlayerZoneStatistic(RakNet::BitStream* inStream, Entity* entity) {
-	const auto set = inStream->ReadBit();
+void GameMessages::HandleModifyPlayerZoneStatistic(RakNet::BitStream& inStream, Entity* entity) {
+	const auto set = inStream.ReadBit();
 	const auto statisticsName = GeneralUtils::ReadWString(inStream);
 
 	int32_t value;
-	if (inStream->ReadBit()) {
-		inStream->Read<int32_t>(value);
+	if (inStream.ReadBit()) {
+		inStream.Read<int32_t>(value);
 	} else {
 		value = 0;
 	}
 
 	LWOMAPID zone;
-	if (inStream->ReadBit()) {
-		inStream->Read<LWOMAPID>(zone);
+	if (inStream.ReadBit()) {
+		inStream.Read<LWOMAPID>(zone);
 	} else {
 		zone = LWOMAPID_INVALID;
 	}
@@ -6072,13 +6072,13 @@ void GameMessages::HandleModifyPlayerZoneStatistic(RakNet::BitStream* inStream, 
 	}
 }
 
-void GameMessages::HandleUpdatePlayerStatistic(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleUpdatePlayerStatistic(RakNet::BitStream& inStream, Entity* entity) {
 	int32_t updateID;
-	inStream->Read<int32_t>(updateID);
+	inStream.Read<int32_t>(updateID);
 
 	int64_t updateValue;
-	if (inStream->ReadBit()) {
-		inStream->Read<int64_t>(updateValue);
+	if (inStream.ReadBit()) {
+		inStream.Read<int64_t>(updateValue);
 	} else {
 		updateValue = 1;
 	}
@@ -6089,14 +6089,14 @@ void GameMessages::HandleUpdatePlayerStatistic(RakNet::BitStream* inStream, Enti
 	}
 }
 
-void GameMessages::HandleDeactivateBubbleBuff(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleDeactivateBubbleBuff(RakNet::BitStream& inStream, Entity* entity) {
 	auto controllablePhysicsComponent = entity->GetComponent<ControllablePhysicsComponent>();
 	if (controllablePhysicsComponent) controllablePhysicsComponent->DeactivateBubbleBuff();
 }
 
-void GameMessages::HandleActivateBubbleBuff(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleActivateBubbleBuff(RakNet::BitStream& inStream, Entity* entity) {
 	bool specialAnimations;
-	if (!inStream->Read(specialAnimations)) return;
+	if (!inStream.Read(specialAnimations)) return;
 
 	std::u16string type = GeneralUtils::ReadWString(inStream);
 	auto bubbleType = eBubbleType::DEFAULT;
@@ -6129,9 +6129,9 @@ void GameMessages::SendDeactivateBubbleBuffFromServer(LWOOBJID objectId, const S
 	SEND_PACKET;
 }
 
-void GameMessages::HandleZoneSummaryDismissed(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleZoneSummaryDismissed(RakNet::BitStream& inStream, Entity* entity) {
 	LWOOBJID player_id;
-	inStream->Read<LWOOBJID>(player_id);
+	inStream.Read<LWOOBJID>(player_id);
 	auto target = Game::entityManager->GetEntity(player_id);
 	entity->TriggerEvent(eTriggerEventType::ZONE_SUMMARY_DISMISSED, target);
 };
@@ -6165,25 +6165,25 @@ void GameMessages::SendShowBillboardInteractIcon(const SystemAddress& sysAddr, L
 	else SEND_PACKET
 }
 
-void GameMessages::HandleRequestActivityExit(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleRequestActivityExit(RakNet::BitStream& inStream, Entity* entity) {
 	bool canceled = false;
-	inStream->Read(canceled);
+	inStream.Read(canceled);
 	if (!canceled) return;
 
 	LWOOBJID player_id = LWOOBJID_EMPTY;
-	inStream->Read(player_id);
+	inStream.Read(player_id);
 	auto player = Game::entityManager->GetEntity(player_id);
 	if (!entity || !player) return;
 	entity->RequestActivityExit(entity, player_id, canceled);
 }
 
-void GameMessages::HandleAddDonationItem(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleAddDonationItem(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	uint32_t count = 1;
 	bool hasCount = false;
-	inStream->Read(hasCount);
-	if (hasCount) inStream->Read(count);
+	inStream.Read(hasCount);
+	if (hasCount) inStream.Read(count);
 	LWOOBJID itemId = LWOOBJID_EMPTY;
-	inStream->Read(itemId);
+	inStream.Read(itemId);
 	if (!itemId) return;
 
 	auto* donationVendorComponent = entity->GetComponent<DonationVendorComponent>();
@@ -6207,15 +6207,15 @@ void GameMessages::HandleAddDonationItem(RakNet::BitStream* inStream, Entity* en
 	inventoryComponent->MoveItemToInventory(item, eInventoryType::DONATION, count, true, false, true);
 }
 
-void GameMessages::HandleRemoveDonationItem(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr) {
+void GameMessages::HandleRemoveDonationItem(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	bool confirmed = false;
-	inStream->Read(confirmed);
+	inStream.Read(confirmed);
 	uint32_t count = 1;
 	bool hasCount = false;
-	inStream->Read(hasCount);
-	if (hasCount) inStream->Read(count);
+	inStream.Read(hasCount);
+	if (hasCount) inStream.Read(count);
 	LWOOBJID itemId = LWOOBJID_EMPTY;
-	inStream->Read(itemId);
+	inStream.Read(itemId);
 	if (!itemId) return;
 
 	User* user = UserManager::Instance()->GetUser(sysAddr);
@@ -6232,7 +6232,7 @@ void GameMessages::HandleRemoveDonationItem(RakNet::BitStream* inStream, Entity*
 	inventoryComponent->MoveItemToInventory(item, eInventoryType::BRICKS, count, true, false, true);
 }
 
-void GameMessages::HandleConfirmDonationOnPlayer(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleConfirmDonationOnPlayer(RakNet::BitStream& inStream, Entity* entity) {
 	auto* inventoryComponent = entity->GetComponent<InventoryComponent>();
 	if (!inventoryComponent) return;
 	auto* missionComponent = entity->GetComponent<MissionComponent>();
@@ -6264,7 +6264,7 @@ void GameMessages::HandleConfirmDonationOnPlayer(RakNet::BitStream* inStream, En
 	characterComponent->SetCurrentInteracting(LWOOBJID_EMPTY);
 }
 
-void GameMessages::HandleCancelDonationOnPlayer(RakNet::BitStream* inStream, Entity* entity) {
+void GameMessages::HandleCancelDonationOnPlayer(RakNet::BitStream& inStream, Entity* entity) {
 	auto* inventoryComponent = entity->GetComponent<InventoryComponent>();
 	if (!inventoryComponent) return;
 	auto* inventory = inventoryComponent->GetInventory(eInventoryType::DONATION);

--- a/dGame/dGameMessages/GameMessages.h
+++ b/dGame/dGameMessages/GameMessages.h
@@ -145,7 +145,7 @@ namespace GameMessages {
 	void SendMatchResponse(Entity* entity, const SystemAddress& sysAddr, int response);
 	void SendMatchUpdate(Entity* entity, const SystemAddress& sysAddr, std::string data, eMatchUpdate type);
 
-	void HandleUnUseModel(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleUnUseModel(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 	void SendStartCelebrationEffect(Entity* entity, const SystemAddress& sysAddr, int celebrationID);
 
 	// https://lcdruniverse.org/lu_packets/lu_packets/world/gm/client/struct.SetResurrectRestoreValues.html
@@ -182,7 +182,7 @@ namespace GameMessages {
 	 * @param entity The Entity that sent the message
 	 * @param sysAddr The SystemAddress that sent the message
 	 */
-	void HandleControlBehaviors(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleControlBehaviors(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	// Rails stuff
 	void SendSetRailMovement(const LWOOBJID& objectID, bool pathGoForward, std::u16string pathName, uint32_t pathStart,
@@ -196,9 +196,9 @@ namespace GameMessages {
 		bool collisionEnabled = true, bool useDB = true, int32_t railComponentID = -1,
 		LWOOBJID railActivatorObjectID = LWOOBJID_EMPTY);
 
-	void HandleClientRailMovementReady(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleCancelRailMovement(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandlePlayerRailArrivedNotification(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleClientRailMovementReady(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleCancelRailMovement(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandlePlayerRailArrivedNotification(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	void SendNotifyClientObject(const LWOOBJID& objectID, std::u16string name, int param1 = 0, int param2 = 0, const LWOOBJID& paramObj = LWOOBJID_EMPTY, std::string paramStr = "", const SystemAddress& sysAddr = UNASSIGNED_SYSTEM_ADDRESS);
 	void SendNotifyClientZoneObject(const LWOOBJID& objectID, const std::u16string& name, int param1, int param2, const LWOOBJID& paramObj, const std::string& paramStr, const SystemAddress& sysAddr);
@@ -251,39 +251,39 @@ namespace GameMessages {
 
 	void SendUGCEquipPostDeleteBasedOnEditMode(LWOOBJID objectId, const SystemAddress& sysAddr, LWOOBJID inventoryItem, int itemTotal);
 
-	void HandleSetPropertyAccess(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleSetPropertyAccess(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleUpdatePropertyOrModelForFilterCheck(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleUpdatePropertyOrModelForFilterCheck(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleQueryPropertyData(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleQueryPropertyData(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleSetBuildMode(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleSetBuildMode(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleStartBuildingWithItem(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleStartBuildingWithItem(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandlePropertyEditorBegin(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandlePropertyEditorBegin(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandlePropertyEditorEnd(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandlePropertyEditorEnd(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandlePropertyContentsFromClient(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandlePropertyContentsFromClient(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandlePropertyModelEquipped(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandlePropertyModelEquipped(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandlePlacePropertyModel(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandlePlacePropertyModel(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleUpdatePropertyModel(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleUpdatePropertyModel(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleDeletePropertyModel(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleDeletePropertyModel(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleBBBLoadItemRequest(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleBBBLoadItemRequest(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleBBBSaveRequest(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleBBBSaveRequest(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandlePropertyEntranceSync(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandlePropertyEntranceSync(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleEnterProperty(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleEnterProperty(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleSetConsumableItem(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleSetConsumableItem(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	void SendPlayCinematic(LWOOBJID objectId, std::u16string pathName, const SystemAddress& sysAddr,
 		bool allowGhostUpdates = true, bool bCloseMultiInteract = true, bool bSendServerNotify = false, bool bUseControlledObjectForAudioListener = false,
@@ -292,7 +292,7 @@ namespace GameMessages {
 
 	void SendEndCinematic(LWOOBJID objectID, std::u16string pathName, const SystemAddress& sysAddr = UNASSIGNED_SYSTEM_ADDRESS,
 		float leadOut = -1.0f, bool leavePlayerLocked = false);
-	void HandleCinematicUpdate(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleCinematicUpdate(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	void SendSetStunned(LWOOBJID objectId, eStateChangeType stateChangeType, const SystemAddress& sysAddr,
 		LWOOBJID originator = LWOOBJID_EMPTY, bool bCantAttack = false, bool bCantEquip = false,
@@ -344,7 +344,7 @@ namespace GameMessages {
 
 	void SendNotifyObject(LWOOBJID objectId, LWOOBJID objIDSender, std::u16string name, const SystemAddress& sysAddr, int param1 = 0, int param2 = 0);
 
-	void HandleVerifyAck(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleVerifyAck(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	void SendTeamPickupItem(LWOOBJID objectId, LWOOBJID lootID, LWOOBJID lootOwnerID, const SystemAddress& sysAddr);
 
@@ -361,13 +361,13 @@ namespace GameMessages {
 
 	void SendServerTradeUpdate(LWOOBJID objectId, uint64_t coins, const std::vector<TradeItem>& items, const SystemAddress& sysAddr);
 
-	void HandleClientTradeRequest(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleClientTradeRequest(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleClientTradeCancel(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleClientTradeCancel(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleClientTradeAccept(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleClientTradeAccept(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleClientTradeUpdate(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleClientTradeUpdate(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	//Pets:
 	void SendNotifyPetTamingMinigame(LWOOBJID objectId, LWOOBJID petId, LWOOBJID playerTamingId, bool bForceTeleport, ePetTamingNotifyType notifyType, NiPoint3 petsDestPos, NiPoint3 telePos, NiQuaternion teleRot, const SystemAddress& sysAddr);
@@ -402,23 +402,23 @@ namespace GameMessages {
 
 	void SendPetNameChanged(LWOOBJID objectId, int32_t moderationStatus, std::u16string name, std::u16string ownerName, const SystemAddress& sysAddr);
 
-	void HandleClientExitTamingMinigame(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleClientExitTamingMinigame(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleStartServerPetMinigameTimer(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleStartServerPetMinigameTimer(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandlePetTamingTryBuild(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandlePetTamingTryBuild(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleNotifyTamingBuildSuccess(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleNotifyTamingBuildSuccess(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleRequestSetPetName(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleRequestSetPetName(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleCommandPet(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleCommandPet(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleDespawnPet(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleDespawnPet(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleMessageBoxResponse(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleMessageBoxResponse(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleChoiceBoxRespond(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleChoiceBoxRespond(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	void SendDisplayZoneSummary(LWOOBJID objectId, const SystemAddress& sysAddr, bool isPropertyMap = false, bool isZoneStart = false, LWOOBJID sender = LWOOBJID_EMPTY);
 
@@ -455,7 +455,7 @@ namespace GameMessages {
 	 * @param entity The Entity that is dismounting
 	 * @param sysAddr the system address to send game message responses to
 	 */
-	void HandleDismountComplete(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleDismountComplete(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	/**
 	 * @brief Handle acknowledging that the client possessed something
@@ -464,7 +464,7 @@ namespace GameMessages {
 	 * @param entity The Entity that is possessing
 	 * @param sysAddr the system address to send game message responses to
 	 */
-	void HandleAcknowledgePossession(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleAcknowledgePossession(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	/**
 	 * @brief A request from a client to get the hot properties that would appear on the news feed
@@ -474,7 +474,7 @@ namespace GameMessages {
 	 * @param entity The Entity that sent the request
 	 * @param sysAddr The SystemAddress of the Entity that sent the request
 	 */
-	void HandleGetHotPropertyData(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleGetHotPropertyData(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	/**
 	 * @brief A request from a client to get the hot properties that would appear on the news feed
@@ -496,26 +496,26 @@ namespace GameMessages {
 	 * @param entity The Entity that sent the request
 	 * @param sysAddr The SystemAddress of the Entity that sent the request
 	 */
-	void SendGetHotPropertyData(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void SendGetHotPropertyData(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	//Racing:
-	void HandleModuleAssemblyQueryData(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleModuleAssemblyQueryData(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleModularAssemblyNIFCompleted(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleModularAssemblyNIFCompleted(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleVehicleSetWheelLockState(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleVehicleSetWheelLockState(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleRacingClientReady(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleRacingClientReady(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleRequestDie(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleRequestDie(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleVehicleNotifyServerAddPassiveBoostAction(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleVehicleNotifyServerAddPassiveBoostAction(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleVehicleNotifyServerRemovePassiveBoostAction(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleVehicleNotifyServerRemovePassiveBoostAction(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleRacingPlayerInfoResetFinished(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleRacingPlayerInfoResetFinished(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
-	void HandleVehicleNotifyHitImaginationServer(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleVehicleNotifyHitImaginationServer(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	void SendModuleAssemblyDBDataForClient(LWOOBJID objectId, LWOOBJID assemblyID, const std::u16string& data, const SystemAddress& sysAddr);
 
@@ -555,7 +555,7 @@ namespace GameMessages {
 		bool bUseLeaderboards
 	);
 
-	void HandleUpdatePropertyPerformanceCost(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleUpdatePropertyPerformanceCost(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	void SendNotifyClientShootingGalleryScore(LWOOBJID objectId, const SystemAddress& sysAddr,
 		float addTime,
@@ -564,20 +564,20 @@ namespace GameMessages {
 		NiPoint3 targetPos
 	);
 
-	void HandleUpdateShootingGalleryRotation(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleUpdateShootingGalleryRotation(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	void SendUpdateReputation(const LWOOBJID objectId, const int64_t reputation, const SystemAddress& sysAddr);
 
 	// Leaderboards
 	void SendActivitySummaryLeaderboardData(const LWOOBJID& objectID, const Leaderboard* leaderboard,
 		const SystemAddress& sysAddr = UNASSIGNED_SYSTEM_ADDRESS);
-	void HandleActivitySummaryLeaderboardData(RakNet::BitStream* instream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleActivitySummaryLeaderboardData(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 	void SendRequestActivitySummaryLeaderboardData(const LWOOBJID& objectID, const LWOOBJID& targetID,
 		const SystemAddress& sysAddr, const int32_t& gameID = 0,
 		const int32_t& queryType = 1, const int32_t& resultsEnd = 10,
 		const int32_t& resultsStart = 0, bool weekly = false);
-	void HandleRequestActivitySummaryLeaderboardData(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleActivityStateChangeRequest(RakNet::BitStream* inStream, Entity* entity);
+	void HandleRequestActivitySummaryLeaderboardData(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleActivityStateChangeRequest(RakNet::BitStream& inStream, Entity* entity);
 
 	void SendVehicleAddPassiveBoostAction(LWOOBJID objectId, const SystemAddress& sysAddr);
 
@@ -587,82 +587,82 @@ namespace GameMessages {
 
 	//NT:
 
-	void HandleRequestMoveItemBetweenInventoryTypes(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleRequestMoveItemBetweenInventoryTypes(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	void SendShowActivityCountdown(LWOOBJID objectId, bool bPlayAdditionalSound, bool bPlayCountdownSound, std::u16string sndName, int32_t stateToPlaySoundOn, const SystemAddress& sysAddr);
 
 	//Handlers:
 
-	void HandleToggleGhostReferenceOverride(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleSetGhostReferencePosition(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleToggleGhostReferenceOverride(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleSetGhostReferencePosition(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 
 	void SendSetNamebillboardState(const SystemAddress& sysAddr, LWOOBJID objectId);
 	void SendShowBillboardInteractIcon(const SystemAddress& sysAddr, LWOOBJID objectId);
-	void HandleBuyFromVendor(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleSellToVendor(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleBuybackFromVendor(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleParseChatMessage(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleToggleGhostReffrenceOverride(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleSetGhostReffrenceOverride(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleFireEventServerSide(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleRequestPlatformResync(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleQuickBuildCancel(RakNet::BitStream* inStream, Entity* entity);
-	void HandleRequestUse(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandlePlayEmote(RakNet::BitStream* inStream, Entity* entity);
-	void HandleModularBuildConvertModel(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleSetFlag(RakNet::BitStream* inStream, Entity* entity);
-	void HandleRespondToMission(RakNet::BitStream* inStream, Entity* entity);
-	void HandleMissionDialogOK(RakNet::BitStream* inStream, Entity* entity);
-	void HandleRequestLinkedMission(RakNet::BitStream* inStream, Entity* entity);
-	void HandleHasBeenCollected(RakNet::BitStream* inStream, Entity* entity);
-	void HandleNotifyServerLevelProcessingComplete(RakNet::BitStream* inStream, Entity* entity);
-	void HandlePickupCurrency(RakNet::BitStream* inStream, Entity* entity);
-	void HandleRequestDie(RakNet::BitStream* inStream, Entity* entity);
-	void HandleEquipItem(RakNet::BitStream* inStream, Entity* entity);
-	void HandleUnequipItem(RakNet::BitStream* inStream, Entity* entity);
-	void HandleRemoveItemFromInventory(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleMoveItemInInventory(RakNet::BitStream* inStream, Entity* entity);
-	void HandleMoveItemBetweenInventoryTypes(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleBuildModeSet(RakNet::BitStream* inStream, Entity* entity);
-	void HandleModularBuildFinish(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleDoneArrangingWithItem(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleModularBuildMoveAndEquip(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandlePickupItem(RakNet::BitStream* inStream, Entity* entity);
-	void HandleResurrect(RakNet::BitStream* inStream, Entity* entity);
-	void HandleModifyPlayerZoneStatistic(RakNet::BitStream* inStream, Entity* entity);
-	void HandleUpdatePlayerStatistic(RakNet::BitStream* inStream, Entity* entity);
+	void HandleBuyFromVendor(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleSellToVendor(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleBuybackFromVendor(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleParseChatMessage(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleToggleGhostReffrenceOverride(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleSetGhostReffrenceOverride(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleFireEventServerSide(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleRequestPlatformResync(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleQuickBuildCancel(RakNet::BitStream& inStream, Entity* entity);
+	void HandleRequestUse(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandlePlayEmote(RakNet::BitStream& inStream, Entity* entity);
+	void HandleModularBuildConvertModel(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleSetFlag(RakNet::BitStream& inStream, Entity* entity);
+	void HandleRespondToMission(RakNet::BitStream& inStream, Entity* entity);
+	void HandleMissionDialogOK(RakNet::BitStream& inStream, Entity* entity);
+	void HandleRequestLinkedMission(RakNet::BitStream& inStream, Entity* entity);
+	void HandleHasBeenCollected(RakNet::BitStream& inStream, Entity* entity);
+	void HandleNotifyServerLevelProcessingComplete(RakNet::BitStream& inStream, Entity* entity);
+	void HandlePickupCurrency(RakNet::BitStream& inStream, Entity* entity);
+	void HandleRequestDie(RakNet::BitStream& inStream, Entity* entity);
+	void HandleEquipItem(RakNet::BitStream& inStream, Entity* entity);
+	void HandleUnequipItem(RakNet::BitStream& inStream, Entity* entity);
+	void HandleRemoveItemFromInventory(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleMoveItemInInventory(RakNet::BitStream& inStream, Entity* entity);
+	void HandleMoveItemBetweenInventoryTypes(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleBuildModeSet(RakNet::BitStream& inStream, Entity* entity);
+	void HandleModularBuildFinish(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleDoneArrangingWithItem(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleModularBuildMoveAndEquip(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandlePickupItem(RakNet::BitStream& inStream, Entity* entity);
+	void HandleResurrect(RakNet::BitStream& inStream, Entity* entity);
+	void HandleModifyPlayerZoneStatistic(RakNet::BitStream& inStream, Entity* entity);
+	void HandleUpdatePlayerStatistic(RakNet::BitStream& inStream, Entity* entity);
 
-	void HandlePushEquippedItemsState(RakNet::BitStream* inStream, Entity* entity);
+	void HandlePushEquippedItemsState(RakNet::BitStream& inStream, Entity* entity);
 
-	void HandlePopEquippedItemsState(RakNet::BitStream* inStream, Entity* entity);
+	void HandlePopEquippedItemsState(RakNet::BitStream& inStream, Entity* entity);
 
-	void HandleClientItemConsumed(RakNet::BitStream* inStream, Entity* entity);
+	void HandleClientItemConsumed(RakNet::BitStream& inStream, Entity* entity);
 
-	void HandleUseNonEquipmentItem(RakNet::BitStream* inStream, Entity* entity);
+	void HandleUseNonEquipmentItem(RakNet::BitStream& inStream, Entity* entity);
 
-	void HandleMatchRequest(RakNet::BitStream* inStream, Entity* entity);
+	void HandleMatchRequest(RakNet::BitStream& inStream, Entity* entity);
 
-	void HandleReportBug(RakNet::BitStream* inStream, Entity* entity);
+	void HandleReportBug(RakNet::BitStream& inStream, Entity* entity);
 
 	void SendRemoveBuff(Entity* entity, bool fromUnEquip, bool removeImmunity, uint32_t buffId);
 
 	// bubble
-	void HandleDeactivateBubbleBuff(RakNet::BitStream* inStream, Entity* entity);
+	void HandleDeactivateBubbleBuff(RakNet::BitStream& inStream, Entity* entity);
 
-	void HandleActivateBubbleBuff(RakNet::BitStream* inStream, Entity* entity);
+	void HandleActivateBubbleBuff(RakNet::BitStream& inStream, Entity* entity);
 
 	void SendActivateBubbleBuffFromServer(LWOOBJID objectId, const SystemAddress& sysAddr);
 
 	void SendDeactivateBubbleBuffFromServer(LWOOBJID objectId, const SystemAddress& sysAddr);
 
-	void HandleZoneSummaryDismissed(RakNet::BitStream* inStream, Entity* entity);
-	void HandleRequestActivityExit(RakNet::BitStream* inStream, Entity* entity);
+	void HandleZoneSummaryDismissed(RakNet::BitStream& inStream, Entity* entity);
+	void HandleRequestActivityExit(RakNet::BitStream& inStream, Entity* entity);
 
 	// Donation vendor
-	void HandleAddDonationItem(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleRemoveDonationItem(RakNet::BitStream* inStream, Entity* entity, const SystemAddress& sysAddr);
-	void HandleConfirmDonationOnPlayer(RakNet::BitStream* inStream, Entity* entity);
-	void HandleCancelDonationOnPlayer(RakNet::BitStream* inStream, Entity* entity);
+	void HandleAddDonationItem(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleRemoveDonationItem(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
+	void HandleConfirmDonationOnPlayer(RakNet::BitStream& inStream, Entity* entity);
+	void HandleCancelDonationOnPlayer(RakNet::BitStream& inStream, Entity* entity);
 };
 
 #endif // GAMEMESSAGES_H

--- a/dGame/dGameMessages/RequestServerProjectileImpact.h
+++ b/dGame/dGameMessages/RequestServerProjectileImpact.h
@@ -19,44 +19,44 @@ public:
 		sBitStream = _sBitStream;
 	}
 
-	RequestServerProjectileImpact(RakNet::BitStream* stream) : RequestServerProjectileImpact() {
+	RequestServerProjectileImpact(RakNet::BitStream& stream) : RequestServerProjectileImpact() {
 		Deserialize(stream);
 	}
 
 	~RequestServerProjectileImpact() {
 	}
 
-	void Serialize(RakNet::BitStream* stream) {
-		stream->Write(eGameMessageType::REQUEST_SERVER_PROJECTILE_IMPACT);
+	void Serialize(RakNet::BitStream& stream) {
+		stream.Write(eGameMessageType::REQUEST_SERVER_PROJECTILE_IMPACT);
 
-		stream->Write(i64LocalID != LWOOBJID_EMPTY);
-		if (i64LocalID != LWOOBJID_EMPTY) stream->Write(i64LocalID);
+		stream.Write(i64LocalID != LWOOBJID_EMPTY);
+		if (i64LocalID != LWOOBJID_EMPTY) stream.Write(i64LocalID);
 
-		stream->Write(i64TargetID != LWOOBJID_EMPTY);
-		if (i64TargetID != LWOOBJID_EMPTY) stream->Write(i64TargetID);
+		stream.Write(i64TargetID != LWOOBJID_EMPTY);
+		if (i64TargetID != LWOOBJID_EMPTY) stream.Write(i64TargetID);
 
 		uint32_t sBitStreamLength = sBitStream.length();
-		stream->Write(sBitStreamLength);
+		stream.Write(sBitStreamLength);
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
-			stream->Write(sBitStream[k]);
+			stream.Write(sBitStream[k]);
 		}
 
 	}
 
-	bool Deserialize(RakNet::BitStream* stream) {
+	bool Deserialize(RakNet::BitStream& stream) {
 		bool i64LocalIDIsDefault{};
-		stream->Read(i64LocalIDIsDefault);
-		if (i64LocalIDIsDefault != 0) stream->Read(i64LocalID);
+		stream.Read(i64LocalIDIsDefault);
+		if (i64LocalIDIsDefault != 0) stream.Read(i64LocalID);
 
 		bool i64TargetIDIsDefault{};
-		stream->Read(i64TargetIDIsDefault);
-		if (i64TargetIDIsDefault != 0) stream->Read(i64TargetID);
+		stream.Read(i64TargetIDIsDefault);
+		if (i64TargetIDIsDefault != 0) stream.Read(i64TargetID);
 
 		uint32_t sBitStreamLength{};
-		stream->Read(sBitStreamLength);
+		stream.Read(sBitStreamLength);
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
-			stream->Read(character);
+			stream.Read(character);
 			sBitStream.push_back(character);
 		}
 

--- a/dGame/dGameMessages/StartSkill.h
+++ b/dGame/dGameMessages/StartSkill.h
@@ -36,92 +36,92 @@ public:
 		uiSkillHandle = _uiSkillHandle;
 	}
 
-	StartSkill(RakNet::BitStream* stream) : StartSkill() {
+	StartSkill(RakNet::BitStream& stream) : StartSkill() {
 		Deserialize(stream);
 	}
 
 	~StartSkill() {
 	}
 
-	void Serialize(RakNet::BitStream* stream) {
-		stream->Write(eGameMessageType::START_SKILL);
+	void Serialize(RakNet::BitStream& stream) {
+		stream.Write(eGameMessageType::START_SKILL);
 
-		stream->Write(bUsedMouse);
+		stream.Write(bUsedMouse);
 
-		stream->Write(consumableItemID != LWOOBJID_EMPTY);
-		if (consumableItemID != LWOOBJID_EMPTY) stream->Write(consumableItemID);
+		stream.Write(consumableItemID != LWOOBJID_EMPTY);
+		if (consumableItemID != LWOOBJID_EMPTY) stream.Write(consumableItemID);
 
-		stream->Write(fCasterLatency != 0.0f);
-		if (fCasterLatency != 0.0f) stream->Write(fCasterLatency);
+		stream.Write(fCasterLatency != 0.0f);
+		if (fCasterLatency != 0.0f) stream.Write(fCasterLatency);
 
-		stream->Write(iCastType != 0);
-		if (iCastType != 0) stream->Write(iCastType);
+		stream.Write(iCastType != 0);
+		if (iCastType != 0) stream.Write(iCastType);
 
-		stream->Write(lastClickedPosit != NiPoint3Constant::ZERO);
-		if (lastClickedPosit != NiPoint3Constant::ZERO) stream->Write(lastClickedPosit);
+		stream.Write(lastClickedPosit != NiPoint3Constant::ZERO);
+		if (lastClickedPosit != NiPoint3Constant::ZERO) stream.Write(lastClickedPosit);
 
-		stream->Write(optionalOriginatorID);
+		stream.Write(optionalOriginatorID);
 
-		stream->Write(optionalTargetID != LWOOBJID_EMPTY);
-		if (optionalTargetID != LWOOBJID_EMPTY) stream->Write(optionalTargetID);
+		stream.Write(optionalTargetID != LWOOBJID_EMPTY);
+		if (optionalTargetID != LWOOBJID_EMPTY) stream.Write(optionalTargetID);
 
-		stream->Write(originatorRot != NiQuaternionConstant::IDENTITY);
-		if (originatorRot != NiQuaternionConstant::IDENTITY) stream->Write(originatorRot);
+		stream.Write(originatorRot != NiQuaternionConstant::IDENTITY);
+		if (originatorRot != NiQuaternionConstant::IDENTITY) stream.Write(originatorRot);
 
 		uint32_t sBitStreamLength = sBitStream.length();
-		stream->Write(sBitStreamLength);
+		stream.Write(sBitStreamLength);
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
-			stream->Write(sBitStream[k]);
+			stream.Write(sBitStream[k]);
 		}
 
-		stream->Write(skillID);
+		stream.Write(skillID);
 
-		stream->Write(uiSkillHandle != 0);
-		if (uiSkillHandle != 0) stream->Write(uiSkillHandle);
+		stream.Write(uiSkillHandle != 0);
+		if (uiSkillHandle != 0) stream.Write(uiSkillHandle);
 	}
 
-	bool Deserialize(RakNet::BitStream* stream) {
-		stream->Read(bUsedMouse);
+	bool Deserialize(RakNet::BitStream& stream) {
+		stream.Read(bUsedMouse);
 
 		bool consumableItemIDIsDefault{};
-		stream->Read(consumableItemIDIsDefault);
-		if (consumableItemIDIsDefault != 0) stream->Read(consumableItemID);
+		stream.Read(consumableItemIDIsDefault);
+		if (consumableItemIDIsDefault != 0) stream.Read(consumableItemID);
 
 		bool fCasterLatencyIsDefault{};
-		stream->Read(fCasterLatencyIsDefault);
-		if (fCasterLatencyIsDefault != 0) stream->Read(fCasterLatency);
+		stream.Read(fCasterLatencyIsDefault);
+		if (fCasterLatencyIsDefault != 0) stream.Read(fCasterLatency);
 
 		bool iCastTypeIsDefault{};
-		stream->Read(iCastTypeIsDefault);
-		if (iCastTypeIsDefault != 0) stream->Read(iCastType);
+		stream.Read(iCastTypeIsDefault);
+		if (iCastTypeIsDefault != 0) stream.Read(iCastType);
 
 		bool lastClickedPositIsDefault{};
-		stream->Read(lastClickedPositIsDefault);
-		if (lastClickedPositIsDefault != 0) stream->Read(lastClickedPosit);
+		stream.Read(lastClickedPositIsDefault);
+		if (lastClickedPositIsDefault != 0) stream.Read(lastClickedPosit);
 
-		stream->Read(optionalOriginatorID);
+		stream.Read(optionalOriginatorID);
 
 		bool optionalTargetIDIsDefault{};
-		stream->Read(optionalTargetIDIsDefault);
-		if (optionalTargetIDIsDefault != 0) stream->Read(optionalTargetID);
+		stream.Read(optionalTargetIDIsDefault);
+		if (optionalTargetIDIsDefault != 0) stream.Read(optionalTargetID);
 
 		bool originatorRotIsDefault{};
-		stream->Read(originatorRotIsDefault);
-		if (originatorRotIsDefault != 0) stream->Read(originatorRot);
+		stream.Read(originatorRotIsDefault);
+		if (originatorRotIsDefault != 0) stream.Read(originatorRot);
 
 		uint32_t sBitStreamLength{};
-		stream->Read(sBitStreamLength);
+		stream.Read(sBitStreamLength);
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
-			stream->Read(character);
+			stream.Read(character);
 			sBitStream.push_back(character);
 		}
 
-		stream->Read(skillID);
+		stream.Read(skillID);
 
 		bool uiSkillHandleIsDefault{};
-		stream->Read(uiSkillHandleIsDefault);
-		if (uiSkillHandleIsDefault != 0) stream->Read(uiSkillHandle);
+		stream.Read(uiSkillHandleIsDefault);
+		if (uiSkillHandleIsDefault != 0) stream.Read(uiSkillHandle);
 
 		return true;
 	}

--- a/dGame/dGameMessages/SyncSkill.h
+++ b/dGame/dGameMessages/SyncSkill.h
@@ -21,39 +21,39 @@ public:
 		uiSkillHandle = _uiSkillHandle;
 	}
 
-	SyncSkill(RakNet::BitStream* stream) : SyncSkill() {
+	SyncSkill(RakNet::BitStream& stream) : SyncSkill() {
 		Deserialize(stream);
 	}
 
 	~SyncSkill() {
 	}
 
-	void Serialize(RakNet::BitStream* stream) {
-		stream->Write(eGameMessageType::SYNC_SKILL);
+	void Serialize(RakNet::BitStream& stream) {
+		stream.Write(eGameMessageType::SYNC_SKILL);
 
-		stream->Write(bDone);
+		stream.Write(bDone);
 		uint32_t sBitStreamLength = sBitStream.length();
-		stream->Write(sBitStreamLength);
+		stream.Write(sBitStreamLength);
 		for (unsigned int k = 0; k < sBitStreamLength; k++) {
-			stream->Write(sBitStream[k]);
+			stream.Write(sBitStream[k]);
 		}
 
-		stream->Write(uiBehaviorHandle);
-		stream->Write(uiSkillHandle);
+		stream.Write(uiBehaviorHandle);
+		stream.Write(uiSkillHandle);
 	}
 
-	bool Deserialize(RakNet::BitStream* stream) {
-		stream->Read(bDone);
+	bool Deserialize(RakNet::BitStream& stream) {
+		stream.Read(bDone);
 		uint32_t sBitStreamLength{};
-		stream->Read(sBitStreamLength);
+		stream.Read(sBitStreamLength);
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
-			stream->Read(character);
+			stream.Read(character);
 			sBitStream.push_back(character);
 		}
 
-		stream->Read(uiBehaviorHandle);
-		stream->Read(uiSkillHandle);
+		stream.Read(uiBehaviorHandle);
+		stream.Read(uiSkillHandle);
 
 		return true;
 	}

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -950,7 +950,7 @@ void HandlePacket(Packet* packet) {
 			static_cast<int32_t>(messageID)
 		);
 
-		if (isSender) GameMessageHandler::HandleMessage(&dataStream, packet->systemAddress, objectID, messageID);
+		if (isSender) GameMessageHandler::HandleMessage(dataStream, packet->systemAddress, objectID, messageID);
 		break;
 	}
 

--- a/tests/dCommonTests/AMFDeserializeTests.cpp
+++ b/tests/dCommonTests/AMFDeserializeTests.cpp
@@ -11,7 +11,7 @@
 /**
  * Helper method that all tests use to get their respective AMF.
  */
-AMFBaseValue* ReadFromBitStream(RakNet::BitStream* bitStream) {
+AMFBaseValue* ReadFromBitStream(RakNet::BitStream& bitStream) {
 	AMFDeserialize deserializer;
 	AMFBaseValue* returnValue(deserializer.Read(bitStream));
 	return returnValue;
@@ -23,7 +23,7 @@ AMFBaseValue* ReadFromBitStream(RakNet::BitStream* bitStream) {
 TEST(dCommonTests, AMFDeserializeAMFUndefinedTest) {
 	CBITSTREAM;
 	bitStream.Write<uint8_t>(0x00);
-	std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(&bitStream));
+	std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(bitStream));
 	ASSERT_EQ(res->GetValueType(), eAmf::Undefined);
 }
 
@@ -34,7 +34,7 @@ TEST(dCommonTests, AMFDeserializeAMFUndefinedTest) {
 TEST(dCommonTests, AMFDeserializeAMFNullTest) {
 	CBITSTREAM;
 	bitStream.Write<uint8_t>(0x01);
-	std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(&bitStream));
+	std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(bitStream));
 	ASSERT_EQ(res->GetValueType(), eAmf::Null);
 }
 
@@ -44,7 +44,7 @@ TEST(dCommonTests, AMFDeserializeAMFNullTest) {
 TEST(dCommonTests, AMFDeserializeAMFFalseTest) {
 	CBITSTREAM;
 	bitStream.Write<uint8_t>(0x02);
-	std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(&bitStream));
+	std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(bitStream));
 	ASSERT_EQ(res->GetValueType(), eAmf::False);
 }
 
@@ -54,7 +54,7 @@ TEST(dCommonTests, AMFDeserializeAMFFalseTest) {
 TEST(dCommonTests, AMFDeserializeAMFTrueTest) {
 	CBITSTREAM;
 	bitStream.Write<uint8_t>(0x03);
-	std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(&bitStream));
+	std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(bitStream));
 	ASSERT_EQ(res->GetValueType(), eAmf::True);
 }
 
@@ -67,7 +67,7 @@ TEST(dCommonTests, AMFDeserializeAMFIntegerTest) {
 		bitStream.Write<uint8_t>(0x04);
 		// 127 == 01111111
 		bitStream.Write<uint8_t>(127);
-		std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(&bitStream));
+		std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(bitStream));
 		ASSERT_EQ(res->GetValueType(), eAmf::Integer);
 		// Check that the max value of a byte can be read correctly
 		ASSERT_EQ(static_cast<AMFIntValue*>(res.get())->GetValue(), 127);
@@ -76,7 +76,7 @@ TEST(dCommonTests, AMFDeserializeAMFIntegerTest) {
 	{
 		bitStream.Write<uint8_t>(0x04);
 		bitStream.Write<uint32_t>(UINT32_MAX);
-		std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(&bitStream));
+		std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(bitStream));
 		ASSERT_EQ(res->GetValueType(), eAmf::Integer);
 		// Check that we can read the maximum value correctly
 		ASSERT_EQ(static_cast<AMFIntValue*>(res.get())->GetValue(), 536870911);
@@ -90,7 +90,7 @@ TEST(dCommonTests, AMFDeserializeAMFIntegerTest) {
 		bitStream.Write<uint8_t>(255);
 		// 127 == 01111111
 		bitStream.Write<uint8_t>(127);
-		std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(&bitStream));
+		std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(bitStream));
 		ASSERT_EQ(res->GetValueType(), eAmf::Integer);
 		// Check that short max can be read correctly
 		ASSERT_EQ(static_cast<AMFIntValue*>(res.get())->GetValue(), UINT16_MAX);
@@ -102,7 +102,7 @@ TEST(dCommonTests, AMFDeserializeAMFIntegerTest) {
 		bitStream.Write<uint8_t>(255);
 		// 127 == 01111111
 		bitStream.Write<uint8_t>(127);
-		std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(&bitStream));
+		std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(bitStream));
 		ASSERT_EQ(res->GetValueType(), eAmf::Integer);
 		// Check that 2 byte max can be read correctly
 		ASSERT_EQ(static_cast<AMFIntValue*>(res.get())->GetValue(), 16383);
@@ -116,7 +116,7 @@ TEST(dCommonTests, AMFDeserializeAMFDoubleTest) {
 	CBITSTREAM;
 	bitStream.Write<uint8_t>(0x05);
 	bitStream.Write<double>(25346.4f);
-	std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(&bitStream));
+	std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(bitStream));
 	ASSERT_EQ(res->GetValueType(), eAmf::Double);
 	ASSERT_EQ(static_cast<AMFDoubleValue*>(res.get())->GetValue(), 25346.4f);
 }
@@ -130,7 +130,7 @@ TEST(dCommonTests, AMFDeserializeAMFStringTest) {
 	bitStream.Write<uint8_t>(0x0F);
 	std::string toWrite = "stateID";
 	for (auto e : toWrite) bitStream.Write<char>(e);
-	std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(&bitStream));
+	std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(bitStream));
 	ASSERT_EQ(res->GetValueType(), eAmf::String);
 	ASSERT_EQ(static_cast<AMFStringValue*>(res.get())->GetValue(), "stateID");
 }
@@ -145,7 +145,7 @@ TEST(dCommonTests, AMFDeserializeAMFArrayTest) {
 	bitStream.Write<uint8_t>(0x01);
 	bitStream.Write<uint8_t>(0x01);
 	{
-		std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(&bitStream));
+		std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(bitStream));
 		ASSERT_EQ(res->GetValueType(), eAmf::Array);
 		ASSERT_EQ(static_cast<AMFArrayValue*>(res.get())->GetAssociative().size(), 0);
 		ASSERT_EQ(static_cast<AMFArrayValue*>(res.get())->GetDense().size(), 0);
@@ -164,7 +164,7 @@ TEST(dCommonTests, AMFDeserializeAMFArrayTest) {
 	bitStream.Write<uint8_t>(0x0B);
 	for (auto e : "10447") if (e != '\0') bitStream.Write<char>(e);
 	{
-		std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(&bitStream));
+		std::unique_ptr<AMFBaseValue> res(ReadFromBitStream(bitStream));
 		ASSERT_EQ(res->GetValueType(), eAmf::Array);
 		ASSERT_EQ(static_cast<AMFArrayValue*>(res.get())->GetAssociative().size(), 1);
 		ASSERT_EQ(static_cast<AMFArrayValue*>(res.get())->GetDense().size(), 1);
@@ -213,7 +213,7 @@ TEST(dCommonTests, AMFDeserializeUnimplementedValuesTest) {
 		testBitStream.Write(value);
 		bool caughtException = false;
 		try {
-			ReadFromBitStream(&testBitStream);
+			ReadFromBitStream(testBitStream);
 		} catch (eAmf unimplementedValueType) {
 			caughtException = true;
 		}
@@ -238,7 +238,7 @@ TEST(dCommonTests, AMFDeserializeLivePacketTest) {
 
 	testFileStream.close();
 
-	std::unique_ptr<AMFBaseValue> resultFromFn(ReadFromBitStream(&testBitStream));
+	std::unique_ptr<AMFBaseValue> resultFromFn(ReadFromBitStream(testBitStream));
 	auto result = static_cast<AMFArrayValue*>(resultFromFn.get());
 	// Test the outermost array
 
@@ -343,14 +343,6 @@ TEST(dCommonTests, AMFDeserializeLivePacketTest) {
 	ASSERT_EQ(thirdDistance->GetValue(), 25.0f);
 }
 
-/**
- * @brief Tests that having no BitStream returns a nullptr.
- */
-TEST(dCommonTests, AMFDeserializeNullTest) {
-	std::unique_ptr<AMFBaseValue> result(ReadFromBitStream(nullptr));
-	ASSERT_EQ(result.get(), nullptr);
-}
-
 TEST(dCommonTests, AMFBadConversionTest) {
 	std::ifstream testFileStream;
 	testFileStream.open("AMFBitStreamTest.bin", std::ios::binary);
@@ -364,7 +356,7 @@ TEST(dCommonTests, AMFBadConversionTest) {
 
 	testFileStream.close();
 
-	std::unique_ptr<AMFBaseValue> resultFromFn(ReadFromBitStream(&testBitStream));
+	std::unique_ptr<AMFBaseValue> resultFromFn(ReadFromBitStream(testBitStream));
 	auto result = static_cast<AMFArrayValue*>(resultFromFn.get());
 
 	// Actually a string value.

--- a/tests/dGameTests/dGameMessagesTests/GameMessageTests.cpp
+++ b/tests/dGameTests/dGameMessagesTests/GameMessageTests.cpp
@@ -38,7 +38,7 @@ protected:
 		}
 		return readFile;
 	}
-	AMFArrayValue* ReadArrayFromBitStream(RakNet::BitStream* inStream) {
+	AMFArrayValue* ReadArrayFromBitStream(RakNet::BitStream& inStream) {
 		AMFDeserialize des;
 		AMFBaseValue* readArray = des.Read(inStream);
 		EXPECT_EQ(readArray->GetValueType(), eAmf::Array);
@@ -88,7 +88,7 @@ TEST_F(GameMessageTests, SendBlueprintLoadItemResponse) {
 TEST_F(GameMessageTests, ControlBehaviorAddStrip) {
 	auto data = ReadFromFile("addStrip");
 	RakNet::BitStream inStream((unsigned char*)data.c_str(), data.length(), true);
-	AddStripMessage addStrip(ReadArrayFromBitStream(&inStream));
+	AddStripMessage addStrip(ReadArrayFromBitStream(inStream));
 	ASSERT_FLOAT_EQ(addStrip.GetPosition().GetX(), 50.65);
 	ASSERT_FLOAT_EQ(addStrip.GetPosition().GetY(), 178.05);
 	ASSERT_EQ(addStrip.GetActionContext().GetStripId(), 0);
@@ -103,7 +103,7 @@ TEST_F(GameMessageTests, ControlBehaviorAddStrip) {
 TEST_F(GameMessageTests, ControlBehaviorRemoveStrip) {
 	auto data = ReadFromFile("removeStrip");
 	RakNet::BitStream inStream((unsigned char*)data.c_str(), data.length(), true);
-	RemoveStripMessage removeStrip(ReadArrayFromBitStream(&inStream));
+	RemoveStripMessage removeStrip(ReadArrayFromBitStream(inStream));
 	ASSERT_EQ(static_cast<int32_t>(removeStrip.GetActionContext().GetStripId()), 1);
 	ASSERT_EQ(static_cast<int32_t>(removeStrip.GetActionContext().GetStateId()), 0);
 	ASSERT_EQ(removeStrip.GetBehaviorId(), -1);
@@ -112,7 +112,7 @@ TEST_F(GameMessageTests, ControlBehaviorRemoveStrip) {
 TEST_F(GameMessageTests, ControlBehaviorMergeStrips) {
 	auto data = ReadFromFile("mergeStrips");
 	RakNet::BitStream inStream((unsigned char*)data.c_str(), data.length(), true);
-	MergeStripsMessage mergeStrips(ReadArrayFromBitStream(&inStream));
+	MergeStripsMessage mergeStrips(ReadArrayFromBitStream(inStream));
 	ASSERT_EQ(mergeStrips.GetSourceActionContext().GetStripId(), 2);
 	ASSERT_EQ(mergeStrips.GetDestinationActionContext().GetStripId(), 0);
 	ASSERT_EQ(static_cast<uint32_t>(mergeStrips.GetSourceActionContext().GetStateId()), 0);
@@ -124,7 +124,7 @@ TEST_F(GameMessageTests, ControlBehaviorMergeStrips) {
 TEST_F(GameMessageTests, ControlBehaviorSplitStrip) {
 	auto data = ReadFromFile("splitStrip");
 	RakNet::BitStream inStream((unsigned char*)data.c_str(), data.length(), true);
-	SplitStripMessage splitStrip(ReadArrayFromBitStream(&inStream));
+	SplitStripMessage splitStrip(ReadArrayFromBitStream(inStream));
 	ASSERT_EQ(splitStrip.GetBehaviorId(), -1);
 
 	ASSERT_FLOAT_EQ(splitStrip.GetPosition().GetX(), 275.65);
@@ -139,7 +139,7 @@ TEST_F(GameMessageTests, ControlBehaviorSplitStrip) {
 TEST_F(GameMessageTests, ControlBehaviorUpdateStripUI) {
 	auto data = ReadFromFile("updateStripUI");
 	RakNet::BitStream inStream((unsigned char*)data.c_str(), data.length(), true);
-	UpdateStripUiMessage updateStripUi(ReadArrayFromBitStream(&inStream));
+	UpdateStripUiMessage updateStripUi(ReadArrayFromBitStream(inStream));
 	ASSERT_FLOAT_EQ(updateStripUi.GetPosition().GetX(), 116.65);
 	ASSERT_FLOAT_EQ(updateStripUi.GetPosition().GetY(), 35.35);
 	ASSERT_EQ(updateStripUi.GetActionContext().GetStripId(), 0);
@@ -150,7 +150,7 @@ TEST_F(GameMessageTests, ControlBehaviorUpdateStripUI) {
 TEST_F(GameMessageTests, ControlBehaviorAddAction) {
 	auto data = ReadFromFile("addAction");
 	RakNet::BitStream inStream((unsigned char*)data.c_str(), data.length(), true);
-	AddActionMessage addAction(ReadArrayFromBitStream(&inStream));
+	AddActionMessage addAction(ReadArrayFromBitStream(inStream));
 	ASSERT_EQ(addAction.GetActionIndex(), 3);
 	ASSERT_EQ(addAction.GetActionContext().GetStripId(), 0);
 	ASSERT_EQ(static_cast<uint32_t>(addAction.GetActionContext().GetStateId()), 0);
@@ -164,7 +164,7 @@ TEST_F(GameMessageTests, ControlBehaviorAddAction) {
 TEST_F(GameMessageTests, ControlBehaviorMigrateActions) {
 	auto data = ReadFromFile("migrateActions");
 	RakNet::BitStream inStream((unsigned char*)data.c_str(), data.length(), true);
-	MigrateActionsMessage migrateActions(ReadArrayFromBitStream(&inStream));
+	MigrateActionsMessage migrateActions(ReadArrayFromBitStream(inStream));
 	ASSERT_EQ(migrateActions.GetSrcActionIndex(), 1);
 	ASSERT_EQ(migrateActions.GetDstActionIndex(), 2);
 	ASSERT_EQ(migrateActions.GetSourceActionContext().GetStripId(), 1);
@@ -177,7 +177,7 @@ TEST_F(GameMessageTests, ControlBehaviorMigrateActions) {
 TEST_F(GameMessageTests, ControlBehaviorRearrangeStrip) {
 	auto data = ReadFromFile("rearrangeStrip");
 	RakNet::BitStream inStream((unsigned char*)data.c_str(), data.length(), true);
-	RearrangeStripMessage rearrangeStrip(ReadArrayFromBitStream(&inStream));
+	RearrangeStripMessage rearrangeStrip(ReadArrayFromBitStream(inStream));
 	ASSERT_EQ(rearrangeStrip.GetSrcActionIndex(), 2);
 	ASSERT_EQ(rearrangeStrip.GetDstActionIndex(), 1);
 	ASSERT_EQ(rearrangeStrip.GetActionContext().GetStripId(), 0);
@@ -188,7 +188,7 @@ TEST_F(GameMessageTests, ControlBehaviorRearrangeStrip) {
 TEST_F(GameMessageTests, ControlBehaviorAdd) {
 	auto data = ReadFromFile("add");
 	RakNet::BitStream inStream((unsigned char*)data.c_str(), data.length(), true);
-	AddMessage add(ReadArrayFromBitStream(&inStream));
+	AddMessage add(ReadArrayFromBitStream(inStream));
 	ASSERT_EQ(add.GetBehaviorId(), 10446);
 	ASSERT_EQ(add.GetBehaviorIndex(), 0);
 }
@@ -196,7 +196,7 @@ TEST_F(GameMessageTests, ControlBehaviorAdd) {
 TEST_F(GameMessageTests, ControlBehaviorRemoveActions) {
 	auto data = ReadFromFile("removeActions");
 	RakNet::BitStream inStream((unsigned char*)data.c_str(), data.length(), true);
-	RemoveActionsMessage removeActions(ReadArrayFromBitStream(&inStream));
+	RemoveActionsMessage removeActions(ReadArrayFromBitStream(inStream));
 	ASSERT_EQ(removeActions.GetBehaviorId(), -1);
 	ASSERT_EQ(removeActions.GetActionIndex(), 1);
 	ASSERT_EQ(removeActions.GetActionContext().GetStripId(), 0);
@@ -206,7 +206,7 @@ TEST_F(GameMessageTests, ControlBehaviorRemoveActions) {
 TEST_F(GameMessageTests, ControlBehaviorRename) {
 	auto data = ReadFromFile("rename");
 	RakNet::BitStream inStream((unsigned char*)data.c_str(), data.length(), true);
-	RenameMessage rename(ReadArrayFromBitStream(&inStream));
+	RenameMessage rename(ReadArrayFromBitStream(inStream));
 	ASSERT_EQ(rename.GetName(), "test");
 	ASSERT_EQ(rename.GetBehaviorId(), -1);
 }
@@ -214,7 +214,7 @@ TEST_F(GameMessageTests, ControlBehaviorRename) {
 TEST_F(GameMessageTests, ControlBehaviorUpdateAction) {
 	auto data = ReadFromFile("updateAction");
 	RakNet::BitStream inStream((unsigned char*)data.c_str(), data.length(), true);
-	UpdateActionMessage updateAction(ReadArrayFromBitStream(&inStream));
+	UpdateActionMessage updateAction(ReadArrayFromBitStream(inStream));
 	ASSERT_EQ(updateAction.GetAction().GetType(), "FlyDown");
 	ASSERT_EQ(updateAction.GetAction().GetValueParameterName(), "Distance");
 	ASSERT_EQ(updateAction.GetAction().GetValueParameterString(), "");


### PR DESCRIPTION
As part of ongoing raw pointer reduction efforts, convert game messages to use references to raknet bitstreams instead of raw pointers.