### PR TITLE
fix: remove extra access of PlayerData

### DIFF
--- a/dChatServer/PlayerContainer.cpp
+++ b/dChatServer/PlayerContainer.cpp
@@ -390,7 +390,7 @@ LWOOBJID PlayerContainer::GetId(const std::u16string& playerName) {
 }
 
 PlayerData& PlayerContainer::GetPlayerDataMutable(const LWOOBJID& playerID) {
-	return m_Players[playerID];
+	return m_Players.contains(playerID) ? m_Players[playerID] : m_Players[LWOOBJID_EMPTY];
 }
 
 PlayerData& PlayerContainer::GetPlayerDataMutable(const std::string& playerName) {


### PR DESCRIPTION
Prevents a bad actor from possibly spamming the server with sequential IDs and allocating a bunch of memory.

Tested that I can still send and receive friend requests.  Tested that I can send and complete a best friend request while the other player is offline