### PR TITLE
fix: Remove multiple Script syntax

### DIFF
--- a/dGame/Entity.h
+++ b/dGame/Entity.h
@@ -146,7 +146,8 @@ public:
 
 	void AddComponent(eReplicaComponentType componentId, Component* component);
 
-	std::vector<ScriptComponent*> GetScriptComponents();
+	// This is expceted to never return nullptr, an assert checks this.
+	CppScripts::Script* const GetScript();
 
 	void Subscribe(LWOOBJID scriptObjId, CppScripts::Script* scriptToAdd, const std::string& notificationName);
 	void Unsubscribe(LWOOBJID scriptObjId, const std::string& notificationName);

--- a/dGame/dBehaviors/SkillEventBehavior.cpp
+++ b/dGame/dBehaviors/SkillEventBehavior.cpp
@@ -3,15 +3,14 @@
 #include "BehaviorContext.h"
 #include "EntityManager.h"
 #include "CppScripts.h"
+#include "Entity.h"
 
 void SkillEventBehavior::Handle(BehaviorContext* context, RakNet::BitStream& bitStream, BehaviorBranchContext branch) {
 	auto* target = Game::entityManager->GetEntity(branch.target);
 	auto* caster = Game::entityManager->GetEntity(context->originator);
 
 	if (caster != nullptr && target != nullptr && this->m_effectHandle != nullptr && !this->m_effectHandle->empty()) {
-		for (CppScripts::Script* script : CppScripts::GetEntityScripts(target)) {
-			script->OnSkillEventFired(target, caster, *this->m_effectHandle);
-		}
+		target->GetScript()->OnSkillEventFired(target, caster, *this->m_effectHandle);
 	}
 }
 
@@ -21,8 +20,6 @@ SkillEventBehavior::Calculate(BehaviorContext* context, RakNet::BitStream& bitSt
 	auto* caster = Game::entityManager->GetEntity(context->originator);
 
 	if (caster != nullptr && target != nullptr && this->m_effectHandle != nullptr && !this->m_effectHandle->empty()) {
-		for (CppScripts::Script* script : CppScripts::GetEntityScripts(target)) {
-			script->OnSkillEventFired(target, caster, *this->m_effectHandle);
-		}
+		target->GetScript()->OnSkillEventFired(target, caster, *this->m_effectHandle);
 	}
 }

--- a/dGame/dComponents/CMakeLists.txt
+++ b/dGame/dComponents/CMakeLists.txt
@@ -48,6 +48,7 @@ set(DGAME_DCOMPONENTS_SOURCES
 	"HavokVehiclePhysicsComponent.cpp"
 	"VendorComponent.cpp"
 	"MiniGameControlComponent.cpp"
+	"ScriptComponent.cpp"
 )
 
 add_library(dComponents OBJECT ${DGAME_DCOMPONENTS_SOURCES})

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -785,16 +785,12 @@ void DestroyableComponent::Smash(const LWOOBJID source, const eKillType killType
 		}
 
 		Entity* zoneControl = Game::entityManager->GetZoneControlEntity();
-		for (CppScripts::Script* script : CppScripts::GetEntityScripts(zoneControl)) {
-			script->OnPlayerDied(zoneControl, m_Parent);
-		}
+		if (zoneControl) zoneControl->GetScript()->OnPlayerDied(zoneControl, m_Parent);
 
 		std::vector<Entity*> scriptedActs = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SCRIPTED_ACTIVITY);
 		for (Entity* scriptEntity : scriptedActs) {
 			if (scriptEntity->GetObjectID() != zoneControl->GetObjectID()) { // Don't want to trigger twice on instance worlds
-				for (CppScripts::Script* script : CppScripts::GetEntityScripts(scriptEntity)) {
-					script->OnPlayerDied(scriptEntity, m_Parent);
-				}
+				scriptEntity->GetScript()->OnPlayerDied(scriptEntity, m_Parent);
 			}
 		}
 	}

