### PR TITLE
fix: Add exception inheritance for CppSQLite3Exception, harder try catch re-throw in exception handler

### DIFF
--- a/dCommon/Diagnostics.cpp
+++ b/dCommon/Diagnostics.cpp
@@ -120,6 +120,8 @@ void CatchUnhandled(int sig) {
 		if (eptr) std::rethrow_exception(eptr);
 	} catch(const std::exception& e) {
 		LOG("Caught exception: '%s'", e.what());
+	} catch (...) {
+		LOG("Caught unknown exception.");
 	}
 
 #ifndef INCLUDE_BACKTRACE

--- a/thirdparty/SQLite/CppSQLite3.h
+++ b/thirdparty/SQLite/CppSQLite3.h
@@ -36,10 +36,11 @@
 #include "sqlite3.h"
 #include <cstdio>
 #include <cstring>
+#include <exception>
 
 #define CPPSQLITE_ERROR 1000
 
-class CppSQLite3Exception
+class CppSQLite3Exception : public std::exception
 {
 public:
 
@@ -54,6 +55,8 @@ public:
     const int errorCode() { return mnErrCode; }
 
     const char* errorMessage() { return mpszErrMess; }
+    
+    const char* what() const noexcept override { return mpszErrMess; }
 
     static const char* errorCodeAsString(int nErrCode);
 


### PR DESCRIPTION
Allows this to be caught in our exception handler by name.  Fixes the try catch re-throw to catch any exception if the exception re-thrown does not inherit std::exception.

Tested that replacing a dummy query.bind with a non-existent field
- prints `Caught unknown exception.` when not inheriting from std::exception
- prints `SQLITE3_ERROR...` when inheriting from std::exception