### PR TITLE
feat: Help command pagination

### DIFF
--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -870,14 +870,50 @@ void SlashCommandHandler::Startup() {
     	.aliases = { "help", "h"},
     	.handle = [](Entity* entity, const SystemAddress& sysAddr, const std::string& args) {
         	std::ostringstream feedback;
-        	feedback << "----- Commands -----";
+        	constexpr size_t pageSize = 10; // Number of commands per page
 
-        	// Loop through CommandInfos and display commands the player can access
-        	for (const auto& [alias, command] : CommandInfos) {
-            	if (command.requiredLevel <= entity->GetGMLevel()) {
-                	LOG("Help command: %s", alias.c_str());
-                	feedback << "\n/" << alias << ": " << command.help;
-            	}
+        	// Filter CommandInfos based on playe s GM level
+        	std::vector<std::pair<std::string, Command>> accessibleCommands;
+        	std::copy_if(CommandInfos.begin(), CommandInfos.end(), std::back_inserter(accessibleCommands),
+                     	[&](const auto& pair) {
+                        	 return pair.second.requiredLevel <= entity->GetGMLevel();
+                     	});
+
+        	// Calculate total number of pages based on accessible commands
+        	size_t totalPages = (accessibleCommands.size() + pageSize - 1) / pageSize;
+
+        	size_t page = 1; // Default to first page
+
+        	// Check if page number is provided
+        	if (!args.empty()) {
+            	try {
+                	page = std::stoi(args);
+            	} catch (const std::exception&) {
+                	feedback << "Invalid page number.";
+                	GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedback.str()));
+                	return;
+        	    }
+        	}
+
+        	// Check if requested page number is valid
+        	if (page < 1 || page > totalPages) {
+            	feedback << "Invalid page number. Total pages: " << totalPages;
+            	GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedback.str()));
+        	    return;
+        	}
+
+        	// Calculate starting and ending index for commands on the current page
+        	size_t startIdx = (page - 1) * pageSize;
+        	size_t endIdx = std::min(startIdx + pageSize, accessibleCommands.size());
+
+        	// Display commands for the current page
+        	feedback << "----- Commands (Page " << page << ") -----";
+        	size_t count = 0;
+        	for (size_t i = startIdx; i < endIdx; ++i) {
+            	const auto& [alias, command] = accessibleCommands[i];
+            	LOG("Help command: %s", alias.c_str());
+            	feedback << "\n/" << alias << ": " << command.help;
+            	++count;
         	}
 
         	// Send feedback text

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -867,17 +867,53 @@ void SlashCommandHandler::Startup() {
 	Command HelpCommand{
     	.help = "Display command info",
     	.info = "If a command is given, display detailed info on that command. Otherwise display a list of commands with short descriptions.",
-    	.aliases = { "help", "h"},
+ 		.aliases = { "help", "h"},
     	.handle = [](Entity* entity, const SystemAddress& sysAddr, const std::string& args) {
-        	std::ostringstream feedback;
-        	feedback << "----- Commands -----";
+    		std::ostringstream feedback;
+        	constexpr size_t pageSize = 10; // Number of commands per page
 
-        	// Loop through CommandInfos and display commands the player can access
-        	for (const auto& [alias, command] : CommandInfos) {
-            	if (command.requiredLevel <= entity->GetGMLevel()) {
-                	LOG("Help command: %s", alias.c_str());
-                	feedback << "\n/" << alias << ": " << command.help;
+        	// Filter CommandInfos based on player's GM level
+        	std::vector<std::pair<std::string, Command>> accessibleCommands;
+        	std::copy_if(CommandInfos.begin(), CommandInfos.end(), std::back_inserter(accessibleCommands),
+                     	[&](const auto& pair) {
+                        	 return pair.second.requiredLevel <= entity->GetGMLevel();
+            });
+
+        	// Calculate total number of pages based on accessible commands
+        	size_t totalPages = (accessibleCommands.size() + pageSize - 1) / pageSize;
+
+        	size_t page = 1; // Default to first page
+
+        	// Check if page number is provided
+        	if (!args.empty()) {
+            	try {
+                	page = std::stoi(args);
+            	} catch (const std::exception&) {
+                	feedback << "Invalid page number.";
+                	GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedback.str()));
+                	return;
             	}
+        	}
+
+        	// Check if requested page number is valid
+        	if (page < 1 || page > totalPages) {
+            	feedback << "Invalid page number. Total pages: " << totalPages;
+            	GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedback.str()));
+            	return;
+        	}
+
+        	// Calculate starting and ending index for commands on the current page
+        	size_t startIdx = (page - 1) * pageSize;
+        	size_t endIdx = std::min(startIdx + pageSize, accessibleCommands.size());
+
+        	// Display commands for the current page
+        	feedback << "----- Commands (Page " << page << ") -----";
+        	size_t count = 0;
+        	for (size_t i = startIdx; i < endIdx; ++i) {
+            	const auto& [alias, command] = accessibleCommands[i];
+            	LOG("Help command: %s", alias.c_str());
+            	feedback << "\n/" << alias << ": " << command.help;
+            	++count;
         	}
 
         	// Send feedback text

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -867,53 +867,17 @@ void SlashCommandHandler::Startup() {
 	Command HelpCommand{
     	.help = "Display command info",
     	.info = "If a command is given, display detailed info on that command. Otherwise display a list of commands with short descriptions.",
- 		.aliases = { "help", "h"},
+    	.aliases = { "help", "h"},
     	.handle = [](Entity* entity, const SystemAddress& sysAddr, const std::string& args) {
-    		std::ostringstream feedback;
-        	constexpr size_t pageSize = 10; // Number of commands per page
+        	std::ostringstream feedback;
+        	feedback << "----- Commands -----";
 
-        	// Filter CommandInfos based on player's GM level
-        	std::vector<std::pair<std::string, Command>> accessibleCommands;
-        	std::copy_if(CommandInfos.begin(), CommandInfos.end(), std::back_inserter(accessibleCommands),
-                     	[&](const auto& pair) {
-                        	 return pair.second.requiredLevel <= entity->GetGMLevel();
-            });
-
-        	// Calculate total number of pages based on accessible commands
-        	size_t totalPages = (accessibleCommands.size() + pageSize - 1) / pageSize;
-
-        	size_t page = 1; // Default to first page
-
-        	// Check if page number is provided
-        	if (!args.empty()) {
-            	try {
-                	page = std::stoi(args);
-            	} catch (const std::exception&) {
-                	feedback << "Invalid page number.";
-                	GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedback.str()));
-                	return;
+        	// Loop through CommandInfos and display commands the player can access
+        	for (const auto& [alias, command] : CommandInfos) {
+            	if (command.requiredLevel <= entity->GetGMLevel()) {
+                	LOG("Help command: %s", alias.c_str());
+                	feedback << "\n/" << alias << ": " << command.help;
             	}
-        	}
-
-        	// Check if requested page number is valid
-        	if (page < 1 || page > totalPages) {
-            	feedback << "Invalid page number. Total pages: " << totalPages;
-            	GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedback.str()));
-            	return;
-        	}
-
-        	// Calculate starting and ending index for commands on the current page
-        	size_t startIdx = (page - 1) * pageSize;
-        	size_t endIdx = std::min(startIdx + pageSize, accessibleCommands.size());
-
-        	// Display commands for the current page
-        	feedback << "----- Commands (Page " << page << ") -----";
-        	size_t count = 0;
-        	for (size_t i = startIdx; i < endIdx; ++i) {
-            	const auto& [alias, command] = accessibleCommands[i];
-            	LOG("Help command: %s", alias.c_str());
-            	feedback << "\n/" << alias << ": " << command.help;
-            	++count;
         	}
 
         	// Send feedback text


### PR DESCRIPTION
feat: Help Command Pagination



feat: Command Organization

Description: Changed HelpCommand to now be sorted into different pages for commands, which should help to further help users to find the correct commands they are looking for without having to scroll through a list of 92 commands. 

Motivation and Context: Recommendation from Aron, and my own experience reading through the /help command list.

How Has This Been Tested?: Running my server and using the `/help` command will return page 1 of the command list. Running `/help 1` will as well, but `/help 2` and so forth will return that respective page number of commands (currently 10 commands per page). If a user tries to enter a command higher than the number of pages, it will say it is an invalid page number. Additionally, commands will only show up given the user has the proper GMLevel to use that command. 
