### PR TITLE
feat: Help Command Pagination

### DIFF
--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -20,7 +20,6 @@
 
 namespace {
 	std::map<std::string, Command> CommandInfos;
-	std::map<std::string, Command> CommandInfos;
 	std::map<std::string, Command> RegisteredCommands;
 }
 
@@ -38,9 +37,6 @@ void SlashCommandHandler::RegisterCommand(Command command) {
 			LOG_DEBUG("Command alias %s is already registered! Skipping!", alias.c_str());
 			continue;
 		}
-	}
-	CommandInfos[command.aliases[0]] = command;
-}
 	}
 	CommandInfos[command.aliases[0]] = command;
 }
@@ -143,11 +139,6 @@ void SlashCommandHandler::SendAnnouncement(const std::string& title, const std::
 
 	bitStream.Write<uint32_t>(title.size());
 	for (auto character : title) {
-		bitStream.Write<char>(character);
-	}
-
-	bitStream.Write<uint32_t>(message.size());
-	for (auto character : message) {
 		bitStream.Write<char>(character);
 	}
 
@@ -918,7 +909,6 @@ void SlashCommandHandler::Startup() {
 
 	Command HelpCommand{
 		.help = "Display command info",
-		.info = "If a command is given, display detailed info on that command. Otherwise display a list of commands with short descriptions.",
 		.info = "If a command is given, display detailed info on that command. Otherwise display a list of commands with short descriptions.",
 		.aliases = { "help", "h"},
 		.handle = GMZeroCommands::Help,

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -136,8 +136,6 @@ void SlashCommandHandler::SendAnnouncement(const std::string& title, const std::
 	Game::chatServer->Send(&bitStream, SYSTEM_PRIORITY, RELIABLE, 0, Game::chatSysAddr, false);
 }
 
-<<<<<<< Updated upstream
-=======
 void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
     std::ostringstream feedback;
     constexpr size_t pageSize = 10; // Number of commands per page
@@ -191,7 +189,6 @@ void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const st
     if (!feedbackStr.empty()) GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedbackStr));
 }
 
