### PR TITLE
chore: Hide C symbol visibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ include(CTest)
 set(CMAKE_CXX_STANDARD 20)
 set(CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POLICY_DEFAULT_CMP0063 NEW) # Set CMAKE visibility policy to NEW on project and subprojects
+set(CMAKE_C_VISIBILITY_PRESET hidden) # Set C symbol visibility to default to hidden
 set(CMAKE_CXX_VISIBILITY_PRESET hidden) # Set C++ symbol visibility to default to hidden
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 


### PR DESCRIPTION
Update C symbol visibility to default to hidden as well. Marking as draft for now as while this unifies the default symbol behaviors of gcc, clang, and MSVC (as MSVC defaults to hidden), I'm not actually sure if we have enough C code in the project for this to affect anything and so need to check if there's any difference in the compiled binaries.