### PR TITLE
fix: out of order physics updates

### DIFF
--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -388,13 +388,13 @@ int main(int argc, char** argv) {
 		//In world we'd update our other systems here.
 
 		if (zoneID != 0 && deltaTime > 0.0f) {
-			Metrics::StartMeasurement(MetricVariable::Physics);
-			dpWorld::StepWorld(deltaTime);
-			Metrics::EndMeasurement(MetricVariable::Physics);
-
 			Metrics::StartMeasurement(MetricVariable::UpdateEntities);
 			Game::entityManager->UpdateEntities(deltaTime);
 			Metrics::EndMeasurement(MetricVariable::UpdateEntities);
+
+			Metrics::StartMeasurement(MetricVariable::Physics);
+			dpWorld::StepWorld(deltaTime);
+			Metrics::EndMeasurement(MetricVariable::Physics);
 
 			Metrics::StartMeasurement(MetricVariable::Ghosting);
 			if (std::chrono::duration<float>(currentTime - ghostingLastTime).count() >= 1.0f) {


### PR DESCRIPTION
fixes an issue where physics entities were not given a chance to be marked as sleeping, causing a initial sleeping calls to be missed and causing objects that collided with one another to not register new collisions since they were sleeping at the time the new collision fired off.

Tested that Brick Fury now corectly aggros the _first_ spawn of enemies near by to him. Tested that the turrets in crux prime now correctly shoot the _first_ wave of enemies that spawn.