### PR TITLE
chore: move the pet minigame table loading logic out of petcomponent

### DIFF
--- a/dDatabase/CDClientDatabase/CDClientManager.cpp
+++ b/dDatabase/CDClientDatabase/CDClientManager.cpp
@@ -25,6 +25,7 @@
 #include "CDScriptComponentTable.h"
 #include "CDSkillBehaviorTable.h"
 #include "CDZoneTableTable.h"
+#include "CDTamingBuildPuzzleTable.h"
 #include "CDVendorComponentTable.h"
 #include "CDActivitiesTable.h"
 #include "CDPackageComponentTable.h"
@@ -108,6 +109,7 @@ DEFINE_TABLE_STORAGE(CDRewardCodesTable);
 DEFINE_TABLE_STORAGE(CDRewardsTable);
 DEFINE_TABLE_STORAGE(CDScriptComponentTable);
 DEFINE_TABLE_STORAGE(CDSkillBehaviorTable);
+DEFINE_TABLE_STORAGE(CDTamingBuildPuzzleTable);
 DEFINE_TABLE_STORAGE(CDVendorComponentTable);
 DEFINE_TABLE_STORAGE(CDZoneTableTable);
 
@@ -152,6 +154,7 @@ void CDClientManager::LoadValuesFromDatabase() {
 	CDRewardsTable::Instance().LoadValuesFromDatabase();
 	CDScriptComponentTable::Instance().LoadValuesFromDatabase();
 	CDSkillBehaviorTable::Instance().LoadValuesFromDatabase();
+	CDTamingBuildPuzzleTable::Instance().LoadValuesFromDatabase();
 	CDVendorComponentTable::Instance().LoadValuesFromDatabase();
 	CDZoneTableTable::Instance().LoadValuesFromDatabase();
 }

--- a/dDatabase/CDClientDatabase/CDClientTables/CDTamingBuildPuzzleTable.cpp
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDTamingBuildPuzzleTable.cpp
@@ -1,0 +1,27 @@
+#include "CDTamingBuildPuzzleTable.h"
+
+const CDTamingBuildPuzzle CDTamingBuildPuzzleTable::defaultEntry = CDTamingBuildPuzzle{};
+
+void CDTamingBuildPuzzleTable::LoadValuesFromDatabase() {
+	auto tableData = CDClientDatabase::ExecuteQuery("SELECT * FROM TamingBuildPuzzles");
+	auto& entries = GetEntriesMutable();
+
+	while (!tableData.eof()) {
+		const auto lot = static_cast<LOT>(tableData.getIntField("NPCLot", LOT_NULL));
+		entries.emplace(lot, CDTamingBuildPuzzle{
+			.puzzleModelLot = lot,
+			.validPieces{ tableData.getStringField("ValidPiecesLXF") },
+			.timeLimit = static_cast<float>(tableData.getFloatField("Timelimit", 30.0f)),
+			.numValidPieces = tableData.getIntField("NumValidPieces", 6),
+			.imaginationCost = tableData.getIntField("imagCostPerBuild", 10)
+		});
+		tableData.nextRow();
+	}
+	tableData.finalize();
+}
+
+const CDTamingBuildPuzzle& CDTamingBuildPuzzleTable::GetByLOT(const LOT lot) {
+	const auto& entries = GetEntries();
+	const auto itr = entries.find(lot);
+	return itr != entries.cend() ? itr->second : defaultEntry;
+}

--- a/dDatabase/CDClientDatabase/CDClientTables/CDTamingBuildPuzzleTable.h
+++ b/dDatabase/CDClientDatabase/CDClientTables/CDTamingBuildPuzzleTable.h
@@ -1,0 +1,74 @@
+#pragma once
+#include "CDTable.h"
+
+#include <filesystem>
+
+/**
+ * Type aliases
+*/
+using TamingBuildPuzzleId = uint32_t;
+
+/**
+ * Information for the minigame to be completed
+ */
+struct CDTamingBuildPuzzle {
+	UNUSED_COLUMN(TamingBuildPuzzleId id = 0;)
+
+	// The LOT of the object that is to be created
+	LOT puzzleModelLot = LOT_NULL;
+
+	// The LOT of the NPC
+	UNUSED_COLUMN(LOT npcLot = LOT_NULL;)
+
+	// The .lxfml file that contains the bricks required to build the model
+	std::filesystem::path validPieces{};
+
+	// The .lxfml file that contains the bricks NOT required to build the model
+	UNUSED_COLUMN(std::filesystem::path invalidPieces{};)
+
+	// Difficulty value
+	UNUSED_COLUMN(int32_t difficulty = 1;)
+
+	// The time limit to complete the build
+	float timeLimit = 30.0f;
+
+	// The number of pieces required to complete the minigame
+	int32_t numValidPieces = 6;
+
+	// Number of valid pieces
+	UNUSED_COLUMN(int32_t totalNumPieces = 16;)
+
+	// Model name
+	UNUSED_COLUMN(std::filesystem::path modelName{};)
+
+	// The .lxfml file that contains the full model
+	UNUSED_COLUMN(std::filesystem::path fullModel{};)
+
+	// The duration of the pet taming minigame
+	UNUSED_COLUMN(float duration = 45.0f;)
+
+	// The imagination cost for the tamer to start the minigame
+	int32_t imaginationCost = 10;
+};
+
+class CDTamingBuildPuzzleTable : public CDTable<CDTamingBuildPuzzleTable, std::unordered_map<LOT, CDTamingBuildPuzzle>> {
+public:
+	/**
+	 * Load values from the CD client database
+	*/
+	void LoadValuesFromDatabase();
+
+	/**
+	 * Load the default values into memory instead of attempting to connect to the CD client database
+	*/
+	void LoadValuesFromDefaults();
+
+	/**
+	 * Gets the pet ability table corresponding to the pet LOT
+	 * @returns A reference to the corresponding table, or the default if one cannot be found
+	*/
+	const CDTamingBuildPuzzle& GetByLOT(const LOT lot);
+
+private:
+	static const CDTamingBuildPuzzle defaultEntry;
+};