->>>>>>> Stashed changes
 void SlashCommandHandler::Startup() {
 	// Register Dev Commands
 	Command SetGMLevelCommand{

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -136,6 +136,62 @@ void SlashCommandHandler::SendAnnouncement(const std::string& title, const std::
 	Game::chatServer->Send(&bitStream, SYSTEM_PRIORITY, RELIABLE, 0, Game::chatSysAddr, false);
 }
 
+<<<<<<< Updated upstream
+=======
+void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+    std::ostringstream feedback;
+    constexpr size_t pageSize = 10; // Number of commands per page
+
+    // Filter CommandInfos based on player's GM level
+    std::vector<std::pair<std::string, Command>> accessibleCommands;
+    std::copy_if(CommandInfos.begin(), CommandInfos.end(), std::back_inserter(accessibleCommands),
+                 [&](const auto& pair) {
+                     return pair.second.requiredLevel <= entity->GetGMLevel();
+                 });
+
+    // Calculate total number of pages based on accessible commands
+    size_t totalPages = (accessibleCommands.size() + pageSize - 1) / pageSize;
+
+    size_t page = 1; // Default to first page
+
+    // Check if page number is provided
+    if (!args.empty()) {
+        try {
+            page = std::stoi(args);
+        } catch (const std::exception&) {
+            feedback << "Invalid page number.";
+            GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedback.str()));
+            return;
+        }
+    }
+
+    // Check if requested page number is valid
+    if (page < 1 || page > totalPages) {
+        feedback << "Invalid page number. Total pages: " << totalPages;
+        GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedback.str()));
+        return;
+    }
+
+    // Calculate starting and ending index for commands on the current page
+    size_t startIdx = (page - 1) * pageSize;
+    size_t endIdx = std::min(startIdx + pageSize, accessibleCommands.size());
+
+    // Display commands for the current page
+    feedback << "----- Commands (Page " << page << ") -----";
+    size_t count = 0;
+    for (size_t i = startIdx; i < endIdx; ++i) {
+        const auto& [alias, command] = accessibleCommands[i];
+        LOG("Help command: %s", alias.c_str());
+        feedback << "\n/" << alias << ": " << command.help;
+        ++count;
+    }
+
+	// Send feedback text
+    const auto feedbackStr = feedback.str();
+    if (!feedbackStr.empty()) GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedbackStr));
+}
+
+>>>>>>> Stashed changes
 void SlashCommandHandler::Startup() {
 	// Register Dev Commands
 	Command SetGMLevelCommand{

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -24,25 +24,25 @@ namespace {
 }
 
 void SlashCommandHandler::RegisterCommand(Command command) {
-    if (command.aliases.empty()) {
-        LOG("Command %s has no aliases! Skipping!", command.help.c_str());
-        return;
-    }
+	if (command.aliases.empty()) {
+		LOG("Command %s has no aliases! Skipping!", command.help.c_str());
+		return;
+	}
 
-    for (const auto& alias : command.aliases) {
-        LOG_DEBUG("Registering command %s", alias.c_str());
-        auto [_, success] = RegisteredCommands.try_emplace(alias, command);
-        // Don't allow duplicate commands
-        if (!success) {
-            LOG_DEBUG("Command alias %s is already registered! Skipping!", alias.c_str());
-            continue;
-        }
-    }
+	for (const auto& alias : command.aliases) {
+		LOG_DEBUG("Registering command %s", alias.c_str());
+		auto [_, success] = RegisteredCommands.try_emplace(alias, command);
+		// Don't allow duplicate commands
+		if (!success) {
+			LOG_DEBUG("Command alias %s is already registered! Skipping!", alias.c_str());
+			continue;
+		}
+	}
 
-    // Inserting into CommandInfos using the first alias as the key
-    if (!command.aliases.empty()) {
-        CommandInfos.insert(std::make_pair(command.aliases[0], command));
-    }
+	// Inserting into CommandInfos using the first alias as the key
+	if (!command.aliases.empty()) {
+		CommandInfos.insert(std::make_pair(command.aliases[0], command));
+	}
 }
 
 void SlashCommandHandler::HandleChatCommand(const std::u16string& chat, Entity* entity, const SystemAddress& sysAddr) {
@@ -103,56 +103,56 @@ void SlashCommandHandler::SendAnnouncement(const std::string& title, const std::
 }
 
 void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
-    std::ostringstream feedback;
-    constexpr size_t pageSize = 10; // Number of commands per page
+	std::ostringstream feedback;
+	constexpr size_t pageSize = 10; // Number of commands per page
 
-    // Filter CommandInfos based on player's GM level
-    std::vector<std::pair<std::string, Command>> accessibleCommands;
-    std::copy_if(CommandInfos.begin(), CommandInfos.end(), std::back_inserter(accessibleCommands),
-                [&](const auto& pair) {
-                    return pair.second.requiredLevel <= entity->GetGMLevel();
-                });
+	// Filter CommandInfos based on player's GM level
+	std::vector<std::pair<std::string, Command>> accessibleCommands;
+	std::copy_if(CommandInfos.begin(), CommandInfos.end(), std::back_inserter(accessibleCommands),
+		[&](const auto& pair) {
+			return pair.second.requiredLevel <= entity->GetGMLevel();
+		});
 
-    // Calculate total number of pages based on accessible commands
-    size_t totalPages = (accessibleCommands.size() + pageSize - 1) / pageSize;
+	// Calculate total number of pages based on accessible commands
+	size_t totalPages = (accessibleCommands.size() + pageSize - 1) / pageSize;
 
-    size_t page = 1; // Default to first page
+	size_t page = 1; // Default to first page
 
-    // Check if page number is provided
-    if (!args.empty()) {
-        try {
-            page = std::stoi(args);
-        } catch (const std::exception&) {
-            feedback << "Invalid page number.";
-            GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedback.str()));
-            return;
-        }
-    }
+	// Check if page number is provided
+	if (!args.empty()) {
+		try {
+			page = std::stoi(args);
+		} catch (const std::exception&) {
+			feedback << "Invalid page number.";
+			GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedback.str()));
+			return;
+		}
+	}
 
