### PR TITLE
chore: remove usage of xmldoc as a ptr

### DIFF
--- a/dGame/Character.h
+++ b/dGame/Character.h
@@ -37,7 +37,7 @@ public:
 	void LoadXmlRespawnCheckpoints();
 
 	const std::string& GetXMLData() const { return m_XMLData; }
-	tinyxml2::XMLDocument* GetXMLDoc() const { return m_Doc; }
+	const tinyxml2::XMLDocument& GetXMLDoc() const { return m_Doc; }
 
 	/**
 	 * Out of abundance of safety and clarity of what this saves, this is its own function.
@@ -623,7 +623,7 @@ private:
 	/**
 	 * The character XML belonging to this character
 	 */
-	tinyxml2::XMLDocument* m_Doc;
+	tinyxml2::XMLDocument m_Doc;
 
 	/**
 	 * Title of an announcement this character made (reserved for GMs)

--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -476,8 +476,7 @@ void Entity::Initialize() {
 	}
 
 	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::INVENTORY) > 0 || m_Character) {
-		auto* xmlDoc = m_Character ? m_Character->GetXMLDoc() : nullptr;
-		AddComponent<InventoryComponent>(xmlDoc);
+		AddComponent<InventoryComponent>();
 	}
 	// if this component exists, then we initialize it. it's value is always 0
 	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MULTI_ZONE_ENTRANCE, -1) != -1) {
@@ -1244,7 +1243,7 @@ void Entity::WriteComponents(RakNet::BitStream& outBitStream, eReplicaPacketType
 	outBitStream.Write0();
 }
 
-void Entity::UpdateXMLDoc(tinyxml2::XMLDocument* doc) {
+void Entity::UpdateXMLDoc(tinyxml2::XMLDocument& doc) {
 	//This function should only ever be called from within Character, meaning doc should always exist when this is called.
 	//Naturally, we don't include any non-player components in this update function.
 

--- a/dGame/Entity.h
+++ b/dGame/Entity.h
@@ -174,7 +174,7 @@ public:
 
 	void WriteBaseReplicaData(RakNet::BitStream& outBitStream, eReplicaPacketType packetType);
 	void WriteComponents(RakNet::BitStream& outBitStream, eReplicaPacketType packetType);
-	void UpdateXMLDoc(tinyxml2::XMLDocument* doc);
+	void UpdateXMLDoc(tinyxml2::XMLDocument& doc);
 	void Update(float deltaTime);
 
 	// Events

--- a/dGame/dComponents/BuffComponent.cpp
+++ b/dGame/dComponents/BuffComponent.cpp
@@ -326,9 +326,9 @@ Entity* BuffComponent::GetParent() const {
 	return m_Parent;
 }
 
-void BuffComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
+void BuffComponent::LoadFromXml(const tinyxml2::XMLDocument& doc) {
 	// Load buffs
-	auto* dest = doc->FirstChildElement("obj")->FirstChildElement("dest");
+	auto* dest = doc.FirstChildElement("obj")->FirstChildElement("dest");
 
 	// Make sure we have a clean buff element.
 	auto* buffElement = dest->FirstChildElement("buff");
@@ -386,15 +386,15 @@ void BuffComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
 	}
 }
 
-void BuffComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
+void BuffComponent::UpdateXml(tinyxml2::XMLDocument& doc) {
 	// Save buffs
-	auto* dest = doc->FirstChildElement("obj")->FirstChildElement("dest");
+	auto* dest = doc.FirstChildElement("obj")->FirstChildElement("dest");
 
 	// Make sure we have a clean buff element.
 	auto* buffElement = dest->FirstChildElement("buff");
 
 	if (buffElement == nullptr) {
-		buffElement = doc->NewElement("buff");
+		buffElement = doc.NewElement("buff");
 
 		dest->LinkEndChild(buffElement);
 	} else {
@@ -402,7 +402,7 @@ void BuffComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
 	}
 
 	for (const auto& [id, buff] : m_Buffs) {
-		auto* buffEntry = doc->NewElement("b");
+		auto* buffEntry = doc.NewElement("b");
 		// TODO: change this if to if (buff.cancelOnZone || buff.cancelOnLogout) handling at some point.  No current way to differentiate between zone transfer and logout.
 		if (buff.cancelOnZone) continue;
 

--- a/dGame/dComponents/BuffComponent.h
+++ b/dGame/dComponents/BuffComponent.h
@@ -57,9 +57,9 @@ public:
 
 	Entity* GetParent() const;
 
-	void LoadFromXml(tinyxml2::XMLDocument* doc) override;
+	void LoadFromXml(const tinyxml2::XMLDocument& doc) override;
 
-	void UpdateXml(tinyxml2::XMLDocument* doc) override;
+	void UpdateXml(tinyxml2::XMLDocument& doc) override;
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
 

--- a/dGame/dComponents/CharacterComponent.cpp
+++ b/dGame/dComponents/CharacterComponent.cpp
@@ -186,9 +186,9 @@ void CharacterComponent::SetGMLevel(eGameMasterLevel gmlevel) {
 	m_GMLevel = gmlevel;
 }
 
-void CharacterComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
+void CharacterComponent::LoadFromXml(const tinyxml2::XMLDocument& doc) {
 
-	tinyxml2::XMLElement* character = doc->FirstChildElement("obj")->FirstChildElement("char");
+	auto* character = doc.FirstChildElement("obj")->FirstChildElement("char");
 	if (!character) {
 		LOG("Failed to find char tag while loading XML!");
 		return;
@@ -299,8 +299,8 @@ void CharacterComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
 	}
 }
 
-void CharacterComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
-	tinyxml2::XMLElement* minifig = doc->FirstChildElement("obj")->FirstChildElement("mf");
+void CharacterComponent::UpdateXml(tinyxml2::XMLDocument& doc) {
+	tinyxml2::XMLElement* minifig = doc.FirstChildElement("obj")->FirstChildElement("mf");
 	if (!minifig) {
 		LOG("Failed to find mf tag while updating XML!");
 		return;
@@ -320,7 +320,7 @@ void CharacterComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
 
 	// done with minifig
 
-	tinyxml2::XMLElement* character = doc->FirstChildElement("obj")->FirstChildElement("char");
+	tinyxml2::XMLElement* character = doc.FirstChildElement("obj")->FirstChildElement("char");
 	if (!character) {
 		LOG("Failed to find char tag while updating XML!");
 		return;
@@ -338,11 +338,11 @@ void CharacterComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
 
 	// Set the zone statistics of the form <zs><s/> ... <s/></zs>
 	auto zoneStatistics = character->FirstChildElement("zs");
-	if (!zoneStatistics) zoneStatistics = doc->NewElement("zs");
+	if (!zoneStatistics) zoneStatistics = doc.NewElement("zs");
 	zoneStatistics->DeleteChildren();
 
 	for (auto pair : m_ZoneStatistics) {
-		auto zoneStatistic = doc->NewElement("s");
+		auto zoneStatistic = doc.NewElement("s");
 
 		zoneStatistic->SetAttribute("map", pair.first);
 		zoneStatistic->SetAttribute("ac", pair.second.m_AchievementsCollected);

--- a/dGame/dComponents/CharacterComponent.h
+++ b/dGame/dComponents/CharacterComponent.h
@@ -70,8 +70,8 @@ public:
 	CharacterComponent(Entity* parent, Character* character, const SystemAddress& systemAddress);
 	~CharacterComponent() override;
 
-	void LoadFromXml(tinyxml2::XMLDocument* doc) override;
-	void UpdateXml(tinyxml2::XMLDocument* doc) override;
+	void LoadFromXml(const tinyxml2::XMLDocument& doc) override;
+	void UpdateXml(tinyxml2::XMLDocument& doc) override;
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
 

--- a/dGame/dComponents/Component.cpp
+++ b/dGame/dComponents/Component.cpp
@@ -21,11 +21,11 @@ void Component::OnUse(Entity* originator) {
 
 }
 
-void Component::UpdateXml(tinyxml2::XMLDocument* doc) {
+void Component::UpdateXml(tinyxml2::XMLDocument& doc) {
 
 }
 
-void Component::LoadFromXml(tinyxml2::XMLDocument* doc) {
+void Component::LoadFromXml(const tinyxml2::XMLDocument& doc) {
 
 }
 

--- a/dGame/dComponents/Component.h
+++ b/dGame/dComponents/Component.h
@@ -34,13 +34,13 @@ public:
 	 * Save data from this componennt to character XML
 	 * @param doc the document to write data to
 	 */
