### PR TITLE
chore: unbreak the stacktraces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,8 +4,9 @@ include(CTest)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CXX_STANDARD_REQUIRED ON)
-set(CMAKE_POLICY_DEFAULT_CMP0063 NEW) # Set CMAKE visibility policy to NEW on project and subprojects
-set(CMAKE_CXX_VISIBILITY_PRESET hidden) # Set C++ symbol visibility to default to hidden
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON) 	# Export the compile commands for debugging
+set(CMAKE_POLICY_DEFAULT_CMP0063 NEW) 	# Set CMAKE visibility policy to NEW on project and subprojects
+set(CMAKE_VISIBILITY_INLINES_HIDDEN ON) # Set C and C++ symbol visibility to hide inlined functions
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 # Read variables from file


### PR DESCRIPTION
Fixes #1515 (which I broke) by partially undoing the symbol visibility changes to only hide inlined functions. Also, CMake now dumps the compile commands into compile_commands.json because that was useful to make sure the correct flags were being applied here and it would probably be useful enough to keep it.