-    // Check if requested page number is valid
-    if (page < 1 || page > totalPages) {
-        feedback << "Invalid page number. Total pages: " << totalPages;
-        GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedback.str()));
-        return;
-    }
+	// Check if requested page number is valid
+	if (page < 1 || page > totalPages) {
+		feedback << "Invalid page number. Total pages: " << totalPages;
+		GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedback.str()));
+		return;
+	}
 
-    // Calculate starting and ending index for commands on the current page
-    size_t startIdx = (page - 1) * pageSize;
-    size_t endIdx = std::min(startIdx + pageSize, accessibleCommands.size());
+	// Calculate starting and ending index for commands on the current page
+	size_t startIdx = (page - 1) * pageSize;
+	size_t endIdx = std::min(startIdx + pageSize, accessibleCommands.size());
 
-    // Display commands for the current page
-    feedback << "----- Commands (Page " << page << ") -----";
-    size_t count = 0;
-    for (size_t i = startIdx; i < endIdx; ++i) {
-        const auto& [alias, command] = accessibleCommands[i];
-        LOG("Help command: %s", alias.c_str());
-        feedback << "\n/" << alias << ": " << command.help;
-        ++count;
-    }
+	// Display commands for the current page
+	feedback << "----- Commands (Page " << page << ") -----";
+	size_t count = 0;
+	for (size_t i = startIdx; i < endIdx; ++i) {
+		const auto& [alias, command] = accessibleCommands[i];
+		LOG("Help command: %s", alias.c_str());
+		feedback << "\n/" << alias << ": " << command.help;
+		++count;
+	}
 
