### PR TITLE
chore: add info to debug logs

### DIFF
--- a/dGame/dUtilities/VanityUtilities.cpp
+++ b/dGame/dUtilities/VanityUtilities.cpp
@@ -285,7 +285,7 @@ void ParseXml(const std::string& file) {
 				}
 
 				if (zoneID.value() != currentZoneID) {
-					LOG_DEBUG("Skipping location because it is in %i and not the current zone (%i)", zoneID.value(), currentZoneID);
+					LOG_DEBUG("Skipping (%s) %i location because it is in %i and not the current zone (%i)", name, lot, zoneID.value(), currentZoneID);
 					continue;
 				}
 


### PR DESCRIPTION
Tested that the logs now show the name and lot of the not spawned npc.