### PR TITLE
chore: Remove `new`s in Behavior members

### DIFF
--- a/dGame/dBehaviors/Behavior.h
+++ b/dGame/dBehaviors/Behavior.h
@@ -41,9 +41,9 @@ public:
 	uint32_t m_behaviorId;
 	BehaviorTemplates m_templateId;
 	uint32_t m_effectId;
-	std::string* m_effectHandle = nullptr;
-	std::unordered_map<std::string, std::string>* m_effectNames = nullptr;
-	std::string* m_effectType = nullptr;
+	std::string m_effectHandle;
+	std::unordered_map<std::string, std::string> m_effectNames;
+	std::string m_effectType;
 
 	/*
 	 * Behavior parameters
@@ -88,5 +88,5 @@ public:
 	 */
 
 	explicit Behavior(uint32_t behaviorId);
-	virtual ~Behavior();
+	virtual ~Behavior() = default;
 };

--- a/dGame/dBehaviors/Behavior.h
+++ b/dGame/dBehaviors/Behavior.h
@@ -89,4 +89,10 @@ public:
 
 	explicit Behavior(uint32_t behaviorId);
 	virtual ~Behavior() = default;
+
+	Behavior(const Behavior& other) = default;
+	Behavior(Behavior&& other) = default;
+
+	Behavior& operator=(const Behavior& other) = default;
+	Behavior& operator=(Behavior&& other) = default;
 };

--- a/dGame/dBehaviors/SkillEventBehavior.cpp
+++ b/dGame/dBehaviors/SkillEventBehavior.cpp
@@ -9,17 +9,16 @@ void SkillEventBehavior::Handle(BehaviorContext* context, RakNet::BitStream& bit
 	auto* target = Game::entityManager->GetEntity(branch.target);
 	auto* caster = Game::entityManager->GetEntity(context->originator);
 
-	if (caster != nullptr && target != nullptr && this->m_effectHandle != nullptr && !this->m_effectHandle->empty()) {
-		target->GetScript()->OnSkillEventFired(target, caster, *this->m_effectHandle);
+	if (caster != nullptr && target != nullptr && !this->m_effectHandle.empty()) {
+		target->GetScript()->OnSkillEventFired(target, caster, this->m_effectHandle);
 	}
 }
 
-void
-SkillEventBehavior::Calculate(BehaviorContext* context, RakNet::BitStream& bitStream, BehaviorBranchContext branch) {
+void SkillEventBehavior::Calculate(BehaviorContext* context, RakNet::BitStream& bitStream, BehaviorBranchContext branch) {
 	auto* target = Game::entityManager->GetEntity(branch.target);
 	auto* caster = Game::entityManager->GetEntity(context->originator);
 
-	if (caster != nullptr && target != nullptr && this->m_effectHandle != nullptr && !this->m_effectHandle->empty()) {
-		target->GetScript()->OnSkillEventFired(target, caster, *this->m_effectHandle);
+	if (caster != nullptr && target != nullptr && !this->m_effectHandle.empty()) {
+		target->GetScript()->OnSkillEventFired(target, caster, this->m_effectHandle);
 	}
 }


### PR DESCRIPTION
Could remove all the this-> since everything is prefixed with m_, but meh, too much change for this pr, getting rid of the news is a better fix

Tested that GrowingFlowers still have their SkillEvent fired with the correct parameters, gftikitorch works, sharks eating stinky fish still work