### PR TITLE
chore: Remove dpEntity pointers from collision checking

### DIFF
--- a/dGame/dComponents/BaseCombatAIComponent.cpp
+++ b/dGame/dComponents/BaseCombatAIComponent.cpp
@@ -150,13 +150,13 @@ void BaseCombatAIComponent::Update(const float deltaTime) {
 	m_dpEntityEnemy->SetPosition(m_Parent->GetPosition());
 
 	//Process enter events
-	for (auto en : m_dpEntity->GetNewObjects()) {
-		m_Parent->OnCollisionPhantom(en->GetObjectID());
+	for (const auto en : m_dpEntity->GetNewObjects()) {
+		m_Parent->OnCollisionPhantom(en);
 	}
 
 	//Process exit events
-	for (auto en : m_dpEntity->GetRemovedObjects()) {
-		m_Parent->OnCollisionLeavePhantom(en->GetObjectID());
+	for (const auto en : m_dpEntity->GetRemovedObjects()) {
+		m_Parent->OnCollisionLeavePhantom(en);
 	}
 
 	// Check if we should stop the tether effect

--- a/dGame/dComponents/BaseCombatAIComponent.cpp
+++ b/dGame/dComponents/BaseCombatAIComponent.cpp
@@ -150,13 +150,13 @@ void BaseCombatAIComponent::Update(const float deltaTime) {
 	m_dpEntityEnemy->SetPosition(m_Parent->GetPosition());
 
 	//Process enter events
-	for (const auto en : m_dpEntity->GetNewObjects()) {
-		m_Parent->OnCollisionPhantom(en);
+	for (const auto id : m_dpEntity->GetNewObjects()) {
+		m_Parent->OnCollisionPhantom(id);
 	}
 
 	//Process exit events
-	for (const auto en : m_dpEntity->GetRemovedObjects()) {
-		m_Parent->OnCollisionLeavePhantom(en);
+	for (const auto id : m_dpEntity->GetRemovedObjects()) {
+		m_Parent->OnCollisionLeavePhantom(id);
 	}
 
 	// Check if we should stop the tether effect

--- a/dGame/dComponents/PhantomPhysicsComponent.cpp
+++ b/dGame/dComponents/PhantomPhysicsComponent.cpp
@@ -187,7 +187,7 @@ PhantomPhysicsComponent::PhantomPhysicsComponent(Entity* parent) : PhysicsCompon
 			//add fallback cube:
 			m_dpEntity = new dpEntity(m_Parent->GetObjectID(), 2.0f, 2.0f, 2.0f);
 		}
-	
+
 		m_dpEntity->SetScale(m_Scale);
 		m_dpEntity->SetRotation(m_Rotation);
 		m_dpEntity->SetPosition(m_Position);
@@ -323,14 +323,14 @@ void PhantomPhysicsComponent::Update(float deltaTime) {
 	if (!m_dpEntity) return;
 
 	//Process enter events
-	for (auto en : m_dpEntity->GetNewObjects()) {
+	for (const auto en : m_dpEntity->GetNewObjects()) {
 		if (!en) continue;
-		ApplyCollisionEffect(en->GetObjectID(), m_EffectType, m_DirectionalMultiplier);
-		m_Parent->OnCollisionPhantom(en->GetObjectID());
+		ApplyCollisionEffect(en, m_EffectType, m_DirectionalMultiplier);
+		m_Parent->OnCollisionPhantom(en);
 
 		//If we are a respawn volume, inform the client:
 		if (m_IsRespawnVolume) {
-			auto entity = Game::entityManager->GetEntity(en->GetObjectID());
+			const auto entity = Game::entityManager->GetEntity(en);
 
 			if (entity) {
 				GameMessages::SendPlayerReachedRespawnCheckpoint(entity, m_RespawnPos, m_RespawnRot);
@@ -341,10 +341,10 @@ void PhantomPhysicsComponent::Update(float deltaTime) {
 	}
 
 	//Process exit events
-	for (auto en : m_dpEntity->GetRemovedObjects()) {
+	for (const auto en : m_dpEntity->GetRemovedObjects()) {
 		if (!en) continue;
-		ApplyCollisionEffect(en->GetObjectID(), m_EffectType, 1.0f);
-		m_Parent->OnCollisionLeavePhantom(en->GetObjectID());
+		ApplyCollisionEffect(en, m_EffectType, 1.0f);
+		m_Parent->OnCollisionLeavePhantom(en);
 	}
 }
 

--- a/dGame/dComponents/PhantomPhysicsComponent.cpp
+++ b/dGame/dComponents/PhantomPhysicsComponent.cpp
@@ -330,7 +330,7 @@ void PhantomPhysicsComponent::Update(float deltaTime) {
 
 		//If we are a respawn volume, inform the client:
 		if (m_IsRespawnVolume) {
-			const auto entity = Game::entityManager->GetEntity(en);
+			auto* const entity = Game::entityManager->GetEntity(en);
 
 			if (entity) {
 				GameMessages::SendPlayerReachedRespawnCheckpoint(entity, m_RespawnPos, m_RespawnRot);

--- a/dGame/dComponents/PhantomPhysicsComponent.cpp
+++ b/dGame/dComponents/PhantomPhysicsComponent.cpp
@@ -323,14 +323,13 @@ void PhantomPhysicsComponent::Update(float deltaTime) {
 	if (!m_dpEntity) return;
 
 	//Process enter events
-	for (const auto en : m_dpEntity->GetNewObjects()) {
-		if (!en) continue;
-		ApplyCollisionEffect(en, m_EffectType, m_DirectionalMultiplier);
-		m_Parent->OnCollisionPhantom(en);
+	for (const auto id : m_dpEntity->GetNewObjects()) {
+		ApplyCollisionEffect(id, m_EffectType, m_DirectionalMultiplier);
+		m_Parent->OnCollisionPhantom(id);
 
 		//If we are a respawn volume, inform the client:
 		if (m_IsRespawnVolume) {
-			auto* const entity = Game::entityManager->GetEntity(en);
+			auto* const entity = Game::entityManager->GetEntity(id);
 
 			if (entity) {
 				GameMessages::SendPlayerReachedRespawnCheckpoint(entity, m_RespawnPos, m_RespawnRot);
@@ -341,10 +340,9 @@ void PhantomPhysicsComponent::Update(float deltaTime) {
 	}
 
 	//Process exit events
-	for (const auto en : m_dpEntity->GetRemovedObjects()) {
-		if (!en) continue;
-		ApplyCollisionEffect(en, m_EffectType, 1.0f);
-		m_Parent->OnCollisionLeavePhantom(en);
+	for (const auto id : m_dpEntity->GetRemovedObjects()) {
+		ApplyCollisionEffect(id, m_EffectType, 1.0f);
+		m_Parent->OnCollisionLeavePhantom(id);
 	}
 }
 

--- a/dGame/dComponents/ProximityMonitorComponent.cpp
+++ b/dGame/dComponents/ProximityMonitorComponent.cpp
@@ -5,7 +5,7 @@
 #include "EntityManager.h"
 #include "SimplePhysicsComponent.h"
 
-const std::set<LWOOBJID> ProximityMonitorComponent::m_EmptyObjectSet = {};
+const std::unordered_set<LWOOBJID> ProximityMonitorComponent::m_EmptyObjectSet = {};
 
 ProximityMonitorComponent::ProximityMonitorComponent(Entity* parent, int radiusSmall, int radiusLarge) : Component(parent) {
 	if (radiusSmall != -1 && radiusLarge != -1) {
@@ -38,10 +38,10 @@ void ProximityMonitorComponent::SetProximityRadius(dpEntity* entity, const std::
 	m_ProximitiesData.insert(std::make_pair(name, entity));
 }
 
-const std::set<LWOOBJID>& ProximityMonitorComponent::GetProximityObjects(const std::string& name) {
-	const auto& iter = m_ProximitiesData.find(name);
+const std::unordered_set<LWOOBJID>& ProximityMonitorComponent::GetProximityObjects(const std::string& name) {
+	const auto iter = m_ProximitiesData.find(name);
 
-	if (iter == m_ProximitiesData.end()) {
+	if (iter == m_ProximitiesData.cend()) {
 		return m_EmptyObjectSet;
 	}
 
@@ -49,7 +49,7 @@ const std::set<LWOOBJID>& ProximityMonitorComponent::GetProximityObjects(const s
 }
 
 bool ProximityMonitorComponent::IsInProximity(const std::string& name, LWOOBJID objectID) {
-	const auto& iter = m_ProximitiesData.find(name);
+	const auto iter = m_ProximitiesData.find(name);
 
 	if (iter == m_ProximitiesData.cend()) {
 		return false;
@@ -66,13 +66,13 @@ void ProximityMonitorComponent::Update(float deltaTime) {
 
 		prox.second->SetPosition(m_Parent->GetPosition());
 		//Process enter events
-		for (const auto en : prox.second->GetNewObjects()) {
-			m_Parent->OnCollisionProximity(en, prox.first, "ENTER");
+		for (const auto id : prox.second->GetNewObjects()) {
+			m_Parent->OnCollisionProximity(id, prox.first, "ENTER");
 		}
 
 		//Process exit events
-		for (const auto en : prox.second->GetRemovedObjects()) {
-			m_Parent->OnCollisionProximity(en, prox.first, "LEAVE");
+		for (const auto id : prox.second->GetRemovedObjects()) {
+			m_Parent->OnCollisionProximity(id, prox.first, "LEAVE");
 		}
 	}
 }

--- a/dGame/dComponents/ProximityMonitorComponent.cpp
+++ b/dGame/dComponents/ProximityMonitorComponent.cpp
@@ -7,7 +7,7 @@
 #include "EntityManager.h"
 #include "SimplePhysicsComponent.h"
 
-const std::vector<LWOOBJID> ProximityMonitorComponent::m_EmptyObjectVec = {};
+const std::set<LWOOBJID> ProximityMonitorComponent::m_EmptyObjectSet = {};
 
 ProximityMonitorComponent::ProximityMonitorComponent(Entity* parent, int radiusSmall, int radiusLarge) : Component(parent) {
 	if (radiusSmall != -1 && radiusLarge != -1) {
@@ -40,11 +40,11 @@ void ProximityMonitorComponent::SetProximityRadius(dpEntity* entity, const std::
 	m_ProximitiesData.insert(std::make_pair(name, entity));
 }
 
-const std::vector<LWOOBJID>& ProximityMonitorComponent::GetProximityObjects(const std::string& name) {
+const std::set<LWOOBJID>& ProximityMonitorComponent::GetProximityObjects(const std::string& name) {
 	const auto& iter = m_ProximitiesData.find(name);
 
 	if (iter == m_ProximitiesData.end()) {
-		return m_EmptyObjectVec;
+		return m_EmptyObjectSet;
 	}
 
 	return iter->second->GetCurrentlyCollidingObjects();
@@ -59,7 +59,7 @@ bool ProximityMonitorComponent::IsInProximity(const std::string& name, LWOOBJID 
 
 	const auto& collisions = iter->second->GetCurrentlyCollidingObjects();
 
-	return std::ranges::find(collisions, objectID) != collisions.cend();
+	return collisions.contains(objectID);
 }
 
 void ProximityMonitorComponent::Update(float deltaTime) {

--- a/dGame/dComponents/ProximityMonitorComponent.cpp
+++ b/dGame/dComponents/ProximityMonitorComponent.cpp
@@ -1,5 +1,3 @@
-#include <algorithm>
-
 #include "ProximityMonitorComponent.h"
 #include "GameMessages.h"
 #include "dZoneManager.h"

--- a/dGame/dComponents/ProximityMonitorComponent.cpp
+++ b/dGame/dComponents/ProximityMonitorComponent.cpp
@@ -1,3 +1,5 @@
+#include <algorithm>
+
 #include "ProximityMonitorComponent.h"
 #include "GameMessages.h"
 #include "dZoneManager.h"
@@ -57,7 +59,7 @@ bool ProximityMonitorComponent::IsInProximity(const std::string& name, LWOOBJID 
 
 	const auto& collisions = iter->second->GetCurrentlyCollidingObjects();
 
-	return std::find(collisions.cbegin(), collisions.cend(), objectID) != collisions.cend();
+	return std::ranges::find(collisions, objectID) != collisions.cend();
 }
 
 void ProximityMonitorComponent::Update(float deltaTime) {

--- a/dGame/dComponents/ProximityMonitorComponent.h
+++ b/dGame/dComponents/ProximityMonitorComponent.h
@@ -42,7 +42,7 @@ public:
 	/**
 	 * Returns the last of entities that are used to check proximity, given a name
 	 * @param name the proximity name to retrieve physics objects for
-	 * @return a map of physics entities for this name, indexed by object ID
+	 * @return a vector of physics entity object IDs for this name
 	 */
 	const std::vector<LWOOBJID>& GetProximityObjects(const std::string& name);
 

--- a/dGame/dComponents/ProximityMonitorComponent.h
+++ b/dGame/dComponents/ProximityMonitorComponent.h
@@ -42,9 +42,9 @@ public:
 	/**
 	 * Returns the last of entities that are used to check proximity, given a name
 	 * @param name the proximity name to retrieve physics objects for
-	 * @return a vector of physics entity object IDs for this name
+	 * @return a set of physics entity object IDs for this name
 	 */
-	const std::vector<LWOOBJID>& GetProximityObjects(const std::string& name);
+	const std::set<LWOOBJID>& GetProximityObjects(const std::string& name);
 
 	/**
 	 * Checks if the passed object is in proximity of the named proximity sensor
@@ -70,7 +70,7 @@ private:
 	/**
 	 * Default value for the proximity data
 	 */
-	static const std::vector<LWOOBJID> m_EmptyObjectVec;
+	static const std::set<LWOOBJID> m_EmptyObjectSet;
 };
 
 #endif // PROXIMITYMONITORCOMPONENT_H

--- a/dGame/dComponents/ProximityMonitorComponent.h
+++ b/dGame/dComponents/ProximityMonitorComponent.h
@@ -6,6 +6,8 @@
 #ifndef PROXIMITYMONITORCOMPONENT_H
 #define PROXIMITYMONITORCOMPONENT_H
 
+#include <unordered_set>
+
 #include "BitStream.h"
 #include "Entity.h"
 #include "dpWorld.h"
@@ -44,7 +46,7 @@ public:
 	 * @param name the proximity name to retrieve physics objects for
 	 * @return a set of physics entity object IDs for this name
 	 */
-	const std::set<LWOOBJID>& GetProximityObjects(const std::string& name);
+	const std::unordered_set<LWOOBJID>& GetProximityObjects(const std::string& name);
 
 	/**
 	 * Checks if the passed object is in proximity of the named proximity sensor
@@ -70,7 +72,7 @@ private:
 	/**
 	 * Default value for the proximity data
 	 */
-	static const std::set<LWOOBJID> m_EmptyObjectSet;
+	static const std::unordered_set<LWOOBJID> m_EmptyObjectSet;
 };
 
 #endif // PROXIMITYMONITORCOMPONENT_H

--- a/dGame/dComponents/ProximityMonitorComponent.h
+++ b/dGame/dComponents/ProximityMonitorComponent.h
@@ -44,7 +44,7 @@ public:
 	 * @param name the proximity name to retrieve physics objects for
 	 * @return a map of physics entities for this name, indexed by object ID
 	 */
-	const std::map<LWOOBJID, dpEntity*>& GetProximityObjects(const std::string& name);
+	const std::vector<LWOOBJID>& GetProximityObjects(const std::string& name);
 
 	/**
 	 * Checks if the passed object is in proximity of the named proximity sensor
@@ -70,7 +70,7 @@ private:
 	/**
 	 * Default value for the proximity data
 	 */
-	static const std::map<LWOOBJID, dpEntity*> m_EmptyObjectMap;
+	static const std::vector<LWOOBJID> m_EmptyObjectVec;
 };
 
 #endif // PROXIMITYMONITORCOMPONENT_H

--- a/dPhysics/dpEntity.cpp
+++ b/dPhysics/dpEntity.cpp
@@ -78,19 +78,14 @@ void dpEntity::CheckCollision(dpEntity* other) {
 	}
 
 	const auto objId = other->GetObjectID();
-	const auto objItr = std::ranges::find(m_CurrentlyCollidingObjects, objId);
-	const bool wasFound = objItr != m_CurrentlyCollidingObjects.cend();
+	const bool wasFound = std::ranges::find(m_CurrentlyCollidingObjects, objId) != m_CurrentlyCollidingObjects.cend();
 	const bool isColliding = m_CollisionShape->IsColliding(other->GetShape());
 
 	if (isColliding && !wasFound) {
-		m_CurrentlyCollidingObjects.emplace_back(objId);
+		m_CurrentlyCollidingObjects.emplace(objId);
 		m_NewObjects.push_back(objId);
 	} else if (!isColliding && wasFound) {
-		// Erase object ID from currently colliding objects by swapping and popping vector
-		auto& lastObj = m_CurrentlyCollidingObjects.back();
-		*objItr = std::move(lastObj);
-		m_CurrentlyCollidingObjects.pop_back();
-
+		m_CurrentlyCollidingObjects.erase(objId);
 		m_RemovedObjects.push_back(objId);
 	}
 }

--- a/dPhysics/dpEntity.cpp
+++ b/dPhysics/dpEntity.cpp
@@ -75,14 +75,15 @@ void dpEntity::CheckCollision(dpEntity* other) {
 	}
 
 	const auto objId = other->GetObjectID();
-	const bool wasFound = m_CurrentlyCollidingObjects.contains(objId);
+	const auto objItr = m_CurrentlyCollidingObjects.find(objId);
+	const bool wasFound = objItr != m_CurrentlyCollidingObjects.cend();
 	const bool isColliding = m_CollisionShape->IsColliding(other->GetShape());
 
 	if (isColliding && !wasFound) {
 		m_CurrentlyCollidingObjects.emplace(objId);
 		m_NewObjects.push_back(objId);
 	} else if (!isColliding && wasFound) {
-		m_CurrentlyCollidingObjects.erase(objId);
+		m_CurrentlyCollidingObjects.erase(objItr);
 		m_RemovedObjects.push_back(objId);
 	}
 }

--- a/dPhysics/dpEntity.cpp
+++ b/dPhysics/dpEntity.cpp
@@ -90,7 +90,7 @@ void dpEntity::CheckCollision(dpEntity* other) {
 		m_NewObjects.push_back(other->GetObjectID());
 	} else if (!isColliding && wasFound) {
 		// Erase object ID from currently colliding objects by swapping and popping vector
-		const auto objIdx = objItr - m_CurrentlyCollidingObjects.cbegin();
+		const auto objIdx = std::distance(m_CurrentlyCollidingObjects.cbegin(), objItr);
 		auto& lastObj = m_CurrentlyCollidingObjects.back();
 		m_CurrentlyCollidingObjects[objIdx] = std::move(lastObj);
 		m_CurrentlyCollidingObjects.pop_back();

--- a/dPhysics/dpEntity.cpp
+++ b/dPhysics/dpEntity.cpp
@@ -3,9 +3,6 @@
 #include "dpShapeBox.h"
 #include "dpGrid.h"
 
-#include <algorithm>
-#include <iostream>
-
 dpEntity::dpEntity(const LWOOBJID& objectID, dpShapeType shapeType, bool isStatic) {
 	m_ObjectID = objectID;
 	m_IsStatic = isStatic;
@@ -78,7 +75,7 @@ void dpEntity::CheckCollision(dpEntity* other) {
 	}
 
 	const auto objId = other->GetObjectID();
-	const bool wasFound = std::ranges::find(m_CurrentlyCollidingObjects, objId) != m_CurrentlyCollidingObjects.cend();
+	const bool wasFound = m_CurrentlyCollidingObjects.contains(objId);
 	const bool isColliding = m_CollisionShape->IsColliding(other->GetShape());
 
 	if (isColliding && !wasFound) {

--- a/dPhysics/dpEntity.cpp
+++ b/dPhysics/dpEntity.cpp
@@ -77,25 +77,21 @@ void dpEntity::CheckCollision(dpEntity* other) {
 		return;
 	}
 
-	const auto objItr = std::find(
-		m_CurrentlyCollidingObjects.cbegin(),
-		m_CurrentlyCollidingObjects.cend(),
-		other->GetObjectID()
-	);
+	const auto objId = other->GetObjectID();
+	const auto objItr = std::ranges::find(m_CurrentlyCollidingObjects, objId);
 	const bool wasFound = objItr != m_CurrentlyCollidingObjects.cend();
 	const bool isColliding = m_CollisionShape->IsColliding(other->GetShape());
 
 	if (isColliding && !wasFound) {
-		m_CurrentlyCollidingObjects.emplace_back(other->GetObjectID());
-		m_NewObjects.push_back(other->GetObjectID());
+		m_CurrentlyCollidingObjects.emplace_back(objId);
+		m_NewObjects.push_back(objId);
 	} else if (!isColliding && wasFound) {
 		// Erase object ID from currently colliding objects by swapping and popping vector
-		const auto objIdx = std::distance(m_CurrentlyCollidingObjects.cbegin(), objItr);
 		auto& lastObj = m_CurrentlyCollidingObjects.back();
-		m_CurrentlyCollidingObjects[objIdx] = std::move(lastObj);
+		*objItr = std::move(lastObj);
 		m_CurrentlyCollidingObjects.pop_back();
 
-		m_RemovedObjects.push_back(other->GetObjectID());
+		m_RemovedObjects.push_back(objId);
 	}
 }
 

--- a/dPhysics/dpEntity.h
+++ b/dPhysics/dpEntity.h
@@ -3,6 +3,7 @@
 #include "NiQuaternion.h"
 #include <vector>
 #include <map>
+#include <span>
 
 #include "dCommonVars.h"
 #include "dpCommon.h"
@@ -49,9 +50,9 @@ public:
 	bool GetSleeping() const { return m_Sleeping; }
 	void SetSleeping(bool value) { m_Sleeping = value; }
 
-	const std::vector<LWOOBJID>& GetNewObjects() const { return m_NewObjects; }
-	const std::vector<LWOOBJID>& GetRemovedObjects() const { return m_RemovedObjects; }
-	const std::vector<LWOOBJID>& GetCurrentlyCollidingObjects() const { return m_CurrentlyCollidingObjects; }
+	const std::span<const LWOOBJID> GetNewObjects() const { return m_NewObjects; }
+	const std::span<const LWOOBJID> GetRemovedObjects() const { return m_RemovedObjects; }
+	const std::set<LWOOBJID>& GetCurrentlyCollidingObjects() const { return m_CurrentlyCollidingObjects; }
 
 	void PreUpdate() { m_NewObjects.clear();  m_RemovedObjects.clear(); }
 
@@ -82,5 +83,5 @@ private:
 
 	std::vector<LWOOBJID> m_NewObjects;
 	std::vector<LWOOBJID> m_RemovedObjects;
-	std::vector<LWOOBJID> m_CurrentlyCollidingObjects;
+	std::set<LWOOBJID> m_CurrentlyCollidingObjects;
 };

--- a/dPhysics/dpEntity.h
+++ b/dPhysics/dpEntity.h
@@ -2,7 +2,7 @@
 #include "NiPoint3.h"
 #include "NiQuaternion.h"
 #include <vector>
-#include <map>
+#include <unordered_set>
 #include <span>
 
 #include "dCommonVars.h"
@@ -52,7 +52,7 @@ public:
 
 	const std::span<const LWOOBJID> GetNewObjects() const { return m_NewObjects; }
 	const std::span<const LWOOBJID> GetRemovedObjects() const { return m_RemovedObjects; }
-	const std::set<LWOOBJID>& GetCurrentlyCollidingObjects() const { return m_CurrentlyCollidingObjects; }
+	const std::unordered_set<LWOOBJID>& GetCurrentlyCollidingObjects() const { return m_CurrentlyCollidingObjects; }
 
 	void PreUpdate() { m_NewObjects.clear();  m_RemovedObjects.clear(); }
 
@@ -83,5 +83,5 @@ private:
 
 	std::vector<LWOOBJID> m_NewObjects;
 	std::vector<LWOOBJID> m_RemovedObjects;
-	std::set<LWOOBJID> m_CurrentlyCollidingObjects;
+	std::unordered_set<LWOOBJID> m_CurrentlyCollidingObjects;
 };

--- a/dPhysics/dpEntity.h
+++ b/dPhysics/dpEntity.h
@@ -49,9 +49,9 @@ public:
 	bool GetSleeping() const { return m_Sleeping; }
 	void SetSleeping(bool value) { m_Sleeping = value; }
 
-	const std::vector<dpEntity*>& GetNewObjects() const { return m_NewObjects; }
-	const std::vector<dpEntity*>& GetRemovedObjects() const { return m_RemovedObjects; }
-	const std::map<LWOOBJID, dpEntity*>& GetCurrentlyCollidingObjects() const { return m_CurrentlyCollidingObjects; }
+	const std::vector<LWOOBJID>& GetNewObjects() const { return m_NewObjects; }
+	const std::vector<LWOOBJID>& GetRemovedObjects() const { return m_RemovedObjects; }
+	const std::vector<LWOOBJID>& GetCurrentlyCollidingObjects() const { return m_CurrentlyCollidingObjects; }
 
 	void PreUpdate() { m_NewObjects.clear();  m_RemovedObjects.clear(); }
 
@@ -80,7 +80,7 @@ private:
 
 	bool m_IsGargantuan = false;
 
-	std::vector<dpEntity*> m_NewObjects;
-	std::vector<dpEntity*> m_RemovedObjects;
-	std::map<LWOOBJID, dpEntity*> m_CurrentlyCollidingObjects;
+	std::vector<LWOOBJID> m_NewObjects;
+	std::vector<LWOOBJID> m_RemovedObjects;
+	std::vector<LWOOBJID> m_CurrentlyCollidingObjects;
 };

--- a/dScripts/02_server/Map/AM/WanderingVendor.cpp
+++ b/dScripts/02_server/Map/AM/WanderingVendor.cpp
@@ -21,7 +21,7 @@ void WanderingVendor::OnProximityUpdate(Entity* self, Entity* entering, std::str
 
 		const auto proxObjs = proximityMonitorComponent->GetProximityObjects("playermonitor");
 		bool foundPlayer = false;
-		for (const auto id : proxObjs | std::views::keys) {
+		for (const auto id : proxObjs) {
 			auto* entity = Game::entityManager->GetEntity(id);
 			if (entity && entity->IsPlayer()) {
 				foundPlayer = true;

--- a/dScripts/ai/AG/AgBusDoor.cpp
+++ b/dScripts/ai/AG/AgBusDoor.cpp
@@ -23,13 +23,13 @@ void AgBusDoor::OnProximityUpdate(Entity* self, Entity* entering, std::string na
 	m_Counter = 0;
 	m_OuterCounter = 0;
 
-	for (const auto& pair : proximityMonitorComponent->GetProximityObjects("busDoor")) {
-		auto* entity = Game::entityManager->GetEntity(pair.first);
+	for (const auto id : proximityMonitorComponent->GetProximityObjects("busDoor")) {
+		const auto entity = Game::entityManager->GetEntity(id);
 		if (entity != nullptr && entity->IsPlayer()) m_Counter++;
 	}
 
-	for (const auto& pair : proximityMonitorComponent->GetProximityObjects("busDoorOuter")) {
-		auto* entity = Game::entityManager->GetEntity(pair.first);
+	for (const auto id : proximityMonitorComponent->GetProximityObjects("busDoorOuter")) {
+		const auto entity = Game::entityManager->GetEntity(id);
 		if (entity != nullptr && entity->IsPlayer()) m_OuterCounter++;
 	}
 

--- a/dScripts/ai/AG/AgBusDoor.cpp
+++ b/dScripts/ai/AG/AgBusDoor.cpp
@@ -24,12 +24,12 @@ void AgBusDoor::OnProximityUpdate(Entity* self, Entity* entering, std::string na
 	m_OuterCounter = 0;
 
 	for (const auto id : proximityMonitorComponent->GetProximityObjects("busDoor")) {
-		const auto entity = Game::entityManager->GetEntity(id);
+		const auto* const entity = Game::entityManager->GetEntity(id);
 		if (entity != nullptr && entity->IsPlayer()) m_Counter++;
 	}
 
 	for (const auto id : proximityMonitorComponent->GetProximityObjects("busDoorOuter")) {
-		const auto entity = Game::entityManager->GetEntity(id);
+		const auto* const entity = Game::entityManager->GetEntity(id);
 		if (entity != nullptr && entity->IsPlayer()) m_OuterCounter++;
 	}
 


### PR DESCRIPTION
Fixes #1522. Tested by going into AG and checking that the bus raises and lowers in the Sentinel base