### PR TITLE
fix: stewblaster stopping for non-players

### DIFF
--- a/dGame/dComponents/MovementAIComponent.cpp
+++ b/dGame/dComponents/MovementAIComponent.cpp
@@ -68,6 +68,7 @@ void MovementAIComponent::SetPath(const std::string pathName) {
 }
 
 void MovementAIComponent::Pause() {
+	if (m_Paused) return;
 	m_Paused = true;
 	SetPosition(ApproximateLocation());
 	m_SavedVelocity = GetVelocity();
@@ -76,6 +77,7 @@ void MovementAIComponent::Pause() {
 }
 
 void MovementAIComponent::Resume() {
+	if (!m_Paused) return;
 	m_Paused = false;
 	SetVelocity(m_SavedVelocity);
 	m_SavedVelocity = NiPoint3Constant::ZERO;

--- a/dScripts/02_server/Map/AM/WanderingVendor.cpp
+++ b/dScripts/02_server/Map/AM/WanderingVendor.cpp
@@ -1,6 +1,7 @@
 #include "WanderingVendor.h"
 #include "MovementAIComponent.h"
 #include "ProximityMonitorComponent.h"
+#include <ranges>
 
 void WanderingVendor::OnStartup(Entity* self) {
 	auto movementAIComponent = self->GetComponent<MovementAIComponent>();
@@ -19,7 +20,16 @@ void WanderingVendor::OnProximityUpdate(Entity* self, Entity* entering, std::str
 		if (!proximityMonitorComponent) self->AddComponent<ProximityMonitorComponent>();
 
 		const auto proxObjs = proximityMonitorComponent->GetProximityObjects("playermonitor");
-		if (proxObjs.empty()) self->AddTimer("startWalking", 1.5);
+		bool foundPlayer = false;
+		for (const auto id : proxObjs | std::views::keys) {
+			auto* entity = Game::entityManager->GetEntity(id);
+			if (entity && entity->IsPlayer()) {
+				foundPlayer = true;
+				break;
+			}
+		}
+
+		if (!foundPlayer) self->AddTimer("startWalking", 1.5);
 	}
 }
 


### PR DESCRIPTION
fixes an issue when stew blaster would stop for non-players and would stand still permanently due to enemy hitboxes being removed.  The multiple stoppings from players would also cause unnecessary work to be done, so checks for only being paused or unpaused for pausing or resuming movement were added.

Tested that stewblaster only stops for players and starts moving when there are no players in the vicinity