### PR TITLE
fix: player jittering when picking up loot

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -1635,10 +1635,8 @@ void Entity::PickupItem(const LWOOBJID& objectID) {
 				CDObjectSkillsTable* skillsTable = CDClientManager::GetTable<CDObjectSkillsTable>();
 				std::vector<CDObjectSkills> skills = skillsTable->Query([=](CDObjectSkills entry) {return (entry.objectTemplate == p.second.lot); });
 				for (CDObjectSkills skill : skills) {
-					CDSkillBehaviorTable* skillBehTable = CDClientManager::GetTable<CDSkillBehaviorTable>();
-
 					auto* skillComponent = GetComponent<SkillComponent>();
-					if (skillComponent) skillComponent->CastSkill(skill.skillID, GetObjectID(), GetObjectID());
+					if (skillComponent) skillComponent->CastSkill(skill.skillID, GetObjectID(), GetObjectID(), skill.castOnType, NiQuaternion(0, 0, 0, 0));
 
 					auto* missionComponent = GetComponent<MissionComponent>();
 

--- a/dGame/dComponents/SkillComponent.cpp
+++ b/dGame/dComponents/SkillComponent.cpp
@@ -227,7 +227,7 @@ void SkillComponent::RegisterCalculatedProjectile(const LWOOBJID projectileId, B
 	this->m_managedProjectiles.push_back(entry);
 }
 
-bool SkillComponent::CastSkill(const uint32_t skillId, LWOOBJID target, const LWOOBJID optionalOriginatorID) {
+bool SkillComponent::CastSkill(const uint32_t skillId, LWOOBJID target, const LWOOBJID optionalOriginatorID, const int32_t castType, const NiQuaternion rotationOverride) {
 	uint32_t behaviorId = -1;
 	// try to find it via the cache
 	const auto& pair = m_skillBehaviorCache.find(skillId);
@@ -247,11 +247,19 @@ bool SkillComponent::CastSkill(const uint32_t skillId, LWOOBJID target, const LW
 		return false;
 	}
 
-	return CalculateBehavior(skillId, behaviorId, target, false, false, optionalOriginatorID).success;
+	return CalculateBehavior(skillId, behaviorId, target, false, false, optionalOriginatorID, castType, rotationOverride).success;
 }
 
 
-SkillExecutionResult SkillComponent::CalculateBehavior(const uint32_t skillId, const uint32_t behaviorId, const LWOOBJID target, const bool ignoreTarget, const bool clientInitalized, const LWOOBJID originatorOverride) {
+SkillExecutionResult SkillComponent::CalculateBehavior(
+	const uint32_t skillId,
+	const uint32_t behaviorId,
+	const LWOOBJID target,
+	const bool ignoreTarget,
+	const bool clientInitalized,
+	const LWOOBJID originatorOverride,
+	const int32_t castType,
+	const NiQuaternion rotationOverride) {
 	RakNet::BitStream bitStream{};
 
 	auto* behavior = Behavior::CreateBehavior(behaviorId);
@@ -283,7 +291,7 @@ SkillExecutionResult SkillComponent::CalculateBehavior(const uint32_t skillId, c
 		// Echo start skill
 		EchoStartSkill start;
 
-		start.iCastType = 0;
+		start.iCastType = castType;
 		start.skillID = skillId;
 		start.uiSkillHandle = context->skillUId;
 		start.optionalOriginatorID = context->originator;
@@ -293,6 +301,10 @@ SkillExecutionResult SkillComponent::CalculateBehavior(const uint32_t skillId, c
 
 		if (originator != nullptr) {
 			start.originatorRot = originator->GetRotation();
+		}
+
+		if (rotationOverride != NiQuaternionConstant::IDENTITY) {
+			start.originatorRot = rotationOverride;
 		}
 		//start.optionalTargetID = target;
 
@@ -464,7 +476,7 @@ void SkillComponent::HandleUnCast(const uint32_t behaviorId, const LWOOBJID targ
 	behavior->UnCast(&context, { target });
 }
 
-SkillComponent::SkillComponent(Entity* parent): Component(parent) {
+SkillComponent::SkillComponent(Entity* parent) : Component(parent) {
 	this->m_skillUid = 0;
 }
 

--- a/dGame/dComponents/SkillComponent.h
+++ b/dGame/dComponents/SkillComponent.h
@@ -127,7 +127,7 @@ public:
 	 * @param optionalOriginatorID change the originator of the skill
 	 * @return if the case succeeded
 	 */
-	bool CastSkill(const uint32_t skillId, LWOOBJID target = LWOOBJID_EMPTY, const LWOOBJID optionalOriginatorID = LWOOBJID_EMPTY);
+	bool CastSkill(const uint32_t skillId, LWOOBJID target = LWOOBJID_EMPTY, const LWOOBJID optionalOriginatorID = LWOOBJID_EMPTY, const int32_t castType = 0, const NiQuaternion rotationOverride = NiQuaternionConstant::IDENTITY);
 
 	/**
 	 * Initializes a server-side skill calculation.
@@ -139,7 +139,7 @@ public:
 	 * @param originatorOverride an override for the originator of the skill calculation
 	 * @return the result of the skill calculation
 	 */
-	SkillExecutionResult CalculateBehavior(uint32_t skillId, uint32_t behaviorId, LWOOBJID target, bool ignoreTarget = false, bool clientInitalized = false, LWOOBJID originatorOverride = LWOOBJID_EMPTY);
+	SkillExecutionResult CalculateBehavior(uint32_t skillId, uint32_t behaviorId, LWOOBJID target, bool ignoreTarget = false, bool clientInitalized = false, LWOOBJID originatorOverride = LWOOBJID_EMPTY, const int32_t castType = 0, const NiQuaternion rotationOverride = NiQuaternionConstant::IDENTITY);
 
 	/**
 	 * Register a server-side projectile.


### PR DESCRIPTION
tested that players no longer jitter when picking up items by killing 20 admirals and picking up all their loot at once.  