### PR TITLE
fix: Update switch behavior

### DIFF
--- a/dGame/dBehaviors/SwitchBehavior.cpp
+++ b/dGame/dBehaviors/SwitchBehavior.cpp
@@ -7,9 +7,9 @@
 #include "BuffComponent.h"
 
 void SwitchBehavior::Handle(BehaviorContext* context, RakNet::BitStream& bitStream, const BehaviorBranchContext branch) {
-	auto state = true;
+	bool state = true;
 
-	if (this->m_imagination > 0 || !this->m_isEnemyFaction) {
+	if (m_imagination > 0 || m_targetHasBuff > 0 || m_Distance > -1.0f) {
 		if (!bitStream.Read(state)) {
 			LOG("Unable to read state from bitStream, aborting Handle! %i", bitStream.GetNumberOfUnreadBits());
 			return;
@@ -18,49 +18,59 @@ void SwitchBehavior::Handle(BehaviorContext* context, RakNet::BitStream& bitStre
 
 	auto* entity = Game::entityManager->GetEntity(context->originator);
 
-	if (entity == nullptr) {
-		return;
-	}
+	if (!entity) return;
 
 	auto* destroyableComponent = entity->GetComponent<DestroyableComponent>();
 
-	if (destroyableComponent == nullptr) {
-		return;
+	if (destroyableComponent) {
+		if (m_isEnemyFaction) {
+			auto* target = Game::entityManager->GetEntity(branch.target);
+			if (target) state = destroyableComponent->IsEnemy(target);
+		}
+
+		LOG_DEBUG("[%i] State: (%d), imagination: (%i) / (%f)", entity->GetLOT(), state, destroyableComponent->GetImagination(), destroyableComponent->GetMaxImagination());
 	}
 
-	LOG_DEBUG("[%i] State: (%d), imagination: (%i) / (%f)", entity->GetLOT(), state, destroyableComponent->GetImagination(), destroyableComponent->GetMaxImagination());
-
-	if (state) {
-		this->m_actionTrue->Handle(context, bitStream, branch);
-	} else {
-		this->m_actionFalse->Handle(context, bitStream, branch);
-	}
+	auto* behaviorToCall = state ? m_actionTrue : m_actionFalse;
+	behaviorToCall->Handle(context, bitStream, branch);
 }
 
 void SwitchBehavior::Calculate(BehaviorContext* context, RakNet::BitStream& bitStream, BehaviorBranchContext branch) {
-	auto state = true;
-
-	if (this->m_imagination > 0 || !this->m_isEnemyFaction) {
+	bool state = true;
+	if (m_imagination > 0 || m_targetHasBuff > 0 || m_Distance > -1.0f) {
 		auto* entity = Game::entityManager->GetEntity(branch.target);
 
 		state = entity != nullptr;
 
-		if (state && m_targetHasBuff != 0) {
-			auto* buffComponent = entity->GetComponent<BuffComponent>();
+		if (state) {
+			if (m_targetHasBuff != 0) {
+				auto* buffComponent = entity->GetComponent<BuffComponent>();
 
-			if (buffComponent != nullptr && !buffComponent->HasBuff(m_targetHasBuff)) {
-				state = false;
+				if (buffComponent != nullptr && !buffComponent->HasBuff(m_targetHasBuff)) {
+					state = false;
+				}
+			} else if (m_imagination > 0) {
+				auto* destroyableComponent = entity->GetComponent<DestroyableComponent>();
+
+				if (destroyableComponent && destroyableComponent->GetImagination() < m_imagination) {
+					state = false;
+				}
+			} else if (m_Distance > -1.0f) {
+				auto* originator = Game::entityManager->GetEntity(context->originator);
+
+				if (originator) {
+					const auto distance = (originator->GetPosition() - entity->GetPosition()).Length();
+
+					state = distance <= m_Distance;
+				}
 			}
 		}
 
 		bitStream.Write(state);
 	}
 
-	if (state) {
-		this->m_actionTrue->Calculate(context, bitStream, branch);
-	} else {
-		this->m_actionFalse->Calculate(context, bitStream, branch);
-	}
+	auto* behaviorToCall = state ? m_actionTrue : m_actionFalse;
+	behaviorToCall->Calculate(context, bitStream, branch);
 }
 
 void SwitchBehavior::Load() {
@@ -72,5 +82,7 @@ void SwitchBehavior::Load() {
 
 	this->m_isEnemyFaction = GetBoolean("isEnemyFaction");
 
-	this->m_targetHasBuff = GetInt("target_has_buff");
+	this->m_targetHasBuff = GetInt("target_has_buff", -1);
+
+	this->m_Distance = GetFloat("distance", -1.0f);
 }

--- a/dGame/dBehaviors/SwitchBehavior.h
+++ b/dGame/dBehaviors/SwitchBehavior.h
@@ -14,6 +14,8 @@ public:
 
 	int32_t m_targetHasBuff;
 
+	float m_Distance;
+
 	/*
 	 * Inherited
 	 */


### PR DESCRIPTION
Was using very old code from pre-foss that has not been updated with the new behavior knowledge.  The code has been updated accordingly to what the client expects.

Tested that ice shurikens can now destroy the legs of the skeleton towers in crux prime.  Tested that the following weapons can still do damage to enemies and objects in the world: surikens of ice
serratorizer
Super Morning Star
Super Dagger
elite long barrel blaster (charge and normal)
Mosaic Wand