### PR TITLE
chore: Remove anti-cheat break savings

### DIFF
--- a/dGame/dUtilities/CheatDetection.cpp
+++ b/dGame/dUtilities/CheatDetection.cpp
@@ -130,12 +130,6 @@ bool CheatDetection::VerifyLwoobjidIsSender(const LWOOBJID& id, const SystemAddr
 
 	// This will be true if the player does not possess the entity they are trying to send a packet as.
 	// or if the user does not own the character they are trying to send a packet as.
-	if (invalidPacket) {
-		va_list args;
-		va_start(args, messageIfNotSender);
-		LogAndSaveFailedAntiCheatCheck(id, sysAddr, checkType, messageIfNotSender, args);
-		va_end(args);
-	}
 
 	return !invalidPacket;
 }


### PR DESCRIPTION
This is not quite implemented correctly and as such needs to be re-tooled to only track if specific gms should track their origin.  This doesnt affect gameplay but stops us from flooding the database with useless info.  Any current solution to check the correct GMs would be too slow to actually use so i am opting to just remove this for a future implementation.