### PR TITLE
fix: Falling Off Edge in Pet Puzzle

### DIFF
--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -210,23 +210,24 @@ void PetComponent::OnUse(Entity* originator) {
 	if (dpWorld::IsLoaded()) {
 		NiPoint3 attempt = petPosition + forward * interactionDistance;
 
-		float y = dpWorld::GetNavMesh()->GetHeightAtPoint(attempt);
+		NiPoint3 nearestPoint = dpWorld::GetNavMesh()->NearestPoint(attempt);
 
-		while (std::abs(y - petPosition.y) > 4 && interactionDistance > 10) {
+		while (std::abs(nearestPoint.y - petPosition.y) > 4 && interactionDistance > 10) {
 			const NiPoint3 forward = m_Parent->GetRotation().GetForwardVector();
 
 			attempt = originatorPosition + forward * interactionDistance;
 
-			y = dpWorld::GetNavMesh()->GetHeightAtPoint(attempt);
+			nearestPoint = dpWorld::GetNavMesh()->NearestPoint(attempt);
 
 			interactionDistance -= 0.5f;
 		}
 
-		position = attempt;
+		position = nearestPoint;
 	} else {
 		position = petPosition + forward * interactionDistance;
 	}
-
+	const auto [x, y, z] = position;
+	LOG("position.x %f position.y %f position.z %f", x, y, z);
 
 	auto rotation = NiQuaternion::LookAt(position, petPosition);
 

--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -32,6 +32,8 @@
 #include "eGameMasterLevel.h"
 #include "eMissionState.h"
 #include "dNavMesh.h"
+#include "eGameActivity.h"
+#include "eStateChangeType.h"
 
 std::unordered_map<LWOOBJID, LWOOBJID> PetComponent::currentActivities{};
 std::unordered_map<LWOOBJID, LWOOBJID> PetComponent::activePets{};
@@ -226,8 +228,6 @@ void PetComponent::OnUse(Entity* originator) {
 	} else {
 		position = petPosition + forward * interactionDistance;
 	}
-	const auto [x, y, z] = position;
-	LOG("position.x %f position.y %f position.z %f", x, y, z);
 
 	auto rotation = NiQuaternion::LookAt(position, petPosition);
 
@@ -247,11 +247,11 @@ void PetComponent::OnUse(Entity* originator) {
 		m_Parent->GetObjectID(),
 		LWOOBJID_EMPTY,
 		originator->GetObjectID(),
-		true,
+		false,
 		ePetTamingNotifyType::BEGIN,
-		petPosition,
-		position,
-		rotation,
+		NiPoint3Constant::ZERO,
+		NiPoint3Constant::ZERO,
+		NiQuaternion(0.0f, 0.0f, 0.0f, 0.0f),
 		UNASSIGNED_SYSTEM_ADDRESS
 	);
 
@@ -259,11 +259,18 @@ void PetComponent::OnUse(Entity* originator) {
 
 	m_Tamer = originator->GetObjectID();
 	SetStatus(5);
+	Game::entityManager->SerializeEntity(m_Parent);
 
 	currentActivities.insert_or_assign(m_Tamer, m_Parent->GetObjectID());
 
 	// Notify the start of a pet taming minigame
 	m_Parent->GetScript()->OnNotifyPetTamingMinigame(m_Parent, originator, ePetTamingNotifyType::BEGIN);
+
+	auto* characterComponent = originator->GetComponent<CharacterComponent>();
+	if (characterComponent != nullptr) {
+		characterComponent->SetCurrentActivity(eGameActivity::PET_TAMING);
+		Game::entityManager->SerializeEntity(originator);
+	}
 }
 
 void PetComponent::Update(float deltaTime) {
@@ -628,6 +635,11 @@ void PetComponent::RequestSetPetName(std::u16string name) {
 		UNASSIGNED_SYSTEM_ADDRESS
 	);
 
+	auto* characterComponent = tamer->GetComponent<CharacterComponent>();
+	if (characterComponent != nullptr) {
+		characterComponent->SetCurrentActivity(eGameActivity::NONE);
+		Game::entityManager->SerializeEntity(tamer);
+	}
 	GameMessages::SendTerminateInteraction(m_Tamer, eTerminateType::FROM_INTERACTION, m_Parent->GetObjectID());
 
 	auto* modelEntity = Game::entityManager->GetEntity(m_ModelId);
@@ -667,6 +679,11 @@ void PetComponent::ClientExitTamingMinigame(bool voluntaryExit) {
 		UNASSIGNED_SYSTEM_ADDRESS
 	);
 
+	auto* characterComponent = tamer->GetComponent<CharacterComponent>();
+	if (characterComponent != nullptr) {
+		characterComponent->SetCurrentActivity(eGameActivity::NONE);
+		Game::entityManager->SerializeEntity(tamer);
+	}
 	GameMessages::SendNotifyTamingModelLoadedOnServer(m_Tamer, tamer->GetSystemAddress());
 
 	GameMessages::SendTerminateInteraction(m_Tamer, eTerminateType::FROM_INTERACTION, m_Parent->GetObjectID());
@@ -713,6 +730,11 @@ void PetComponent::ClientFailTamingMinigame() {
 		UNASSIGNED_SYSTEM_ADDRESS
 	);
 
+	auto* characterComponent = tamer->GetComponent<CharacterComponent>();
+	if (characterComponent != nullptr) {
+		characterComponent->SetCurrentActivity(eGameActivity::NONE);
+		Game::entityManager->SerializeEntity(tamer);
+	}
 	GameMessages::SendNotifyTamingModelLoadedOnServer(m_Tamer, tamer->GetSystemAddress());
 
 	GameMessages::SendTerminateInteraction(m_Tamer, eTerminateType::FROM_INTERACTION, m_Parent->GetObjectID());

--- a/dNavigation/dNavMesh.cpp
+++ b/dNavigation/dNavMesh.cpp
@@ -126,9 +126,6 @@ NiPoint3 dNavMesh::NearestPoint(const NiPoint3& location, const float halfExtent
 		dtQueryFilter filter{};
 
 		auto hasPoly = m_NavQuery->findNearestPoly(pos, polyPickExt, &filter, &nearestRef, nearestPoint);
-		toReturn.x = nearestPoint[0];
-		toReturn.y = nearestPoint[1];
-		toReturn.z = nearestPoint[2];
 		if (hasPoly != DT_SUCCESS) {
 			toReturn = location;
 		} else {

--- a/dNavigation/dNavMesh.cpp
+++ b/dNavigation/dNavMesh.cpp
@@ -112,6 +112,34 @@ void dNavMesh::LoadNavmesh() {
 	m_NavMesh = mesh;
 }
 
+NiPoint3 dNavMesh::NearestPoint(const NiPoint3& location, const float halfExtent) const {
+	NiPoint3 toReturn = location;
+	if (m_NavMesh != nullptr) {
+		float pos[3];
+		pos[0] = location.x;
+		pos[1] = location.y;
+		pos[2] = location.z;
+
+		dtPolyRef nearestRef = 0;
+		float polyPickExt[3] = { halfExtent, halfExtent, halfExtent };
+		float nearestPoint[3] = { 0.0f, 0.0f, 0.0f };
+		dtQueryFilter filter{};
+
+		auto hasPoly = m_NavQuery->findNearestPoly(pos, polyPickExt, &filter, &nearestRef, nearestPoint);
+		toReturn.x = nearestPoint[0];
+		toReturn.y = nearestPoint[1];
+		toReturn.z = nearestPoint[2];
+		if (hasPoly != DT_SUCCESS) {
+			toReturn = location;
+		} else {
+			toReturn.x = nearestPoint[0];
+			toReturn.y = nearestPoint[1];
+			toReturn.z = nearestPoint[2];
+		}
+	}
+	return toReturn;
+}
+
 float dNavMesh::GetHeightAtPoint(const NiPoint3& location, const float halfExtentsHeight) const {
 	if (m_NavMesh == nullptr) {
 		return location.y;

--- a/dNavigation/dNavMesh.h
+++ b/dNavigation/dNavMesh.h
@@ -21,7 +21,7 @@ public:
 
 	/**
 	 * Get the height at a point
-	 * 
+	 *
 	 * @param location The location to check for height at. This is the center of the search area.
 	 * @param halfExtentsHeight The half extents height of the search area. This is the distance from the center to the top and bottom of the search area.
 	 * The larger the value of halfExtentsHeight is, the larger the performance cost of the query.
@@ -29,7 +29,7 @@ public:
 	 */
 	float GetHeightAtPoint(const NiPoint3& location, const float halfExtentsHeight = 32.0f) const;
 	std::vector<NiPoint3> GetPath(const NiPoint3& startPos, const NiPoint3& endPos, float speed = 10.0f);
-
+	NiPoint3 NearestPoint(const NiPoint3& location, const float halfExtent = 32.0f) const;
 	bool IsNavmeshLoaded() { return m_NavMesh != nullptr; }
 
 private:


### PR DESCRIPTION
Issue #547 
Description: Modified PetComponents.cpp, dNavMesh.cpp and dNavMesh.h to include a new function nearest point which helps to prevent players from falling off a cliff or an edge when taming a pet. It will instead try to keep the player on the nearest navMesh (terrain)

Motivation and Context: Linked issue from EmosewaMC to work on

Type of Changes: Added new function to dNavMesh and its respective includes in dNavMesh.h. Made changes to petcomponent OnUse (which is used to start a player taming pet interaction).

How Has This Been Tested? : Taming a pet, such as the Goat in Forbidden Valley while on the edge of a cliff, which resulted in keeping the player as close to the edge as necessary to prevent them from falling off. This allows (assuming the camera angle and perspective does not get wacky, which is another WIP). Also testing taming pets right next to ledges, which prevents falling through the wall or clipping through the wall as previously reported.
