### PR TITLE
chore: remove extra speed class

### DIFF
--- a/dGame/dComponents/MovingPlatformComponent.cpp
+++ b/dGame/dComponents/MovingPlatformComponent.cpp
@@ -162,7 +162,7 @@ void MovingPlatformComponent::StartPathing() {
 		const auto& nextWaypoint = m_Path->pathWaypoints[subComponent->mNextWaypointIndex];
 
 		subComponent->mPosition = currentWaypoint.position;
-		subComponent->mSpeed = currentWaypoint.movingPlatform.speed;
+		subComponent->mSpeed = currentWaypoint.speed;
 		subComponent->mWaitTime = currentWaypoint.movingPlatform.wait;
 
 		targetPosition = nextWaypoint.position;
@@ -213,7 +213,7 @@ void MovingPlatformComponent::ContinuePathing() {
 		const auto& nextWaypoint = m_Path->pathWaypoints[subComponent->mNextWaypointIndex];
 
 		subComponent->mPosition = currentWaypoint.position;
-		subComponent->mSpeed = currentWaypoint.movingPlatform.speed;
+		subComponent->mSpeed = currentWaypoint.speed;
 		subComponent->mWaitTime = currentWaypoint.movingPlatform.wait; // + 2;
 
 		pathSize = m_Path->pathWaypoints.size() - 1;

--- a/dZoneManager/Zone.cpp
+++ b/dZoneManager/Zone.cpp
@@ -419,7 +419,7 @@ void Zone::LoadPath(std::istream& file) {
 
 		if (path.pathType == PathType::MovingPlatform) {
 			BinaryIO::BinaryRead(file, waypoint.movingPlatform.lockPlayer);
-			BinaryIO::BinaryRead(file, waypoint.movingPlatform.speed);
+			BinaryIO::BinaryRead(file, waypoint.speed);
 			BinaryIO::BinaryRead(file, waypoint.movingPlatform.wait);
 			if (path.pathVersion >= 13) {
 				BinaryIO::ReadString<uint8_t>(file, waypoint.movingPlatform.departSound, BinaryIO::ReadType::WideString);
@@ -438,7 +438,7 @@ void Zone::LoadPath(std::istream& file) {
 			BinaryIO::BinaryRead(file, waypoint.racing.planeHeight);
 			BinaryIO::BinaryRead(file, waypoint.racing.shortestDistanceToEnd);
 		} else if (path.pathType == PathType::Rail) {
-			if (path.pathVersion > 16) BinaryIO::BinaryRead(file, waypoint.rail.speed);
+			if (path.pathVersion > 16) BinaryIO::BinaryRead(file, waypoint.speed);
 		}
 
 		// object LDF configs

--- a/dZoneManager/Zone.h
+++ b/dZoneManager/Zone.h
@@ -40,7 +40,6 @@ struct SceneTransition {
 
 struct MovingPlatformPathWaypoint {
 	uint8_t lockPlayer;
-	float speed;
 	float wait;
 	std::string departSound;
 	std::string arriveSound;
@@ -62,17 +61,13 @@ struct RacingPathWaypoint {
 	float shortestDistanceToEnd;
 };
 
-struct RailPathWaypoint {
-	float speed;
-};
-
 struct PathWaypoint {
 	NiPoint3 position;
 	NiQuaternion rotation; // not included in all, but it's more convenient here
 	MovingPlatformPathWaypoint movingPlatform;
 	CameraPathWaypoint camera;
 	RacingPathWaypoint racing;
-	RailPathWaypoint rail;
+	float speed;
 	std::vector<LDFBaseData*> config;
 };
 


### PR DESCRIPTION
Speed is used in more waypoints than not so we may as well reduce repeated references.

tested that the data is still loaded as normal in avant gardens