### PR TITLE
fix: more restrictive std::from_chars for floating point

### DIFF
--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -166,7 +166,7 @@ namespace GeneralUtils {
 		return isParsed ? static_cast<T>(result) : std::optional<T>{};
 	}
 
-#ifdef DARKFLAME_PLATFORM_MACOS
+#if !(__GNUC__ >= 11 || _MSC_VER >= 1924)
 
 	// MacOS floating-point parse helper function specializations
 	namespace details {


### PR DESCRIPTION
given that fp is only on 2 compilers, it would make sense to only do the custom impl for not those two compilers.

Still compiles on my machine which has gcc-11 and does not error if I insert an error macro inside the if block.
![image](https://github.com/DarkflameUniverse/DarkflameServer/assets/39972741/538e3bb4-a976-44e2-9a14-95de528eee07)
