### PR TITLE
fix: update InterruptBehavior to current knowledge

### DIFF
--- a/dGame/dBehaviors/InterruptBehavior.cpp
+++ b/dGame/dBehaviors/InterruptBehavior.cpp
@@ -8,36 +8,50 @@
 
 
 void InterruptBehavior::Handle(BehaviorContext* context, RakNet::BitStream& bitStream, BehaviorBranchContext branch) {
-	if (branch.target != context->originator) {
-		bool unknown = false;
+	LWOOBJID usedTarget = m_target ? branch.target : context->originator;
 
-		if (!bitStream.Read(unknown)) {
-			LOG("Unable to read unknown1 from bitStream, aborting Handle! %i", bitStream.GetNumberOfUnreadBits());
+	if (usedTarget != context->originator) {
+		bool isTargetImmuneStuns = false;
+		if (!bitStream.Read(isTargetImmuneStuns)) {
+			LOG("Unable to read isTargetImmune from bitStream, aborting Handle! %i", bitStream.GetNumberOfUnreadBits());
 			return;
 		};
 
-		if (unknown) return;
+		if (isTargetImmuneStuns) return;
 	}
 
 	if (!this->m_interruptBlock) {
-		bool unknown = false;
-
-		if (!bitStream.Read(unknown)) {
-			LOG("Unable to read unknown2 from bitStream, aborting Handle! %i", bitStream.GetNumberOfUnreadBits());
+		bool isBlockingInterrupts = false;
+		if (!bitStream.Read(isBlockingInterrupts)) {
+			LOG("Unable to read isBlockingInterrupts from bitStream, aborting Handle! %i", bitStream.GetNumberOfUnreadBits());
 			return;
 		};
 
-		if (unknown) return;
+		if (isBlockingInterrupts) return;
 	}
 
-	if (this->m_target) // Guess...
-	{
-		bool unknown = false;
+	bool hasInterruptedStatusEffects = false;
+	if (!bitStream.Read(hasInterruptedStatusEffects)) {
+		LOG("Unable to read hasInterruptedStatusEffects from bitStream, aborting Handle! %i", bitStream.GetNumberOfUnreadBits());
+		return;
+	};
 
-		if (!bitStream.Read(unknown)) {
-			LOG("Unable to read unknown3 from bitStream, aborting Handle! %i", bitStream.GetNumberOfUnreadBits());
-			return;
-		};
+	if (hasInterruptedStatusEffects) {
+		bool hasMoreInterruptedStatusEffects = false;
+		int32_t loopLimit = 0;
+		while (bitStream.Read(hasMoreInterruptedStatusEffects) && hasMoreInterruptedStatusEffects) {
+			int32_t statusEffectID = 0;
+			bitStream.Read(statusEffectID);
+			// nothing happens with this data yes.  I have no idea why or what it was used for, but the client literally just reads it and does nothing with it.
+			// 0x004faca4 for a reference.  it also has a hard loop limit of 100 soo,
+			loopLimit++;
+			if (loopLimit > 100) {
+				// if this is hit you have a problem
+				LOG("Loop limit reached for interrupted status effects, aborting Handle due to bad bitstream! %i", bitStream.GetNumberOfUnreadBits());
+				break;
+			}
+			LOG_DEBUG("Interrupted status effect ID: %i", statusEffectID);
+		}
 	}
 
 	if (branch.target == context->originator) return;
@@ -55,7 +69,8 @@ void InterruptBehavior::Handle(BehaviorContext* context, RakNet::BitStream& bitS
 
 
 void InterruptBehavior::Calculate(BehaviorContext* context, RakNet::BitStream& bitStream, BehaviorBranchContext branch) {
-	if (branch.target != context->originator) {
+	LWOOBJID usedTarget = m_target ? branch.target : context->originator;
+	if (usedTarget != context->originator) {
 		bitStream.Write(false);
 	}
 


### PR DESCRIPTION
Should be 100% live accurate as far as logic and bitstream reads goes.

Tested with all valiant weapons and crux prime weapons (drops from dragons) that combat does not desync and that the client reports the same level and amount of skill deserialize issues as before.

Would like Wincent or the last person who worked on this part of the behavior system to give this a once over due to that guess... and it dating back to pre-foss DLU.