### PR TITLE
fix: prevent building in a folder which contains spaces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.25)
 project(Darkflame)
+
+# check if the path to the source directory contains a space
+if("${CMAKE_SOURCE_DIR}" MATCHES " ")
+	message(FATAL_ERROR "The server cannot build in the path (" ${CMAKE_SOURCE_DIR} ") because it contains a space. Please move the server to a path without spaces.")
+endif()
+
 include(CTest)
 
 set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
workaround for #815 

Good enough for now.  Tested that the inverse logic `if(NOT "${CMAKE_SOURCE_DIR}" MATCHES " ")` fails to build in a path without spaces.