### PR TITLE
fix: update serialization, remove unused variable

### DIFF
--- a/dGame/dComponents/ControllablePhysicsComponent.cpp
+++ b/dGame/dComponents/ControllablePhysicsComponent.cpp
@@ -26,7 +26,6 @@ ControllablePhysicsComponent::ControllablePhysicsComponent(Entity* entity) : Phy
 	m_SpeedMultiplier = 1;
 	m_GravityScale = 1;
 	m_DirtyCheats = false;
-	m_IgnoreMultipliers = false;
 
 	m_DirtyEquippedItemInfo = true;
 	m_PickupRadius = 0.0f;
@@ -92,31 +91,31 @@ void ControllablePhysicsComponent::Serialize(RakNet::BitStream& outBitStream, bo
 		outBitStream.Write(m_ImmuneToStunInteractCount);
 	}
 
-	if (m_IgnoreMultipliers) m_DirtyCheats = false;
-
-	outBitStream.Write(m_DirtyCheats);
-	if (m_DirtyCheats) {
+	outBitStream.Write(m_DirtyCheats || bIsInitialUpdate);
+	if (m_DirtyCheats || bIsInitialUpdate) {
 		outBitStream.Write(m_GravityScale);
 		outBitStream.Write(m_SpeedMultiplier);
 
-		m_DirtyCheats = false;
+		if (!bIsInitialUpdate) m_DirtyCheats = false;
 	}
 
-	outBitStream.Write(m_DirtyEquippedItemInfo);
-	if (m_DirtyEquippedItemInfo) {
+	outBitStream.Write(m_DirtyEquippedItemInfo || bIsInitialUpdate);
+	if (m_DirtyEquippedItemInfo || bIsInitialUpdate) {
 		outBitStream.Write(m_PickupRadius);
 		outBitStream.Write(m_InJetpackMode);
-		m_DirtyEquippedItemInfo = false;
+
+		if (!bIsInitialUpdate) m_DirtyEquippedItemInfo = false;
 	}
 
-	outBitStream.Write(m_DirtyBubble);
-	if (m_DirtyBubble) {
+	outBitStream.Write(m_DirtyBubble || bIsInitialUpdate);
+	if (m_DirtyBubble || bIsInitialUpdate) {
 		outBitStream.Write(m_IsInBubble);
 		if (m_IsInBubble) {
 			outBitStream.Write(m_BubbleType);
 			outBitStream.Write(m_SpecialAnims);
 		}
-		m_DirtyBubble = false;
+
+		if (!bIsInitialUpdate) m_DirtyBubble = false;
 	}
 
 	outBitStream.Write(m_DirtyPosition || bIsInitialUpdate);
@@ -149,7 +148,8 @@ void ControllablePhysicsComponent::Serialize(RakNet::BitStream& outBitStream, bo
 			outBitStream.Write(m_AngularVelocity.z);
 		}
 
-		outBitStream.Write0();
+		outBitStream.Write0(); // local_space_info, always zero for now.
+
 		if (!bIsInitialUpdate) {
 			m_DirtyPosition = false;
 			outBitStream.Write(m_IsTeleporting);

--- a/dGame/dComponents/ControllablePhysicsComponent.h
+++ b/dGame/dComponents/ControllablePhysicsComponent.h
@@ -175,18 +175,6 @@ public:
 	const float GetGravityScale() const { return m_GravityScale; }
 
 	/**
-	 * Sets the ignore multipliers value, allowing you to skip the serialization of speed and gravity multipliers
-	 * @param value whether or not to ignore multipliers
-	 */
-	void SetIgnoreMultipliers(bool value) { m_IgnoreMultipliers = value; }
-
-	/**
-	 * Returns the current ignore multipliers value
-	 * @return the current ignore multipliers value
-	 */
-	const bool GetIgnoreMultipliers() const { return m_IgnoreMultipliers; }
-
-	/**
 	 * Can make an entity static, making it unable to move around
 	 * @param value whether or not the entity is static
 	 */
@@ -352,11 +340,6 @@ private:
 	 * Forces a serialization of the speed multiplier and the gravity scale
 	 */
 	bool m_DirtyCheats;
-
-	/**
-	 * Makes it so that the speed multiplier and gravity scale are no longer serialized if false
-	 */
-	bool m_IgnoreMultipliers;
 
 	/**
 	 * Whether this entity is static, making it unable to move


### PR DESCRIPTION
Tested that players show up as normal on each others screens, tested that money magnet still works with item 8600, tested that gravity still works in Moon Base.
This should also resolve an issue (if one exists) where sometimes gravity or money magnet would not be active for a specific player based on the order they loaded in.  Now the correct data will be sent every time.