-	virtual void UpdateXml(tinyxml2::XMLDocument* doc);
+	virtual void UpdateXml(tinyxml2::XMLDocument& doc);
 
 	/**
 	 * Load base data for this component from character XML
 	 * @param doc the document to read data from
 	 */
-	virtual void LoadFromXml(tinyxml2::XMLDocument* doc);
+	virtual void LoadFromXml(const tinyxml2::XMLDocument& doc);
 
 	virtual void Serialize(RakNet::BitStream& outBitStream, bool isConstruction);
 

--- a/dGame/dComponents/ControllablePhysicsComponent.cpp
+++ b/dGame/dComponents/ControllablePhysicsComponent.cpp
@@ -158,8 +158,8 @@ void ControllablePhysicsComponent::Serialize(RakNet::BitStream& outBitStream, bo
 	}
 }
 
-void ControllablePhysicsComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
-	tinyxml2::XMLElement* character = doc->FirstChildElement("obj")->FirstChildElement("char");
+void ControllablePhysicsComponent::LoadFromXml(const tinyxml2::XMLDocument& doc) {
+	auto* character = doc.FirstChildElement("obj")->FirstChildElement("char");
 	if (!character) {
 		LOG("Failed to find char tag!");
 		return;
@@ -178,8 +178,8 @@ void ControllablePhysicsComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
 	m_DirtyPosition = true;
 }
 
-void ControllablePhysicsComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
-	tinyxml2::XMLElement* character = doc->FirstChildElement("obj")->FirstChildElement("char");
+void ControllablePhysicsComponent::UpdateXml(tinyxml2::XMLDocument& doc) {
+	tinyxml2::XMLElement* character = doc.FirstChildElement("obj")->FirstChildElement("char");
 	if (!character) {
 		LOG("Failed to find char tag while updating XML!");
 		return;

--- a/dGame/dComponents/ControllablePhysicsComponent.h
+++ b/dGame/dComponents/ControllablePhysicsComponent.h
@@ -28,8 +28,8 @@ public:
 
 	void Update(float deltaTime) override;
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
-	void LoadFromXml(tinyxml2::XMLDocument* doc) override;
-	void UpdateXml(tinyxml2::XMLDocument* doc) override;
+	void LoadFromXml(const tinyxml2::XMLDocument& doc) override;
+	void UpdateXml(tinyxml2::XMLDocument& doc) override;
 
 	/**
 	 * Sets the position of this entity, also ensures this update is serialized next tick.

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -185,8 +185,8 @@ void DestroyableComponent::Update(float deltaTime) {
 	m_DamageCooldownTimer -= deltaTime;
 }
 
-void DestroyableComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
-	tinyxml2::XMLElement* dest = doc->FirstChildElement("obj")->FirstChildElement("dest");
+void DestroyableComponent::LoadFromXml(const tinyxml2::XMLDocument& doc) {
+	auto* dest = doc.FirstChildElement("obj")->FirstChildElement("dest");
 	if (!dest) {
 		LOG("Failed to find dest tag!");
 		return;
@@ -207,8 +207,8 @@ void DestroyableComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
 	m_DirtyHealth = true;
 }
 
-void DestroyableComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
-	tinyxml2::XMLElement* dest = doc->FirstChildElement("obj")->FirstChildElement("dest");
+void DestroyableComponent::UpdateXml(tinyxml2::XMLDocument& doc) {
+	tinyxml2::XMLElement* dest = doc.FirstChildElement("obj")->FirstChildElement("dest");
 	if (!dest) {
 		LOG("Failed to find dest tag!");
 		return;

--- a/dGame/dComponents/DestroyableComponent.h
+++ b/dGame/dComponents/DestroyableComponent.h
@@ -26,8 +26,8 @@ public:
 
 	void Update(float deltaTime) override;
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
-	void LoadFromXml(tinyxml2::XMLDocument* doc) override;
-	void UpdateXml(tinyxml2::XMLDocument* doc) override;
+	void LoadFromXml(const tinyxml2::XMLDocument& doc) override;
+	void UpdateXml(tinyxml2::XMLDocument& doc) override;
 
 	/**
 	 * Initializes the component using a different LOT

--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -38,7 +38,7 @@
 #include "CDObjectSkillsTable.h"
 #include "CDSkillBehaviorTable.h"
 
-InventoryComponent::InventoryComponent(Entity* parent, tinyxml2::XMLDocument* document) : Component(parent) {
+InventoryComponent::InventoryComponent(Entity* parent) : Component(parent) {
 	this->m_Dirty = true;
 	this->m_Equipped = {};
 	this->m_Pushed = {};
@@ -48,7 +48,8 @@ InventoryComponent::InventoryComponent(Entity* parent, tinyxml2::XMLDocument* do
 	const auto lot = parent->GetLOT();
 
 	if (lot == 1) {
-		LoadXml(document);
+		auto* character = m_Parent->GetCharacter();
+		if (character) LoadXml(character->GetXMLDoc());
 
 		CheckProxyIntegrity();
 
@@ -472,10 +473,10 @@ bool InventoryComponent::HasSpaceForLoot(const std::unordered_map<LOT, int32_t>&
 	return true;
 }
 
-void InventoryComponent::LoadXml(tinyxml2::XMLDocument* document) {
+void InventoryComponent::LoadXml(const tinyxml2::XMLDocument& document) {
 	LoadPetXml(document);
 
-	auto* inventoryElement = document->FirstChildElement("obj")->FirstChildElement("inv");
+	auto* inventoryElement = document.FirstChildElement("obj")->FirstChildElement("inv");
 
 	if (inventoryElement == nullptr) {
 		LOG("Failed to find 'inv' xml element!");
@@ -594,10 +595,10 @@ void InventoryComponent::LoadXml(tinyxml2::XMLDocument* document) {
 	}
 }
 
-void InventoryComponent::UpdateXml(tinyxml2::XMLDocument* document) {
+void InventoryComponent::UpdateXml(tinyxml2::XMLDocument& document) {
 	UpdatePetXml(document);
 
-	auto* inventoryElement = document->FirstChildElement("obj")->FirstChildElement("inv");
+	auto* inventoryElement = document.FirstChildElement("obj")->FirstChildElement("inv");
 
 	if (inventoryElement == nullptr) {
 		LOG("Failed to find 'inv' xml element!");
@@ -631,7 +632,7 @@ void InventoryComponent::UpdateXml(tinyxml2::XMLDocument* document) {
 	bags->DeleteChildren();
 
 	for (const auto* inventory : inventoriesToSave) {
-		auto* bag = document->NewElement("b");
+		auto* bag = document.NewElement("b");
 
 		bag->SetAttribute("t", inventory->GetType());
 		bag->SetAttribute("m", static_cast<unsigned int>(inventory->GetSize()));
@@ -654,14 +655,14 @@ void InventoryComponent::UpdateXml(tinyxml2::XMLDocument* document) {
 			continue;
 		}
 
-		auto* bagElement = document->NewElement("in");
+		auto* bagElement = document.NewElement("in");
 
 		bagElement->SetAttribute("t", inventory->GetType());
 
 		for (const auto& pair : inventory->GetItems()) {
 			auto* item = pair.second;
 
-			auto* itemElement = document->NewElement("i");
+			auto* itemElement = document.NewElement("i");
 
 			itemElement->SetAttribute("l", item->GetLot());
 			itemElement->SetAttribute("id", item->GetId());
@@ -680,7 +681,7 @@ void InventoryComponent::UpdateXml(tinyxml2::XMLDocument* document) {
 					continue;
 				}
 
-				auto* extraInfo = document->NewElement("x");
+				auto* extraInfo = document.NewElement("x");
 
 				extraInfo->SetAttribute("ma", data->GetString(false).c_str());
 
@@ -1542,8 +1543,8 @@ void InventoryComponent::PurgeProxies(Item* item) {
 	}
 }
 
-void InventoryComponent::LoadPetXml(tinyxml2::XMLDocument* document) {
-	auto* petInventoryElement = document->FirstChildElement("obj")->FirstChildElement("pet");
+void InventoryComponent::LoadPetXml(const tinyxml2::XMLDocument& document) {
+	auto* petInventoryElement = document.FirstChildElement("obj")->FirstChildElement("pet");
 
 	if (petInventoryElement == nullptr) {
 		m_Pets.clear();
@@ -1574,19 +1575,19 @@ void InventoryComponent::LoadPetXml(tinyxml2::XMLDocument* document) {
 	}
 }
 
-void InventoryComponent::UpdatePetXml(tinyxml2::XMLDocument* document) {
-	auto* petInventoryElement = document->FirstChildElement("obj")->FirstChildElement("pet");
+void InventoryComponent::UpdatePetXml(tinyxml2::XMLDocument& document) {
+	auto* petInventoryElement = document.FirstChildElement("obj")->FirstChildElement("pet");
 
 	if (petInventoryElement == nullptr) {
-		petInventoryElement = document->NewElement("pet");
+		petInventoryElement = document.NewElement("pet");
 
-		document->FirstChildElement("obj")->LinkEndChild(petInventoryElement);
+		document.FirstChildElement("obj")->LinkEndChild(petInventoryElement);
 	}
 
 	petInventoryElement->DeleteChildren();
 
 	for (const auto& pet : m_Pets) {
-		auto* petElement = document->NewElement("p");
+		auto* petElement = document.NewElement("p");
 
 		petElement->SetAttribute("id", pet.first);
 		petElement->SetAttribute("l", pet.second.lot);

--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -38,12 +38,12 @@ enum class eItemType : int32_t;
 class InventoryComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::INVENTORY;
-	explicit InventoryComponent(Entity* parent, tinyxml2::XMLDocument* document = nullptr);
+	InventoryComponent(Entity* parent);
 
 	void Update(float deltaTime) override;
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
-	void LoadXml(tinyxml2::XMLDocument* document);
-	void UpdateXml(tinyxml2::XMLDocument* document) override;
+	void LoadXml(const tinyxml2::XMLDocument& document);
+	void UpdateXml(tinyxml2::XMLDocument& document) override;
 
 	/**
 	 * Returns an inventory of the specified type, if it exists
@@ -470,13 +470,13 @@ private:
 	 * Saves all the pet information stored in inventory items to the database
 	 * @param document the xml doc to save to
 	 */
-	void LoadPetXml(tinyxml2::XMLDocument* document);
+	void LoadPetXml(const tinyxml2::XMLDocument& document);
 
 	/**
 	 * Loads all the pet information from an xml doc into items
 	 * @param document the xml doc to load from
 	 */
-	void UpdatePetXml(tinyxml2::XMLDocument* document);
+	void UpdatePetXml(tinyxml2::XMLDocument& document);
 };
 
 #endif

--- a/dGame/dComponents/LevelProgressionComponent.cpp
+++ b/dGame/dComponents/LevelProgressionComponent.cpp
@@ -13,8 +13,8 @@ LevelProgressionComponent::LevelProgressionComponent(Entity* parent) : Component
 	m_CharacterVersion = eCharacterVersion::LIVE;
 }
 
-void LevelProgressionComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
-	tinyxml2::XMLElement* level = doc->FirstChildElement("obj")->FirstChildElement("lvl");
+void LevelProgressionComponent::UpdateXml(tinyxml2::XMLDocument& doc) {
+	tinyxml2::XMLElement* level = doc.FirstChildElement("obj")->FirstChildElement("lvl");
 	if (!level) {
 		LOG("Failed to find lvl tag while updating XML!");
 		return;
@@ -24,8 +24,8 @@ void LevelProgressionComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
 	level->SetAttribute("cv", static_cast<uint32_t>(m_CharacterVersion));
 }
 
-void LevelProgressionComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
-	tinyxml2::XMLElement* level = doc->FirstChildElement("obj")->FirstChildElement("lvl");
+void LevelProgressionComponent::LoadFromXml(const tinyxml2::XMLDocument& doc) {
+	auto* level = doc.FirstChildElement("obj")->FirstChildElement("lvl");
 	if (!level) {
 		LOG("Failed to find lvl tag while loading XML!");
 		return;

--- a/dGame/dComponents/LevelProgressionComponent.h
+++ b/dGame/dComponents/LevelProgressionComponent.h
@@ -27,13 +27,13 @@ public:
 	 * Save data from this componennt to character XML
 	 * @param doc the document to write data to
 	 */
-	void UpdateXml(tinyxml2::XMLDocument* doc) override;
+	void UpdateXml(tinyxml2::XMLDocument& doc) override;
 
 	/**
 	 * Load base data for this component from character XML
 	 * @param doc the document to read data from
 	 */
-	void LoadFromXml(tinyxml2::XMLDocument* doc) override;
+	void LoadFromXml(const tinyxml2::XMLDocument& doc) override;
 
 	/**
 	 * Gets the current level of the entity

--- a/dGame/dComponents/MissionComponent.cpp
+++ b/dGame/dComponents/MissionComponent.cpp
@@ -504,10 +504,8 @@ bool MissionComponent::RequiresItem(const LOT lot) {
 }
 
 
-void MissionComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
-	if (doc == nullptr) return;
-
-	auto* mis = doc->FirstChildElement("obj")->FirstChildElement("mis");
+void MissionComponent::LoadFromXml(const tinyxml2::XMLDocument& doc) {
+	auto* mis = doc.FirstChildElement("obj")->FirstChildElement("mis");
 
 	if (mis == nullptr) return;
 
@@ -523,7 +521,7 @@ void MissionComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
 
 		auto* mission = new Mission(this, missionId);
 
-		mission->LoadFromXml(doneM);
+		mission->LoadFromXml(*doneM);
 
 		doneM = doneM->NextSiblingElement();
 
@@ -540,7 +538,7 @@ void MissionComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
 
 		auto* mission = new Mission(this, missionId);
 
-		mission->LoadFromXml(currentM);
+		mission->LoadFromXml(*currentM);
 
 		if (currentM->QueryAttribute("o", &missionOrder) == tinyxml2::XML_SUCCESS && mission->IsMission()) {
 			mission->SetUniqueMissionOrderID(missionOrder);
@@ -554,25 +552,23 @@ void MissionComponent::LoadFromXml(tinyxml2::XMLDocument* doc) {
 }
 
 
-void MissionComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
-	if (doc == nullptr) return;
-
+void MissionComponent::UpdateXml(tinyxml2::XMLDocument& doc) {
 	auto shouldInsertMis = false;
 
-	auto* obj = doc->FirstChildElement("obj");
+	auto* obj = doc.FirstChildElement("obj");
 
 	auto* mis = obj->FirstChildElement("mis");
 
 	if (mis == nullptr) {
-		mis = doc->NewElement("mis");
+		mis = doc.NewElement("mis");
 
 		shouldInsertMis = true;
 	}
 
 	mis->DeleteChildren();
 
-	auto* done = doc->NewElement("done");
-	auto* cur = doc->NewElement("cur");
+	auto* done = doc.NewElement("done");
+	auto* cur = doc.NewElement("cur");
 
 	for (const auto& pair : m_Missions) {
 		auto* mission = pair.second;
@@ -580,10 +576,10 @@ void MissionComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
 		if (mission) {
 			const auto complete = mission->IsComplete();
 
-			auto* m = doc->NewElement("m");
+			auto* m = doc.NewElement("m");
 
 			if (complete) {
-				mission->UpdateXml(m);
+				mission->UpdateXml(*m);
 
 				done->LinkEndChild(m);
 
@@ -591,7 +587,7 @@ void MissionComponent::UpdateXml(tinyxml2::XMLDocument* doc) {
 			}
 			if (mission->IsMission()) m->SetAttribute("o", mission->GetUniqueMissionOrderID());
 
-			mission->UpdateXml(m);
+			mission->UpdateXml(*m);
 
 			cur->LinkEndChild(m);
 		}

--- a/dGame/dComponents/MissionComponent.h
+++ b/dGame/dComponents/MissionComponent.h
@@ -31,8 +31,8 @@ public:
 	explicit MissionComponent(Entity* parent);
 	~MissionComponent() override;
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate, unsigned int& flags);
-	void LoadFromXml(tinyxml2::XMLDocument* doc) override;
-	void UpdateXml(tinyxml2::XMLDocument* doc) override;
+	void LoadFromXml(const tinyxml2::XMLDocument& doc) override;
+	void UpdateXml(tinyxml2::XMLDocument& doc) override;
 
 	/**
 	 * Returns all the missions for this entity, mapped by mission ID

--- a/dGame/dMission/Mission.cpp
+++ b/dGame/dMission/Mission.cpp
@@ -65,24 +65,24 @@ Mission::Mission(MissionComponent* missionComponent, const uint32_t missionId) {
 	}
 }
 
-void Mission::LoadFromXml(tinyxml2::XMLElement* element) {
+void Mission::LoadFromXml(const tinyxml2::XMLElement& element) {
 	// Start custom XML
-	if (element->Attribute("state") != nullptr) {
-		m_State = static_cast<eMissionState>(std::stoul(element->Attribute("state")));
+	if (element.Attribute("state") != nullptr) {
+		m_State = static_cast<eMissionState>(std::stoul(element.Attribute("state")));
 	}
 	// End custom XML
 
-	if (element->Attribute("cct") != nullptr) {
-		m_Completions = std::stoul(element->Attribute("cct"));
+	if (element.Attribute("cct") != nullptr) {
+		m_Completions = std::stoul(element.Attribute("cct"));
 
-		m_Timestamp = std::stoul(element->Attribute("cts"));
+		m_Timestamp = std::stoul(element.Attribute("cts"));
 
 		if (IsComplete()) {
 			return;
 		}
 	}
 
-	auto* task = element->FirstChildElement();
+	auto* task = element.FirstChildElement();
 
 	auto index = 0U;
 
@@ -132,19 +132,19 @@ void Mission::LoadFromXml(tinyxml2::XMLElement* element) {
 	}
 }
 
-void Mission::UpdateXml(tinyxml2::XMLElement* element) {
+void Mission::UpdateXml(tinyxml2::XMLElement& element) {
 	// Start custom XML
-	element->SetAttribute("state", static_cast<unsigned int>(m_State));
+	element.SetAttribute("state", static_cast<unsigned int>(m_State));
 	// End custom XML
 
-	element->DeleteChildren();
+	element.DeleteChildren();
 
-	element->SetAttribute("id", static_cast<unsigned int>(info.id));
+	element.SetAttribute("id", static_cast<unsigned int>(info.id));
 
 	if (m_Completions > 0) {
-		element->SetAttribute("cct", static_cast<unsigned int>(m_Completions));
+		element.SetAttribute("cct", static_cast<unsigned int>(m_Completions));
 
-		element->SetAttribute("cts", static_cast<unsigned int>(m_Timestamp));
+		element.SetAttribute("cts", static_cast<unsigned int>(m_Timestamp));
 
 		if (IsComplete()) {
 			return;
@@ -155,27 +155,27 @@ void Mission::UpdateXml(tinyxml2::XMLElement* element) {
 		if (task->GetType() == eMissionTaskType::COLLECTION ||
 			task->GetType() == eMissionTaskType::VISIT_PROPERTY) {
 
-			auto* child = element->GetDocument()->NewElement("sv");
+			auto* child = element.GetDocument()->NewElement("sv");
 
 			child->SetAttribute("v", static_cast<unsigned int>(task->GetProgress()));
 
-			element->LinkEndChild(child);
+			element.LinkEndChild(child);
 
 			for (auto unique : task->GetUnique()) {
-				auto* uniqueElement = element->GetDocument()->NewElement("sv");
+				auto* uniqueElement = element.GetDocument()->NewElement("sv");
 
 				uniqueElement->SetAttribute("v", static_cast<unsigned int>(unique));
 
-				element->LinkEndChild(uniqueElement);
+				element.LinkEndChild(uniqueElement);
 			}
 
 			break;
 		}
-		auto* child = element->GetDocument()->NewElement("sv");
+		auto* child = element.GetDocument()->NewElement("sv");
 
 		child->SetAttribute("v", static_cast<unsigned int>(task->GetProgress()));
 
-		element->LinkEndChild(child);
+		element.LinkEndChild(child);
 	}
 }
 

--- a/dGame/dMission/Mission.h
+++ b/dGame/dMission/Mission.h
@@ -28,8 +28,8 @@ public:
 	Mission(MissionComponent* missionComponent, uint32_t missionId);
 	~Mission();
 
-	void LoadFromXml(tinyxml2::XMLElement* element);
-	void UpdateXml(tinyxml2::XMLElement* element);
+	void LoadFromXml(const tinyxml2::XMLElement& element);
+	void UpdateXml(tinyxml2::XMLElement& element);
 
 	/**
 	 * Returns the ID of this mission

--- a/dGame/dUtilities/BrickDatabase.cpp
+++ b/dGame/dUtilities/BrickDatabase.cpp
@@ -29,15 +29,14 @@ const BrickList& BrickDatabase::GetBricks(const LxfmlPath& lxfmlPath) {
 		return emptyCache;
 	}
 
-	auto* doc = new tinyxml2::XMLDocument();
-	if (doc->Parse(data.str().c_str(), data.str().size()) != 0) {
-		delete doc;
+	tinyxml2::XMLDocument doc;
+	if (doc.Parse(data.str().c_str(), data.str().size()) != 0) {
 		return emptyCache;
 	}
 
 	BrickList parts;
 
-	auto* lxfml = doc->FirstChildElement("LXFML");
+	auto* lxfml = doc.FirstChildElement("LXFML");
 	auto* bricks = lxfml->FirstChildElement("Bricks");
 	std::string searchTerm = "Brick";
 
@@ -85,8 +84,6 @@ const BrickList& BrickDatabase::GetBricks(const LxfmlPath& lxfmlPath) {
 	}
 
 	m_Cache[lxfmlPath] = parts;
-
-	delete doc;
 
 	return m_Cache[lxfmlPath];
 }


### PR DESCRIPTION
resolves a possible memory leak in BrickDatabase, adds stability to character save doc as it can now no longer be null (and given the context of when UpdateXml would is called, it cannot be a stale reference either since an entity must exist in order to save and LoadFromXml).

Tested that saving manually via force-save, logout and /crash all saved my position and my removed banana as expected. The doc was always deleted on character destruction and on any updates, so this is just a semantic change (and now we no longer have new'd tinyxml2::documents on the heap)