### PR TITLE
Use volume for mariadb persistence

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - darkflame
     image: mariadb:latest
     volumes:
-      - ${DB_DATA_DIR:-./db/data}:/var/lib/mysql
+      - ${DB_DATA_DIR:-db-data}:/var/lib/mysql
     environment:
       - MARIADB_RANDOM_ROOT_PASSWORD=1
       - MARIADB_USER=${MARIADB_USER:-darkflame}
@@ -79,3 +79,6 @@ services:
 
 networks:
   darkflame:
+
+volumes:
+  db-data:


### PR DESCRIPTION
I initially used the bind mount because it's arguably easier to back up and move around than a volume, but turns out with https://github.com/DarkflameUniverse/NexusDashboard/issues/92 it's nothing we can recommend for Docker Desktop on WSL, which unfortunately is the primary setup newcomers will try this with. So changing the default to be a volume should address that (presumably by hosting the volume within the WSL Docker VM, as opposed to the host NTFS filesystem)