### PR TITLE
chore: Set default symbol visibility to hidden in CMAKE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ include(CTest)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POLICY_DEFAULT_CMP0063 NEW)
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 # Read variables from file


### PR DESCRIPTION
Change the default C++ visibility to hidden, since we aren't using them at all. This shrinks WorldServer by about 0.8 MB without any impact to functionality. Tested by moving around Gnarled Forest for about 30 minutes, completing side missions.