### PR TITLE
chore: Convert heap allocation to optional

### DIFF
--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -40,7 +40,7 @@ std::unordered_map<LWOOBJID, LWOOBJID> PetComponent::activePets{};
  * Maps all the pet lots to a flag indicating that the player has caught it. All basic pets have been guessed by ObjID
  * while the faction ones could be checked using their respective missions.
  */
-std::map<LOT, int32_t> PetComponent::petFlags = {
+const std::map<LOT, int32_t> PetComponent::petFlags{
 		{ 3050, 801 },  // Elephant
 		{ 3054, 803 },  // Cat
 		{ 3195, 806 },  // Triceratops
@@ -87,7 +87,6 @@ PetComponent::PetComponent(Entity* parentEntity, uint32_t componentId) : Compone
 	m_StartPosition = NiPoint3Constant::ZERO;
 	m_MovementAI = nullptr;
 	m_TresureTime = 0;
-	m_Preconditions = nullptr;
 
 	std::string checkPreconditions = GeneralUtils::UTF16ToWTF8(parentEntity->GetVar<std::u16string>(u"CheckPrecondition"));
 
@@ -158,7 +157,7 @@ void PetComponent::OnUse(Entity* originator) {
 		return;
 	}
 
-	if (m_Preconditions != nullptr && !m_Preconditions->Check(originator, true)) {
+	if (m_Preconditions.has_value() && !m_Preconditions->Check(originator, true)) {
 		return;
 	}
 
@@ -1086,6 +1085,6 @@ void PetComponent::LoadPetNameFromModeration() {
 	}
 }
 
-void PetComponent::SetPreconditions(std::string& preconditions) {
-	m_Preconditions = new PreconditionExpression(preconditions);
+void PetComponent::SetPreconditions(const std::string& preconditions) {
+	m_Preconditions = std::make_optional<PreconditionExpression>(preconditions);
 }

--- a/dGame/dComponents/PetComponent.h
+++ b/dGame/dComponents/PetComponent.h
@@ -165,7 +165,7 @@ public:
 	 * Sets preconditions for the pet that need  to be met before it can be tamed
 	 * @param conditions the preconditions to set
 	 */
-	void SetPreconditions(std::string& conditions);
+	void SetPreconditions(const std::string& conditions);
 
 	/**
 	 * Returns the entity that this component belongs to
@@ -258,7 +258,7 @@ private:
 	/**
 	 * Flags that indicate that a player has tamed a pet, indexed by the LOT of the pet
 	 */
-	static std::map<LOT, int32_t> petFlags;
+	static const std::map<LOT, int32_t> petFlags;
 
 	/**
 	 * The ID of the component in the pet component table
@@ -349,7 +349,7 @@ private:
 	/**
 	 * Preconditions that need to be met before an entity can tame this pet
 	 */
-	PreconditionExpression* m_Preconditions;
+	std::optional<PreconditionExpression> m_Preconditions = std::nullopt;
 
 	/**
 	 * Pet information loaded from the CDClientDatabase

--- a/dGame/dComponents/PetComponent.h
+++ b/dGame/dComponents/PetComponent.h
@@ -349,7 +349,7 @@ private:
 	/**
 	 * Preconditions that need to be met before an entity can tame this pet
 	 */
-	std::optional<PreconditionExpression> m_Preconditions = std::nullopt;
+	std::optional<PreconditionExpression> m_Preconditions{};
 
 	/**
 	 * Pet information loaded from the CDClientDatabase


### PR DESCRIPTION
swap out the petcomponent precondition expression for an optional
doing this here because the petfixes PR is already big enough