### PR TITLE
chore: Less verbose name for enum underlying type casts

### DIFF
--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -264,8 +264,8 @@ namespace GeneralUtils {
 	 * @returns The enum entry's value in its underlying type
 	*/
 	template <Enum eType>
-	constexpr typename std::underlying_type_t<eType> CastUnderlyingType(const eType entry) noexcept {
-		return static_cast<typename std::underlying_type_t<eType>>(entry);
+	constexpr std::underlying_type_t<eType> ToUnderlying(const eType entry) noexcept {
+		return static_cast<std::underlying_type_t<eType>>(entry);
 	}
 
 	// on Windows we need to undef these or else they conflict with our numeric limits calls

--- a/dNet/AuthPackets.cpp
+++ b/dNet/AuthPackets.cpp
@@ -229,7 +229,7 @@ void AuthPackets::SendLoginResponse(dServer* server, const SystemAddress& sysAdd
 	RakNet::BitStream loginResponse;
 	BitStreamUtils::WriteHeader(loginResponse, eConnectionType::CLIENT, eClientMessageType::LOGIN_RESPONSE);
 
-	loginResponse.Write<uint8_t>(GeneralUtils::CastUnderlyingType(responseCode));
+	loginResponse.Write(GeneralUtils::ToUnderlying(responseCode));
 
 	// Event Gating
 	loginResponse.Write(LUString(Game::config->GetValue("event_1")));

--- a/dNet/AuthPackets.cpp
+++ b/dNet/AuthPackets.cpp
@@ -229,7 +229,7 @@ void AuthPackets::SendLoginResponse(dServer* server, const SystemAddress& sysAdd
 	RakNet::BitStream loginResponse;
 	BitStreamUtils::WriteHeader(loginResponse, eConnectionType::CLIENT, eClientMessageType::LOGIN_RESPONSE);
 
-	loginResponse.Write(GeneralUtils::ToUnderlying(responseCode));
+	loginResponse.Write(responseCode);
 
 	// Event Gating
 	loginResponse.Write(LUString(Game::config->GetValue("event_1")));

--- a/tests/dCommonTests/CMakeLists.txt
+++ b/tests/dCommonTests/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(DCOMMONTEST_SOURCES
 	"AMFDeserializeTests.cpp"
 	"Amf3Tests.cpp"
-	"CastUnderlyingTypeTests.cpp"
+	"ToUnderlyingTests.cpp"
 	"HeaderSkipTest.cpp"
 	"TestCDFeatureGatingTable.cpp"
 	"TestLDFFormat.cpp"

--- a/tests/dCommonTests/ToUnderlyingTests.cpp
+++ b/tests/dCommonTests/ToUnderlyingTests.cpp
@@ -7,13 +7,13 @@
 #include "eWorldMessageType.h"
 
 #define ASSERT_TYPE_EQ(TYPE, ENUM)\
-	ASSERT_TRUE(typeid(TYPE) == typeid(GeneralUtils::CastUnderlyingType(static_cast<ENUM>(0))));
+	ASSERT_TRUE(typeid(TYPE) == typeid(GeneralUtils::ToUnderlying(static_cast<ENUM>(0))));
 
 #define ASSERT_TYPE_NE(TYPE, ENUM)\
-	ASSERT_FALSE(typeid(TYPE) == typeid(GeneralUtils::CastUnderlyingType(static_cast<ENUM>(0))));
+	ASSERT_FALSE(typeid(TYPE) == typeid(GeneralUtils::ToUnderlying(static_cast<ENUM>(0))));
 	
 // Verify that the underlying enum types are being cast correctly
-TEST(CastUnderlyingTypeTests, VerifyCastUnderlyingType) {
+TEST(ToUnderlyingTests, VerifyToUnderlying) {
 	ASSERT_TYPE_EQ(uint8_t, eGameMasterLevel);
 	ASSERT_TYPE_EQ(uint16_t, eGameMessageType);
 	ASSERT_TYPE_EQ(uint32_t, eWorldMessageType)


### PR DESCRIPTION
Having actually needed to use this helper function fairly extensively for a commit on the PetFixes branch, I propose switching it to use a slightly shorter name that's still descriptive