### PR TITLE
fix: commendation vendor cant accept missions

### DIFF
--- a/dGame/dComponents/AchievementVendorComponent.h
+++ b/dGame/dComponents/AchievementVendorComponent.h
@@ -11,7 +11,9 @@ class Entity;
 class AchievementVendorComponent final : public VendorComponent {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::ACHIEVEMENT_VENDOR;
-	AchievementVendorComponent(Entity* parent) : VendorComponent(parent) {};
+	AchievementVendorComponent(Entity* parent);
+	
+	void RefreshInventory(bool isCreation = false) override;
 	bool SellsItem(Entity* buyer, const LOT lot);
 	void Buy(Entity* buyer, LOT lot, uint32_t count);
 

--- a/dGame/dComponents/VendorComponent.h
+++ b/dGame/dComponents/VendorComponent.h
@@ -49,7 +49,7 @@ public:
 
 	void Buy(Entity* buyer, LOT lot, uint32_t count);
 
-protected:
+private:
 	void HandleMrReeCameras();
 	bool SetupItem(LOT item);
 	float m_BuyScalar = 0.0f;

--- a/dGame/dComponents/VendorComponent.h
+++ b/dGame/dComponents/VendorComponent.h
@@ -26,7 +26,7 @@ public:
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
 
 	void OnUse(Entity* originator) override;
-	void RefreshInventory(bool isCreation = false);
+	virtual void RefreshInventory(bool isCreation = false);
 	void SetupConstants();
 	bool SellsItem(const LOT item) const;
 	float GetBuyScalar() const { return m_BuyScalar; }
@@ -49,7 +49,7 @@ public:
 
 	void Buy(Entity* buyer, LOT lot, uint32_t count);
 
-private:
+protected:
 	void HandleMrReeCameras();
 	bool SetupItem(LOT item);
 	float m_BuyScalar = 0.0f;


### PR DESCRIPTION
We never set the HasStandardCost flag in the AchievementVendor.

"Why are you calling RefreshVendor again in the most derived class constructor?  Wont the one in VendorComponent call it?"
No because at that point in time, the vftable for the AchievementVendor has not been assigned yet and as such a call to the virtual function is impossible.  We do need the function to be virtual to prevent the regular refresh from going through as the work is unnecessary for this entity

Tested that you can complete missions from the AchievementVendor and still buy still.