--- a/dDatabase/CDClientDatabase/CDClientTables/CMakeLists.txt
+++ b/dDatabase/CDClientDatabase/CDClientTables/CMakeLists.txt
@@ -36,5 +36,6 @@ set(DDATABASE_CDCLIENTDATABASE_CDCLIENTTABLES_SOURCES "CDActivitiesTable.cpp"
 	"CDRewardsTable.cpp"
 	"CDScriptComponentTable.cpp"
 	"CDSkillBehaviorTable.cpp"
+	"CDTamingBuildPuzzleTable.cpp"
 	"CDVendorComponentTable.cpp"
 	"CDZoneTableTable.cpp" PARENT_SCOPE)

--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -2,6 +2,7 @@
 #include "GameMessages.h"
 #include "BrickDatabase.h"
 #include "CDClientDatabase.h"
+#include "CDTamingBuildPuzzleTable.h"
 #include "ChatPackets.h"
 #include "EntityManager.h"
 #include "Character.h"
@@ -152,8 +153,7 @@ void PetComponent::OnUse(Entity* originator) {
 		m_Tamer = LWOOBJID_EMPTY;
 	}
 
-	auto* inventoryComponent = originator->GetComponent<InventoryComponent>();
-
+	auto* const inventoryComponent = originator->GetComponent<InventoryComponent>();
 	if (inventoryComponent == nullptr) {
 		return;
 	}
@@ -162,86 +162,40 @@ void PetComponent::OnUse(Entity* originator) {
 		return;
 	}
 
-	auto* movementAIComponent = m_Parent->GetComponent<MovementAIComponent>();
-
+	auto* const movementAIComponent = m_Parent->GetComponent<MovementAIComponent>();
 	if (movementAIComponent != nullptr) {
 		movementAIComponent->Stop();
 	}
 
 	inventoryComponent->DespawnPet();
 
-	const auto& cached = buildCache.find(m_Parent->GetLOT());
-	int32_t imaginationCost = 0;
+	const auto& entry =  CDClientManager::GetTable<CDTamingBuildPuzzleTable>()->GetByLOT(m_Parent->GetLOT());
 
-	std::string buildFile;
-
-	if (cached == buildCache.end()) {
-		auto query = CDClientDatabase::CreatePreppedStmt(
-			"SELECT ValidPiecesLXF, PuzzleModelLot, Timelimit, NumValidPieces, imagCostPerBuild FROM TamingBuildPuzzles WHERE NPCLot = ?;");
-		query.bind(1, static_cast<int>(m_Parent->GetLOT()));
-
-		auto result = query.execQuery();
-
-		if (result.eof()) {
-			ChatPackets::SendSystemMessage(originator->GetSystemAddress(), u"Failed to find the puzzle minigame for this pet.");
-
-			return;
-		}
-
-		if (result.fieldIsNull("ValidPiecesLXF")) {
-			result.finalize();
-
-			return;
-		}
-
-		buildFile = std::string(result.getStringField("ValidPiecesLXF"));
-
-		PetPuzzleData data;
-		data.buildFile = buildFile;
-		data.puzzleModelLot = result.getIntField("PuzzleModelLot");
-		data.timeLimit = result.getFloatField("Timelimit");
-		data.numValidPieces = result.getIntField("NumValidPieces");
-		data.imaginationCost = result.getIntField("imagCostPerBuild");
-		if (data.timeLimit <= 0) data.timeLimit = 60;
-		imaginationCost = data.imaginationCost;
-
-		buildCache[m_Parent->GetLOT()] = data;
-
-		result.finalize();
-	} else {
-		buildFile = cached->second.buildFile;
-		imaginationCost = cached->second.imaginationCost;
-	}
-
-	auto* destroyableComponent = originator->GetComponent<DestroyableComponent>();
-
+	const auto* const destroyableComponent = originator->GetComponent<DestroyableComponent>();
 	if (destroyableComponent == nullptr) {
 		return;
 	}
 
-	auto imagination = destroyableComponent->GetImagination();
-
-	if (imagination < imaginationCost) {
+	const auto imagination = destroyableComponent->GetImagination();
+	if (imagination < entry.imaginationCost) {
 		return;
 	}
 
-	const auto& bricks = BrickDatabase::GetBricks(buildFile);
-
+	const auto& bricks = BrickDatabase::GetBricks(entry.validPieces);
 	if (bricks.empty()) {
 		ChatPackets::SendSystemMessage(originator->GetSystemAddress(), u"Failed to load the puzzle minigame for this pet.");
-		LOG("Couldn't find %s for minigame!", buildFile.c_str());
+		LOG("Couldn't find %s for minigame!", entry.validPieces.c_str());
 
 		return;
 	}
 
-	auto petPosition = m_Parent->GetPosition();
+	const auto petPosition = m_Parent->GetPosition();
 
-	auto originatorPosition = originator->GetPosition();
+	const auto originatorPosition = originator->GetPosition();
 
 	m_Parent->SetRotation(NiQuaternion::LookAt(petPosition, originatorPosition));
 
 	float interactionDistance = m_Parent->GetVar<float>(u"interaction_distance");
-
 	if (interactionDistance <= 0) {
 		interactionDistance = 15;
 	}


### PR DESCRIPTION
Cleaning up the pet component as part of the pet fixes branch. This should be in CDClient with the others.