--- a/dGame/dComponents/MovingPlatformComponent.cpp
+++ b/dGame/dComponents/MovingPlatformComponent.cpp
@@ -183,9 +183,7 @@ void MovingPlatformComponent::StartPathing() {
 	const auto travelNext = subComponent->mWaitTime + travelTime;
 
 	m_Parent->AddCallbackTimer(travelTime, [subComponent, this] {
-		for (CppScripts::Script* script : CppScripts::GetEntityScripts(m_Parent)) {
-			script->OnWaypointReached(m_Parent, subComponent->mNextWaypointIndex);
-		}
+		this->m_Parent->GetScript()->OnWaypointReached(m_Parent, subComponent->mNextWaypointIndex);
 		});
 
 	m_Parent->AddCallbackTimer(travelNext, [this] {
@@ -295,9 +293,7 @@ void MovingPlatformComponent::ContinuePathing() {
 	const auto travelNext = subComponent->mWaitTime + travelTime;
 
 	m_Parent->AddCallbackTimer(travelTime, [subComponent, this] {
-		for (CppScripts::Script* script : CppScripts::GetEntityScripts(m_Parent)) {
-			script->OnWaypointReached(m_Parent, subComponent->mNextWaypointIndex);
-		}
+		this->m_Parent->GetScript()->OnWaypointReached(m_Parent, subComponent->mNextWaypointIndex);
 		});
 
 	m_Parent->AddCallbackTimer(travelNext, [this] {

--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -306,9 +306,7 @@ void PetComponent::OnUse(Entity* originator) {
 	currentActivities.insert_or_assign(m_Tamer, m_Parent->GetObjectID());
 
 	// Notify the start of a pet taming minigame
-	for (CppScripts::Script* script : CppScripts::GetEntityScripts(m_Parent)) {
-		script->OnNotifyPetTamingMinigame(m_Parent, originator, ePetTamingNotifyType::BEGIN);
-	}
+	m_Parent->GetScript()->OnNotifyPetTamingMinigame(m_Parent, originator, ePetTamingNotifyType::BEGIN);
 }
 
 void PetComponent::Update(float deltaTime) {
@@ -690,9 +688,7 @@ void PetComponent::RequestSetPetName(std::u16string name) {
 	m_Tamer = LWOOBJID_EMPTY;
 
 	// Notify the end of a pet taming minigame
-	for (CppScripts::Script* script : CppScripts::GetEntityScripts(m_Parent)) {
-		script->OnNotifyPetTamingMinigame(m_Parent, tamer, ePetTamingNotifyType::SUCCESS);
-	}
+	m_Parent->GetScript()->OnNotifyPetTamingMinigame(m_Parent, tamer, ePetTamingNotifyType::SUCCESS);
 }
 
 void PetComponent::ClientExitTamingMinigame(bool voluntaryExit) {
@@ -731,9 +727,7 @@ void PetComponent::ClientExitTamingMinigame(bool voluntaryExit) {
 	Game::entityManager->SerializeEntity(m_Parent);
 
 	// Notify the end of a pet taming minigame
-	for (CppScripts::Script* script : CppScripts::GetEntityScripts(m_Parent)) {
-		script->OnNotifyPetTamingMinigame(m_Parent, tamer, ePetTamingNotifyType::QUIT);
-	}
+	m_Parent->GetScript()->OnNotifyPetTamingMinigame(m_Parent, tamer, ePetTamingNotifyType::QUIT);
 }
 
 void PetComponent::StartTimer() {
@@ -782,9 +776,7 @@ void PetComponent::ClientFailTamingMinigame() {
 	Game::entityManager->SerializeEntity(m_Parent);
 
 	// Notify the end of a pet taming minigame
-	for (CppScripts::Script* script : CppScripts::GetEntityScripts(m_Parent)) {
-		script->OnNotifyPetTamingMinigame(m_Parent, tamer, ePetTamingNotifyType::FAILED);
-	}
+	m_Parent->GetScript()->OnNotifyPetTamingMinigame(m_Parent, tamer, ePetTamingNotifyType::FAILED);
 }
 
 void PetComponent::Wander() {

--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -214,9 +214,7 @@ bool PropertyManagementComponent::Claim(const LWOOBJID playerId) {
 	Database::Get()->InsertNewProperty(info, templateId, worldId);
 
 	auto* zoneControlObject = Game::zoneManager->GetZoneControlObject();
-	for (CppScripts::Script* script : CppScripts::GetEntityScripts(zoneControlObject)) {
-		script->OnZonePropertyRented(zoneControlObject, entity);
-	}
+	if (zoneControlObject) zoneControlObject->GetScript()->OnZonePropertyRented(zoneControlObject, entity);
 	return true;
 }
 

--- a/dGame/dComponents/QuickBuildComponent.cpp
+++ b/dGame/dComponents/QuickBuildComponent.cpp
@@ -414,13 +414,11 @@ void QuickBuildComponent::StartQuickBuild(Entity* const user) {
 			movingPlatform->OnQuickBuildInitilized();
 		}
 
-		for (auto* script : CppScripts::GetEntityScripts(m_Parent)) {
-			script->OnQuickBuildStart(m_Parent, user);
-		}
+		auto* script = m_Parent->GetScript();
+		script->OnQuickBuildStart(m_Parent, user);
 
 		// Notify scripts and possible subscribers
-		for (auto* script : CppScripts::GetEntityScripts(m_Parent))
-			script->OnQuickBuildNotifyState(m_Parent, m_State);
+		script->OnQuickBuildNotifyState(m_Parent, m_State);
 		for (const auto& cb : m_QuickBuildStateCallbacks)
 			cb(m_State);
 	}
@@ -485,10 +483,9 @@ void QuickBuildComponent::CompleteQuickBuild(Entity* const user) {
 	}
 
 	// Notify scripts
-	for (auto* script : CppScripts::GetEntityScripts(m_Parent)) {
-		script->OnQuickBuildComplete(m_Parent, user);
-		script->OnQuickBuildNotifyState(m_Parent, m_State);
-	}
+	auto* script = m_Parent->GetScript();
+	script->OnQuickBuildComplete(m_Parent, user);
+	script->OnQuickBuildNotifyState(m_Parent, m_State);
 
 	// Notify subscribers
 	for (const auto& callback : m_QuickBuildStateCallbacks)
@@ -539,8 +536,7 @@ void QuickBuildComponent::ResetQuickBuild(const bool failed) {
 	Game::entityManager->SerializeEntity(m_Parent);
 
 	// Notify scripts and possible subscribers
-	for (auto* script : CppScripts::GetEntityScripts(m_Parent))
-		script->OnQuickBuildNotifyState(m_Parent, m_State);
+	m_Parent->GetScript()->OnQuickBuildNotifyState(m_Parent, m_State);
 	for (const auto& cb : m_QuickBuildStateCallbacks)
 		cb(m_State);
 
@@ -571,8 +567,7 @@ void QuickBuildComponent::CancelQuickBuild(Entity* const entity, const eQuickBui
 		m_StateDirty = true;
 
 		// Notify scripts and possible subscribers
-		for (auto* script : CppScripts::GetEntityScripts(m_Parent))
-			script->OnQuickBuildNotifyState(m_Parent, m_State);
+		m_Parent->GetScript()->OnQuickBuildNotifyState(m_Parent, m_State);
 		for (const auto& cb : m_QuickBuildStateCallbacks)
 			cb(m_State);
 

--- a/dGame/dComponents/ScriptComponent.cpp
+++ b/dGame/dComponents/ScriptComponent.cpp
@@ -41,7 +41,7 @@ void ScriptComponent::Serialize(RakNet::BitStream& outBitStream, bool bIsInitial
 	}
 }
 
-CppScripts::Script* ScriptComponent::GetScript() {
+CppScripts::Script* const ScriptComponent::GetScript() {
 	return m_Script;
 }
 

--- a/dGame/dComponents/ScriptComponent.h
+++ b/dGame/dComponents/ScriptComponent.h
@@ -30,7 +30,7 @@ public:
 	 * Returns the script that's attached to this entity
 	 * @return the script that's attached to this entity
 	 */
-	CppScripts::Script* GetScript();
+	CppScripts::Script* const GetScript();
 
 	/**
 	 * Sets whether the entity should be serialized, unused

--- a/dGame/dComponents/SkillComponent.cpp
+++ b/dGame/dComponents/SkillComponent.cpp
@@ -268,9 +268,7 @@ SkillExecutionResult SkillComponent::CalculateBehavior(const uint32_t skillId, c
 
 	behavior->Calculate(context, bitStream, { target, 0 });
 
-	for (auto* script : CppScripts::GetEntityScripts(m_Parent)) {
-		script->OnSkillCast(m_Parent, skillId);
-	}
+	m_Parent->GetScript()->OnSkillCast(m_Parent, skillId);
 
 	if (!context->foundTarget) {
 		delete context;

--- a/dGame/dComponents/TriggerComponent.cpp
+++ b/dGame/dComponents/TriggerComponent.cpp
@@ -13,7 +13,8 @@
 #include "SkillComponent.h"
 #include "eEndBehavior.h"
 #include "PlayerManager.h"
-
+#include "Game.h"
+#include "EntityManager.h"
 
 TriggerComponent::TriggerComponent(Entity* parent, const std::string triggerInfo): Component(parent) {
 	m_Parent = parent;
@@ -182,9 +183,7 @@ std::vector<Entity*> TriggerComponent::GatherTargets(LUTriggers::Command* comman
 }
 
 void TriggerComponent::HandleFireEvent(Entity* targetEntity, std::string args) {
-	for (CppScripts::Script* script : CppScripts::GetEntityScripts(targetEntity)) {
-		script->OnFireEventServerSide(targetEntity, m_Parent, args, 0, 0, 0);
-	}
+	targetEntity->GetScript()->OnFireEventServerSide(targetEntity, m_Parent, args, 0, 0, 0);
 }
 
 void TriggerComponent::HandleDestroyObject(Entity* targetEntity, std::string args){

--- a/dGame/dGameMessages/GameMessageHandler.cpp
+++ b/dGame/dGameMessages/GameMessageHandler.cpp
@@ -136,16 +136,14 @@ void GameMessageHandler::HandleMessage(RakNet::BitStream& inStream, const System
 		}
 
 		Entity* zoneControl = Game::entityManager->GetZoneControlEntity();
-		for (CppScripts::Script* script : CppScripts::GetEntityScripts(zoneControl)) {
-			script->OnPlayerLoaded(zoneControl, entity);
+		if (zoneControl) {
+			zoneControl->GetScript()->OnPlayerLoaded(zoneControl, entity);
 		}
 
 		std::vector<Entity*> scriptedActs = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SCRIPT);
 		for (Entity* scriptEntity : scriptedActs) {
 			if (scriptEntity->GetObjectID() != zoneControl->GetObjectID()) { // Don't want to trigger twice on instance worlds
-				for (CppScripts::Script* script : CppScripts::GetEntityScripts(scriptEntity)) {
-					script->OnPlayerLoaded(scriptEntity, entity);
-				}
+				scriptEntity->GetScript()->OnPlayerLoaded(scriptEntity, entity);
 			}
 		}
 

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -5083,9 +5083,7 @@ void GameMessages::HandleRespondToMission(RakNet::BitStream& inStream, Entity* e
 		return;
 	}
 
-	for (CppScripts::Script* script : CppScripts::GetEntityScripts(offerer)) {
-		script->OnRespondToMission(offerer, missionID, Game::entityManager->GetEntity(playerID), reward);
-	}
+	offerer->GetScript()->OnRespondToMission(offerer, missionID, Game::entityManager->GetEntity(playerID), reward);
 }
 
 void GameMessages::HandleMissionDialogOK(RakNet::BitStream& inStream, Entity* entity) {
@@ -5101,9 +5099,7 @@ void GameMessages::HandleMissionDialogOK(RakNet::BitStream& inStream, Entity* en
 	inStream.Read(responder);
 	player = Game::entityManager->GetEntity(responder);
 
-	for (CppScripts::Script* script : CppScripts::GetEntityScripts(entity)) {
-		script->OnMissionDialogueOK(entity, player, missionID, iMissionState);
-	}
+	if (entity) entity->GetScript()->OnMissionDialogueOK(entity, player, missionID, iMissionState);
 
 	// Get the player's mission component
 	MissionComponent* missionComponent = static_cast<MissionComponent*>(player->GetComponent(eReplicaComponentType::MISSION));
@@ -5556,9 +5552,7 @@ void GameMessages::HandleModularBuildFinish(RakNet::BitStream& inStream, Entity*
 
 			ScriptComponent* script = static_cast<ScriptComponent*>(entity->GetComponent(eReplicaComponentType::SCRIPT));
 
-			for (CppScripts::Script* script : CppScripts::GetEntityScripts(entity)) {
-				script->OnModularBuildExit(entity, character, count >= 3, modList);
-			}
+			entity->GetScript()->OnModularBuildExit(entity, character, count >= 3, modList);
 
 			// Move remaining temp models back to models
 			std::vector<Item*> items;
@@ -5734,16 +5728,14 @@ void GameMessages::HandleResurrect(RakNet::BitStream& inStream, Entity* entity) 
 	bool immediate = inStream.ReadBit();
 
 	Entity* zoneControl = Game::entityManager->GetZoneControlEntity();
-	for (CppScripts::Script* script : CppScripts::GetEntityScripts(zoneControl)) {
-		script->OnPlayerResurrected(zoneControl, entity);
+	if (zoneControl) {
+		zoneControl->GetScript()->OnPlayerResurrected(zoneControl, entity);
 	}
 
 	std::vector<Entity*> scriptedActs = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::SCRIPTED_ACTIVITY);
 	for (Entity* scriptEntity : scriptedActs) {
 		if (scriptEntity->GetObjectID() != zoneControl->GetObjectID()) { // Don't want to trigger twice on instance worlds
-			for (CppScripts::Script* script : CppScripts::GetEntityScripts(scriptEntity)) {
-				script->OnPlayerResurrected(scriptEntity, entity);
-			}
+			scriptEntity->GetScript()->OnPlayerResurrected(scriptEntity, entity);
 		}
 	}
 }
@@ -5977,9 +5969,7 @@ void GameMessages::HandlePlayerRailArrivedNotification(RakNet::BitStream& inStre
 
 	const auto possibleRails = Game::entityManager->GetEntitiesByComponent(eReplicaComponentType::RAIL_ACTIVATOR);
 	for (auto* possibleRail : possibleRails) {
-		for (CppScripts::Script* script : CppScripts::GetEntityScripts(possibleRail)) {
-			script->OnPlayerRailArrived(possibleRail, entity, pathName, waypointNumber);
-		}
+		if (possibleRail) possibleRail->GetScript()->OnPlayerRailArrived(possibleRail, entity, pathName, waypointNumber);
 	}
 }
 

--- a/dScripts/02_server/Map/NT/NtCombatChallengeDummy.cpp
+++ b/dScripts/02_server/Map/NT/NtCombatChallengeDummy.cpp
@@ -1,5 +1,6 @@
 #include "NtCombatChallengeDummy.h"
 #include "EntityManager.h"
+#include "Entity.h"
 
 void NtCombatChallengeDummy::OnDie(Entity* self, Entity* killer) {
 	const auto challengeObjectID = self->GetVar<LWOOBJID>(u"challengeObjectID");
@@ -7,9 +8,7 @@ void NtCombatChallengeDummy::OnDie(Entity* self, Entity* killer) {
 	auto* challengeObject = Game::entityManager->GetEntity(challengeObjectID);
 
 	if (challengeObject != nullptr) {
-		for (CppScripts::Script* script : CppScripts::GetEntityScripts(challengeObject)) {
-			script->OnDie(challengeObject, killer);
-		}
+		challengeObject->GetScript()->OnDie(challengeObject, killer);
 	}
 }
 
@@ -19,8 +18,6 @@ void NtCombatChallengeDummy::OnHitOrHealResult(Entity* self, Entity* attacker, i
 	auto* challengeObject = Game::entityManager->GetEntity(challengeObjectID);
 
 	if (challengeObject != nullptr) {
-		for (CppScripts::Script* script : CppScripts::GetEntityScripts(challengeObject)) {
-			script->OnHitOrHealResult(challengeObject, attacker, damage);
-		}
+		challengeObject->GetScript()->OnHitOrHealResult(challengeObject, attacker, damage);
 	}
 }

--- a/dScripts/02_server/Map/NT/NtCombatChallengeExplodingDummy.cpp
+++ b/dScripts/02_server/Map/NT/NtCombatChallengeExplodingDummy.cpp
@@ -9,9 +9,7 @@ void NtCombatChallengeExplodingDummy::OnDie(Entity* self, Entity* killer) {
 	auto* challengeObject = Game::entityManager->GetEntity(challengeObjectID);
 
 	if (challengeObject != nullptr) {
-		for (CppScripts::Script* script : CppScripts::GetEntityScripts(challengeObject)) {
-			script->OnDie(challengeObject, killer);
-		}
+		challengeObject->GetScript()->OnDie(challengeObject, killer);
 	}
 }
 
@@ -32,9 +30,7 @@ void NtCombatChallengeExplodingDummy::OnHitOrHealResult(Entity* self, Entity* at
 	auto* challengeObject = Game::entityManager->GetEntity(challengeObjectID);
 
 	if (challengeObject != nullptr) {
-		for (CppScripts::Script* script : CppScripts::GetEntityScripts(challengeObject)) {
-			script->OnHitOrHealResult(challengeObject, attacker, damage);
-		}
+		challengeObject->GetScript()->OnHitOrHealResult(challengeObject, attacker, damage);
 	}
 	auto skillComponent = self->GetComponent<SkillComponent>();
 	if (skillComponent != nullptr) {

--- a/dScripts/CMakeLists.txt
+++ b/dScripts/CMakeLists.txt
@@ -11,7 +11,6 @@ set(DSCRIPTS_SOURCES
 	"InvalidScript.cpp"
 	"NPCAddRemoveItem.cpp"
 	"NtFactionSpyServer.cpp"
-	"ScriptComponent.cpp"
 	"ScriptedPowerupSpawner.cpp"
 	"SpawnPetBaseServer.cpp")
 

--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -322,16 +322,18 @@
 #include "WblRobotCitizen.h"
 
 namespace {
-	InvalidScript* invalidToReturn = new InvalidScript();
+	// This is in the translation unit instead of the header to prevent wierd linker errors
+	InvalidScript* const InvalidToReturn = new InvalidScript();
 	std::map<std::string, CppScripts::Script*> m_Scripts;
 };
 
-CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scriptName) {
-	if (m_Scripts.find(scriptName) != m_Scripts.end()) {
-		return m_Scripts[scriptName];
+CppScripts::Script* const CppScripts::GetScript(Entity* parent, const std::string& scriptName) {
+	auto itr = m_Scripts.find(scriptName);
+	if (itr != m_Scripts.end()) {
+		return itr->second;
 	}
 
-	Script* script = invalidToReturn;
+	Script* script = InvalidToReturn;
 
 	//VE / AG:
 	if (scriptName == "scripts\\ai\\AG\\L_AG_SHIP_PLAYER_DEATH_TRIGGER.lua")
@@ -950,7 +952,7 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 
 	// handle invalid script reporting if the path is greater than zero and it's not an ignored script
 	// information not really needed for sys admins but is for developers
-	else if (script == invalidToReturn) {
+	else if (script == InvalidToReturn) {
 		if ((scriptName.length() > 0) && !((scriptName == "scripts\\02_server\\Enemy\\General\\L_SUSPEND_LUA_AI.lua") ||
 			(scriptName == "scripts\\02_server\\Enemy\\General\\L_BASE_ENEMY_SPIDERLING.lua") ||
 			(scriptName =="scripts\\ai\\FV\\L_ACT_NINJA_STUDENT.lua") ||
@@ -963,13 +965,6 @@ CppScripts::Script* CppScripts::GetScript(Entity* parent, const std::string& scr
 	return script;
 }
 
-std::vector<CppScripts::Script*> CppScripts::GetEntityScripts(Entity* entity) {
-	std::vector<CppScripts::Script*> scripts;
-	std::vector<ScriptComponent*> comps = entity->GetScriptComponents();
-	for (ScriptComponent* scriptComp : comps) {
-		if (scriptComp != nullptr) {
-			scripts.push_back(scriptComp->GetScript());
-		}
-	}
-	return scripts;
+CppScripts::Script* const CppScripts::GetInvalidScript() {
+	return InvalidToReturn;
 }

--- a/dScripts/CppScripts.h
+++ b/dScripts/CppScripts.h
@@ -357,6 +357,10 @@ namespace CppScripts {
 		virtual void OnRequestActivityExit(Entity* sender, LWOOBJID player, bool canceled){};
 	};
 
-	Script* GetScript(Entity* parent, const std::string& scriptName);
-	std::vector<Script*> GetEntityScripts(Entity* entity);
+	Script* const GetScript(Entity* parent, const std::string& scriptName);
+
+	// Get the invalid script.  Would be a static variable of the namespace, but that would be
+	// more cluttery to use.  Also this allows us to control where this invalid script is defined and initialized
+	// since we dont want anyone externally modifying it.
+	Script* const GetInvalidScript();
 };


### PR DESCRIPTION
squashed and rebased from #1489 

The client physically does not support having multiple scripts on a GameObject. This PR seeks to remove implying the possibility of this being a thing.

tested:
entering, playing and leaving avant gardens survival (single player, played start to finish)
Using pirate hook build (OnStartup)
red blocks smashables cycle (OnDie, OnQuickbuildComplete)
spider queen instance battle functions from start to finish (OnStartup, ondie, otimer done, OnHitOrHealResult, OnUpdate)
entering fv for the first time (OnPhantomCollision)
building fv canister for blue brick (notifyObject)
boogie down functions (onemote received)
property tutorial missions (OnZonePropertyModelRotated, OnZonePropertyModelRemovedWhileEquipped, OnZonePropertyModelRemoved, OnZonePropertyModelPickedUp, OnZonePropertyModelPlaced, OnZonePropertyModelEquipped, OnZonePropertyEditBegin, OnZonePropertyEditEnd)
growing flowers on crux (OnSkillEventFired)
Imaginite pack (OnHit)
damaged by fire (OnPhantomCollision, OnOffPhantomCollision)
building both consoles fv (OnQuickbuildNotifyState)
Mast teleporting (OnQuickBuildComplete)
fans in ag turn off and on (OnFireEventServerSide trigger)
naxue naomi breadcrumbs mission (OnMissionDialogueOK)
nexus jay join faction mission (OnRespondToMission)
build rocket for mardolf the orange (OnModularBuildExit)
Using a ninjago ice rail activator in caves (OnPlayerRailActivated)