### PR TITLE
fix: use after free in mission progression after removing item from inventory

### DIFF
--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -5354,14 +5354,14 @@ void GameMessages::HandleRemoveItemFromInventory(RakNet::BitStream& inStream, En
 		if (eInvType == eInventoryType::MODELS) {
 			item->DisassembleModel(iStackCount);
 		}
-
+		auto lot = item->GetLot();
 		item->SetCount(item->GetCount() - iStackCount, true);
 		Game::entityManager->SerializeEntity(entity);
 
 		auto* missionComponent = entity->GetComponent<MissionComponent>();
 
 		if (missionComponent != nullptr) {
-			missionComponent->Progress(eMissionTaskType::GATHER, item->GetLot(), LWOOBJID_EMPTY, "", -iStackCount);
+			missionComponent->Progress(eMissionTaskType::GATHER, lot, LWOOBJID_EMPTY, "", -iStackCount);
 		}
 	}
 }


### PR DESCRIPTION
SetCount is cursed...  other methods of freeing the memory should be explored

no longer has ub when deleting an item from the inventory and makes it so if you delete items that are apart of gather tasks, the progress is now properly undone