### PR TITLE
chore: disable non-standard volatile behavior on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,8 @@ if(UNIX)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99 -O2 -fPIC")
 elseif(MSVC)
 	# Skip warning for invalid conversion from size_t to uint32_t for all targets below for now
-	add_compile_options("/wd4267" "/utf-8")
+	# Also disable non-portable MSVC volatile behavior
+	add_compile_options("/wd4267" "/utf-8" "/volatile:iso")
 elseif(WIN32)
 	add_compile_definitions(_CRT_SECURE_NO_WARNINGS)
 endif()


### PR DESCRIPTION
Discovered this at work the other day. By default, MSVC treats all volatile variables as if they were atomics on x86 and x64 architectures, and requires this use of an obscure compiler flag to disable this.

https://learn.microsoft.com/en-us/cpp/build/reference/volatile-volatile-keyword-interpretation?view=msvc-170

This is, needless to say, very much not portable and it makes me worried it could potentially cause odd behavior between the platforms. While there's no evidence it has at the moment, I'd rather nip this in the bud. This PR adds said obscure compiler flag to CMake and thus brings MSVC inline with gcc and clang's treatment of volatile in accordance to the C++ standard.