-    // Send feedback text
-    const auto feedbackStr = feedback.str();
-    if (!feedbackStr.empty()) GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedbackStr));
+	// Send feedback text
+	const auto feedbackStr = feedback.str();
+	if (!feedbackStr.empty()) GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedbackStr));
 }
 
 void SlashCommandHandler::Startup() {
@@ -918,11 +918,11 @@ void SlashCommandHandler::Startup() {
 	// Register GM Zero Commands
 
 	Command HelpCommand{
-    	.help = "Display command info",
-    	.info = "If a command is given, display detailed info on that command. Otherwise display a list of commands with short descriptions.",
-    	.aliases = { "help", "h"},
-    	.handle = GMZeroCommands::Help,
-    	.requiredLevel = eGameMasterLevel::CIVILIAN
+		.help = "Display command info",
+		.info = "If a command is given, display detailed info on that command. Otherwise display a list of commands with short descriptions.",
+		.aliases = { "help", "h"},
+		.handle = GMZeroCommands::Help,
+		.requiredLevel = eGameMasterLevel::CIVILIAN
 	};
 	RegisterCommand(HelpCommand);
 

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -79,7 +79,7 @@ void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const st
 	trimmedArgs.erase(trimmedArgs.begin(), std::find_if_not(trimmedArgs.begin(), trimmedArgs.end(), [](unsigned char ch) {
 		return std::isspace(ch);
 		}));
-	std::optional<int> parsedPage = GeneralUtils::TryParse<int>(trimmedArgs);
+	std::optional<uint32_t> parsedPage = GeneralUtils::TryParse<uint32_t>(trimmedArgs);
 	if (trimmedArgs.empty() || parsedPage.has_value()) {
 		size_t page = parsedPage.value_or(1);
 

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -141,6 +141,7 @@ void SlashCommandHandler::SendAnnouncement(const std::string& title, const std::
 	for (auto character : title) {
 		bitStream.Write<char>(character);
 	}
+	bitStream.Write<uint32_t>(message.size());
 
 	Game::chatServer->Send(&bitStream, SYSTEM_PRIORITY, RELIABLE, 0, Game::chatSysAddr, false);
 }

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -91,9 +91,10 @@ void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const st
 
 	// Check if page number is provided
 	if (!args.empty()) {
-		try {
-			page = std::stoi(args);
-		} catch (const std::exception&) {
+		std::optional<int> parsedPage = GeneralUtils::TryParse<int>(args);
+		if (parsedPage.has_value()) {
+			page = *parsedPage;
+		} else {
 			feedback << "Invalid page number.";
 			GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedback.str()));
 			return;
@@ -113,12 +114,10 @@ void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const st
 
 	// Display commands for the current page
 	feedback << "----- Commands (Page " << page << ") -----";
-	size_t count = 0;
 	for (size_t i = startIdx; i < endIdx; ++i) {
 		const auto& [alias, command] = accessibleCommands[i];
 		LOG("Help command: %s", alias.c_str());
 		feedback << "\n/" << alias << ": " << command.help;
-		++count;
 	}
 
 	// Send feedback text

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -79,10 +79,6 @@ void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const st
 	trimmedArgs.erase(trimmedArgs.begin(), std::find_if_not(trimmedArgs.begin(), trimmedArgs.end(), [](unsigned char ch) {
 		return std::isspace(ch);
 		}));
-	trimmedArgs.erase(std::find_if_not(trimmedArgs.rbegin(), trimmedArgs.rend(), [](unsigned char ch) {
-		return std::isspace(ch);
-		}).base(), trimmedArgs.end());
-
 	std::optional<int> parsedPage = GeneralUtils::TryParse<int>(trimmedArgs);
 	if (trimmedArgs.empty() || parsedPage.has_value()) {
 		size_t page = parsedPage.value_or(1);

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -143,6 +143,31 @@ void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const st
 	}
 }
 
+void SlashCommandHandler::SendAnnouncement(const std::string& title, const std::string& message) {
+	AMFArrayValue args;
+
+	args.Insert("title", title);
+	args.Insert("message", message);
+
+	GameMessages::SendUIMessageServerToAllClients("ToggleAnnounce", args);
+
+	//Notify chat about it
+	CBITSTREAM;
+	BitStreamUtils::WriteHeader(bitStream, eConnectionType::CHAT, eChatMessageType::GM_ANNOUNCE);
+
+	bitStream.Write<uint32_t>(title.size());
+	for (auto character : title) {
+		bitStream.Write<char>(character);
+	}
+
+	bitStream.Write<uint32_t>(message.size());
+	for (auto character : message) {
+		bitStream.Write<char>(character);
+	}
+
+	Game::chatServer->Send(&bitStream, SYSTEM_PRIORITY, RELIABLE, 0, Game::chatSysAddr, false);
+}
+
 void SlashCommandHandler::Startup() {
 	// Register Dev Commands
 	Command SetGMLevelCommand{

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -143,9 +143,9 @@ void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const st
     // Filter CommandInfos based on player's GM level
     std::vector<std::pair<std::string, Command>> accessibleCommands;
     std::copy_if(CommandInfos.begin(), CommandInfos.end(), std::back_inserter(accessibleCommands),
-                 [&](const auto& pair) {
-                     return pair.second.requiredLevel <= entity->GetGMLevel();
-                 });
+                    [&](const auto& pair) {
+                        return pair.second.requiredLevel <= entity->GetGMLevel();
+                    });
 
     // Calculate total number of pages based on accessible commands
     size_t totalPages = (accessibleCommands.size() + pageSize - 1) / pageSize;
@@ -153,7 +153,7 @@ void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const st
     size_t page = 1; // Default to first page
 
     // Check if page number is provided
-    if (!args.empty()) {
+     if (!args.empty()) {
         try {
             page = std::stoi(args);
         } catch (const std::exception&) {
@@ -184,7 +184,7 @@ void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const st
         ++count;
     }
 
-	// Send feedback text
+    // Send feedback text
     const auto feedbackStr = feedback.str();
     if (!feedbackStr.empty()) GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedbackStr));
 }

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -8,6 +8,7 @@
 #include "SlashCommandHandler.h"
 
 #include <iomanip>
+#include <ranges>
 
 #include "DEVGMCommands.h"
 #include "GMGreaterThanZeroCommands.h"
@@ -118,8 +119,8 @@ void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const st
 		return;
 	}
 
-	auto it = std::find_if(CommandInfos.begin(), CommandInfos.end(), [&trimmedArgs](const auto& pair) {
-		return pair.first == trimmedArgs || std::find(pair.second.aliases.begin(), pair.second.aliases.end(), trimmedArgs) != pair.second.aliases.end();
+	auto it = std::ranges::find_if(CommandInfos, [&trimmedArgs](const auto& pair) {
+		return std::ranges::find(pair.second.aliases, trimmedArgs) != pair.second.aliases.end();
 		});
 
 	if (it != CommandInfos.end() && entity->GetGMLevel() >= it->second.requiredLevel) {

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -76,9 +76,10 @@ void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const st
 	constexpr size_t pageSize = 10;
 
 	std::string trimmedArgs = args;
-	trimmedArgs.erase(trimmedArgs.begin(), std::find_if_not(trimmedArgs.begin(), trimmedArgs.end(), [](unsigned char ch) {
+	trimmedArgs.erase(std::find_if_not(trimmedArgs.rbegin(), trimmedArgs.rend(), [](unsigned char ch) {
 		return std::isspace(ch);
-		}));
+		}).base(), trimmedArgs.end());
+
 	std::optional<uint32_t> parsedPage = GeneralUtils::TryParse<uint32_t>(trimmedArgs);
 	if (trimmedArgs.empty() || parsedPage.has_value()) {
 		size_t page = parsedPage.value_or(1);

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -19,28 +19,31 @@
 #include "dServer.h"
 
 namespace {
-	std::vector<Command> CommandInfos;
+	std::map<std::string, Command> CommandInfos;
 	std::map<std::string, Command> RegisteredCommands;
 }
 
 void SlashCommandHandler::RegisterCommand(Command command) {
-	if (command.aliases.empty()) {
-		LOG("Command %s has no aliases! Skipping!", command.help.c_str());
-		return;
-	}
+    if (command.aliases.empty()) {
+        LOG("Command %s has no aliases! Skipping!", command.help.c_str());
+        return;
+    }
 
-	for (const auto& alias : command.aliases) {
-		LOG_DEBUG("Registering command %s", alias.c_str());
-		auto [_, success] = RegisteredCommands.try_emplace(alias, command);
-		// Don't allow duplicate commands
-		if (!success) {
-			LOG_DEBUG("Command alias %s is already registered! Skipping!", alias.c_str());
-			continue;
-		}
-	}
+    for (const auto& alias : command.aliases) {
+        LOG_DEBUG("Registering command %s", alias.c_str());
+        auto [_, success] = RegisteredCommands.try_emplace(alias, command);
+        // Don't allow duplicate commands
+        if (!success) {
+            LOG_DEBUG("Command alias %s is already registered! Skipping!", alias.c_str());
+            continue;
+        }
+    }
 
-	CommandInfos.push_back(command);
-};
+    // Inserting into CommandInfos using the first alias as the key
+    if (!command.aliases.empty()) {
+        CommandInfos.insert(std::make_pair(command.aliases[0], command));
+    }
+}
 
 void SlashCommandHandler::HandleChatCommand(const std::u16string& chat, Entity* entity, const SystemAddress& sysAddr) {
 	auto input = GeneralUtils::UTF16ToWTF8(chat);
@@ -72,43 +75,6 @@ void SlashCommandHandler::HandleChatCommand(const std::u16string& chat, Entity* 
 	if (!error.empty()) {
 		GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(error));
 	}
-}
-
-// This commands in here so we can access the CommandInfos to display info
-void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
-	std::ostringstream feedback;
-	if (args.empty()) {
-		feedback << "----- Commands -----";
-		for (const auto& command : CommandInfos) {
-			// TODO: Limit displaying commands based on GM level they require
-			if (command.requiredLevel > entity->GetGMLevel()) continue;
-			LOG("Help command: %s", command.aliases[0].c_str());
-			feedback << "\n/" << command.aliases[0] << ": " << command.help;
-		}
-	} else {
-		bool foundCommand = false;
-		for (const auto& command : CommandInfos) {
-			if (std::ranges::find(command.aliases, args) == command.aliases.end()) continue;
-
-			if (entity->GetGMLevel() < command.requiredLevel) break;
-			foundCommand = true;
-			feedback << "----- " << command.aliases.at(0) << " -----\n";
-			// info can be a localizable string
-			feedback << command.info;
-			if (command.aliases.size() == 1) break;
-
-			feedback << "\nAliases: ";
-			for (size_t i = 0; i < command.aliases.size(); i++) {
-				if (i > 0) feedback << ", ";
-				feedback << command.aliases[i];
-			}
-		}
-
-		// Let GameMasters know if the command doesn't exist
-		if (!foundCommand && entity->GetGMLevel() > eGameMasterLevel::CIVILIAN) feedback << "Command " << std::quoted(args) << " does not exist!";
-	}
-	const auto feedbackStr = feedback.str();
-	if (!feedbackStr.empty()) GameMessages::SendSlashCommandFeedbackText(entity, GeneralUtils::ASCIIToUTF16(feedbackStr));
 }
 
 void SlashCommandHandler::SendAnnouncement(const std::string& title, const std::string& message) {
@@ -143,9 +109,9 @@ void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const st
     // Filter CommandInfos based on player's GM level
     std::vector<std::pair<std::string, Command>> accessibleCommands;
     std::copy_if(CommandInfos.begin(), CommandInfos.end(), std::back_inserter(accessibleCommands),
-                    [&](const auto& pair) {
-                        return pair.second.requiredLevel <= entity->GetGMLevel();
-                    });
+                [&](const auto& pair) {
+                    return pair.second.requiredLevel <= entity->GetGMLevel();
+                });
 
     // Calculate total number of pages based on accessible commands
     size_t totalPages = (accessibleCommands.size() + pageSize - 1) / pageSize;
@@ -153,7 +119,7 @@ void GMZeroCommands::Help(Entity* entity, const SystemAddress& sysAddr, const st
     size_t page = 1; // Default to first page
 
     // Check if page number is provided
-     if (!args.empty()) {
+    if (!args.empty()) {
         try {
             page = std::stoi(args);
         } catch (const std::exception&) {
@@ -952,11 +918,11 @@ void SlashCommandHandler::Startup() {
 	// Register GM Zero Commands
 
 	Command HelpCommand{
-		.help = "Display command info",
-		.info = "If a command is given, display detailed info on that command. Otherwise display a list of commands with short desctiptions.",
-		.aliases = { "help", "h"},
-		.handle = GMZeroCommands::Help,
-		.requiredLevel = eGameMasterLevel::CIVILIAN
+    	.help = "Display command info",
+    	.info = "If a command is given, display detailed info on that command. Otherwise display a list of commands with short descriptions.",
+    	.aliases = { "help", "h"},
+    	.handle = GMZeroCommands::Help,
+    	.requiredLevel = eGameMasterLevel::CIVILIAN
 	};
 	RegisterCommand(HelpCommand);
 
@@ -1069,3 +1035,4 @@ void SlashCommandHandler::Startup() {
 	RegisterCommand(InstanceInfoCommand);
 
 }
+


### PR DESCRIPTION

feat: Help Command Pagination

Description: Changed HelpCommand to now be sorted into different pages for commands, which should help to further help users to find the correct commands they are looking for without having to scroll through a list of 92 commands.

Motivation and Context: Recommendation from Aron, and my own experience reading through the /help command list.

How Has This Been Tested?: Running my server and using the /help command will return page 1 of the command list. Running /help 1 will as well, but /help 2 and so forth will return that respective page number of commands (currently 10 commands per page). If a user tries to enter a command higher than the number of pages, it will say it is an invalid page number. Additionally, commands will only show up given the user has the proper GMLevel to use that command.
