### PR TITLE
fix: console sound in Nexus Tower

### DIFF
--- a/dScripts/02_server/Map/General/TokenConsoleServer.cpp
+++ b/dScripts/02_server/Map/General/TokenConsoleServer.cpp
@@ -17,7 +17,9 @@ void TokenConsoleServer::OnUse(Entity* self, Entity* user) {
 		inv->RemoveItem(6194, bricksToTake);
 
 		//play sound
-		GameMessages::SendPlayNDAudioEmitter(self, user->GetSystemAddress(), "947d0d52-c7f8-4516-8dee-e1593a7fd1d1");
+		if (self->HasVar(u"sound1")) {
+			GameMessages::SendPlayNDAudioEmitter(self, user->GetSystemAddress(), self->GetVarAsString(u"sound1"));
+		}
 
 		//figure out which faction the player belongs to:
 		auto character = user->GetCharacter();

--- a/dScripts/02_server/Map/NS/NsTokenConsoleServer.cpp
+++ b/dScripts/02_server/Map/NS/NsTokenConsoleServer.cpp
@@ -39,7 +39,7 @@ void NsTokenConsoleServer::OnUse(Entity* self, Entity* user) {
 	const auto useSound = self->GetVar<std::string>(u"sound1");
 
 	if (!useSound.empty()) {
-		GameMessages::SendPlayNDAudioEmitter(self, UNASSIGNED_SYSTEM_ADDRESS, useSound);
+		GameMessages::SendPlayNDAudioEmitter(self, user->GetSystemAddress(), useSound);
 	}
 
 	// Player must be in faction to interact with this entity.


### PR DESCRIPTION
Tested that turning in bricks in Nexus Tower now correctly plays a sound.  The change in the other script is merely a formality as that path is unused in the Nimbus Station console
fixes #527
