### PR TITLE
feat: add remaining item extra save data to saving

### DIFF
--- a/dCommon/LDFFormat.h
+++ b/dCommon/LDFFormat.h
@@ -31,22 +31,22 @@ public:
 
 	virtual ~LDFBaseData() {}
 
-	virtual void WriteToPacket(RakNet::BitStream& packet) = 0;
+	virtual void WriteToPacket(RakNet::BitStream& packet) const = 0;
 
-	virtual const std::u16string& GetKey() = 0;
+	virtual const std::u16string& GetKey() const = 0;
 
-	virtual eLDFType GetValueType() = 0;
+	virtual eLDFType GetValueType() const = 0;
 
 	/** Gets a string from the key/value pair
 	 * @param includeKey Whether or not to include the key in the data
 	 * @param includeTypeId Whether or not to include the type id in the data
 	 * @return The string representation of the data
 	 */
-	virtual std::string GetString(bool includeKey = true, bool includeTypeId = true) = 0;
+	virtual std::string GetString(bool includeKey = true, bool includeTypeId = true) const = 0;
 
-	virtual std::string GetValueAsString() = 0;
+	virtual std::string GetValueAsString() const = 0;
 
-	virtual LDFBaseData* Copy() = 0;
+	virtual LDFBaseData* Copy() const = 0;
 
 	/**
 	 * Given an input string, return the data as a LDF key.
@@ -62,7 +62,7 @@ private:
 	T value;
 
 	//! Writes the key to the packet
-	void WriteKey(RakNet::BitStream& packet) {
+	void WriteKey(RakNet::BitStream& packet) const {
 		packet.Write<uint8_t>(this->key.length() * sizeof(uint16_t));
 		for (uint32_t i = 0; i < this->key.length(); ++i) {
 			packet.Write<uint16_t>(this->key[i]);
@@ -70,7 +70,7 @@ private:
 	}
 
 	//! Writes the value to the packet
-	void WriteValue(RakNet::BitStream& packet) {
+	void WriteValue(RakNet::BitStream& packet) const {
 		packet.Write<uint8_t>(this->GetValueType());
 		packet.Write(this->value);
 	}
@@ -90,7 +90,7 @@ public:
 	/*!
 	  \return The value
 	 */
-	const T& GetValue(void) { return this->value; }
+	const T& GetValue(void) const { return this->value; }
 
 	//! Sets the value
 	/*!
@@ -102,13 +102,13 @@ public:
 	/*!
 	  \return The value string
 	 */
-	std::string GetValueString(void) { return ""; }
+	std::string GetValueString(void) const { return ""; }
 
 	//! Writes the data to a packet
 	/*!
 	  \param packet The packet
 	 */
-	void WriteToPacket(RakNet::BitStream& packet) override {
+	void WriteToPacket(RakNet::BitStream& packet) const override {
 		this->WriteKey(packet);
 		this->WriteValue(packet);
 	}
@@ -117,13 +117,13 @@ public:
 	/*!
 	 \return The key
 	 */
-	const std::u16string& GetKey(void) override { return this->key; }
+	const std::u16string& GetKey(void) const override { return this->key; }
 
 	//! Gets the LDF Type
 	/*!
 	 \return The LDF value type
 	 */
-	eLDFType GetValueType(void) override { return LDF_TYPE_UNKNOWN; }
+	eLDFType GetValueType(void) const override { return LDF_TYPE_UNKNOWN; }
 
 	//! Gets the string data
 	/*!
@@ -131,7 +131,7 @@ public:
 	  \param includeTypeId Whether or not to include the type id in the data
 	  \return The string representation of the data
 	 */
-	std::string GetString(const bool includeKey = true, const bool includeTypeId = true) override {
+	std::string GetString(const bool includeKey = true, const bool includeTypeId = true) const override {
 		if (GetValueType() == -1) {
 			return GeneralUtils::UTF16ToWTF8(this->key) + "=-1:<server variable>";
 		}
@@ -154,11 +154,11 @@ public:
 		return stream.str();
 	}
 
-	std::string GetValueAsString() override {
+	std::string GetValueAsString() const override {
 		return this->GetValueString();
 	}
 
-	LDFBaseData* Copy() override {
+	LDFBaseData* Copy() const override {
 		return new LDFData<T>(key, value);
 	}
 
@@ -166,19 +166,19 @@ public:
 };
 
 // LDF Types
-template<> inline eLDFType LDFData<std::u16string>::GetValueType(void) { return LDF_TYPE_UTF_16; };
-template<> inline eLDFType LDFData<int32_t>::GetValueType(void) { return LDF_TYPE_S32; };
-template<> inline eLDFType LDFData<float>::GetValueType(void) { return LDF_TYPE_FLOAT; };
-template<> inline eLDFType LDFData<double>::GetValueType(void) { return LDF_TYPE_DOUBLE; };
-template<> inline eLDFType LDFData<uint32_t>::GetValueType(void) { return LDF_TYPE_U32; };
-template<> inline eLDFType LDFData<bool>::GetValueType(void) { return LDF_TYPE_BOOLEAN; };
-template<> inline eLDFType LDFData<uint64_t>::GetValueType(void) { return LDF_TYPE_U64; };
-template<> inline eLDFType LDFData<LWOOBJID>::GetValueType(void) { return LDF_TYPE_OBJID; };
-template<> inline eLDFType LDFData<std::string>::GetValueType(void) { return LDF_TYPE_UTF_8; };
+template<> inline eLDFType LDFData<std::u16string>::GetValueType(void) const { return LDF_TYPE_UTF_16; };
+template<> inline eLDFType LDFData<int32_t>::GetValueType(void) const { return LDF_TYPE_S32; };
+template<> inline eLDFType LDFData<float>::GetValueType(void) const { return LDF_TYPE_FLOAT; };
+template<> inline eLDFType LDFData<double>::GetValueType(void) const { return LDF_TYPE_DOUBLE; };
+template<> inline eLDFType LDFData<uint32_t>::GetValueType(void) const { return LDF_TYPE_U32; };
+template<> inline eLDFType LDFData<bool>::GetValueType(void) const { return LDF_TYPE_BOOLEAN; };
+template<> inline eLDFType LDFData<uint64_t>::GetValueType(void) const { return LDF_TYPE_U64; };
+template<> inline eLDFType LDFData<LWOOBJID>::GetValueType(void) const { return LDF_TYPE_OBJID; };
+template<> inline eLDFType LDFData<std::string>::GetValueType(void) const { return LDF_TYPE_UTF_8; };
 
 // The specialized version for std::u16string (UTF-16)
 template<>
-inline void LDFData<std::u16string>::WriteValue(RakNet::BitStream& packet) {
+inline void LDFData<std::u16string>::WriteValue(RakNet::BitStream& packet) const {
 	packet.Write<uint8_t>(this->GetValueType());
 
 	packet.Write<uint32_t>(this->value.length());
@@ -189,7 +189,7 @@ inline void LDFData<std::u16string>::WriteValue(RakNet::BitStream& packet) {
 
 // The specialized version for bool
 template<>
-inline void LDFData<bool>::WriteValue(RakNet::BitStream& packet) {
+inline void LDFData<bool>::WriteValue(RakNet::BitStream& packet) const {
 	packet.Write<uint8_t>(this->GetValueType());
 
 	packet.Write<uint8_t>(this->value);
@@ -197,7 +197,7 @@ inline void LDFData<bool>::WriteValue(RakNet::BitStream& packet) {
 
 // The specialized version for std::string (UTF-8)
 template<>
-inline void LDFData<std::string>::WriteValue(RakNet::BitStream& packet) {
+inline void LDFData<std::string>::WriteValue(RakNet::BitStream& packet) const {
 	packet.Write<uint8_t>(this->GetValueType());
 
 	packet.Write<uint32_t>(this->value.length());
@@ -206,18 +206,18 @@ inline void LDFData<std::string>::WriteValue(RakNet::BitStream& packet) {
 	}
 }
 
-template<> inline std::string LDFData<std::u16string>::GetValueString() {
+template<> inline std::string LDFData<std::u16string>::GetValueString() const {
 	return GeneralUtils::UTF16ToWTF8(this->value, this->value.size());
 }
 
-template<> inline std::string LDFData<int32_t>::GetValueString() { return std::to_string(this->value); }
-template<> inline std::string LDFData<float>::GetValueString() { return std::to_string(this->value); }
-template<> inline std::string LDFData<double>::GetValueString() { return std::to_string(this->value); }
-template<> inline std::string LDFData<uint32_t>::GetValueString() { return std::to_string(this->value); }
-template<> inline std::string LDFData<bool>::GetValueString() { return std::to_string(this->value); }
-template<> inline std::string LDFData<uint64_t>::GetValueString() { return std::to_string(this->value); }
-template<> inline std::string LDFData<LWOOBJID>::GetValueString() { return std::to_string(this->value); }
+template<> inline std::string LDFData<int32_t>::GetValueString() const { return std::to_string(this->value); }
+template<> inline std::string LDFData<float>::GetValueString() const { return std::to_string(this->value); }
+template<> inline std::string LDFData<double>::GetValueString() const { return std::to_string(this->value); }
+template<> inline std::string LDFData<uint32_t>::GetValueString() const { return std::to_string(this->value); }
+template<> inline std::string LDFData<bool>::GetValueString() const { return std::to_string(this->value); }
+template<> inline std::string LDFData<uint64_t>::GetValueString() const { return std::to_string(this->value); }
+template<> inline std::string LDFData<LWOOBJID>::GetValueString() const { return std::to_string(this->value); }
 
-template<> inline std::string LDFData<std::string>::GetValueString() { return this->value; }
+template<> inline std::string LDFData<std::string>::GetValueString() const { return this->value; }
 
 #endif  //!__LDFFORMAT__H__

--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -38,6 +38,38 @@
 #include "CDObjectSkillsTable.h"
 #include "CDSkillBehaviorTable.h"
 
+namespace {
+	const std::map<std::string, std::string> ExtraSettingSaveAbbreviations = {
+		{ "assemblyPartLOTs", "ma" },
+		{ "blueprintID", "b" },
+		{ "userModelID", "ui" },
+		{ "userModelName", "un" },
+		{ "userModelDesc", "ud" },
+		{ "userModelHasBhvr", "ub" },
+		{ "userModelBehaviors", "ubh" },
+		{ "userModelBehaviorSourceID", "ubs" },
+		{ "userModelPhysicsType", "up" },
+		{ "userModelMod", "um" },
+		{ "userModelOpt", "uo" },
+		{ "reforgedLOT", "rl" },
+	};
+
+	const std::map<std::string, std::string> ExtraSettingLoadAbbreviations = {
+		{ "ma", "assemblyPartLOTs" },
+		{ "b", "blueprintID" },
+		{ "ui", "userModelID" },
+		{ "un", "userModelName" },
+		{ "ud", "userModelDesc" },
+		{ "ub", "userModelHasBhvr" },
+		{ "ubh", "userModelBehaviors" },
+		{ "ubs", "userModelBehaviorSourceID" },
+		{ "up", "userModelPhysicsType" },
+		{ "um", "userModelMod" },
+		{ "uo", "userModelOpt" },
+		{ "rl", "reforgedLOT" },
+	};
+}
+
 InventoryComponent::InventoryComponent(Entity* parent) : Component(parent) {
 	this->m_Dirty = true;
 	this->m_Equipped = {};
@@ -1624,3 +1656,10 @@ bool InventoryComponent::SetSkill(BehaviorSlot slot, uint32_t skillId){
 	return true;
 }
 
+void InventoryComponent::SaveItemConfigXml(const tinyxml2::XMLElement& x, Item* item) {
+
+}
+
+void InventoryComponent::LoadItemConfigXml(const tinyxml2::XMLElement& x, Item* item) {
+
+}

--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -477,6 +477,10 @@ private:
 	 * @param document the xml doc to load from
 	 */
 	void UpdatePetXml(tinyxml2::XMLDocument& document);
+
+	void SaveItemConfigXml(const tinyxml2::XMLElement& x, Item* item);
+
+	void LoadItemConfigXml(const tinyxml2::XMLElement& x, Item* item);
 };
 
 #endif

--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -478,9 +478,9 @@ private:
 	 */
 	void UpdatePetXml(tinyxml2::XMLDocument& document);
 
-	void SaveItemConfigXml(const tinyxml2::XMLElement& x, Item* item);
+	void SaveItemConfigXml(tinyxml2::XMLElement& i, const Item* const item) const;
 
-	void LoadItemConfigXml(const tinyxml2::XMLElement& x, Item* item);
+	void LoadItemConfigXml(const tinyxml2::XMLElement& i, Item* const item);
 };
 
 #endif

--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -477,10 +477,6 @@ private:
 	 * @param document the xml doc to load from
 	 */
 	void UpdatePetXml(tinyxml2::XMLDocument& document);
-
-	void SaveItemConfigXml(tinyxml2::XMLElement& i, const Item* const item) const;
-
-	void LoadItemConfigXml(const tinyxml2::XMLElement& i, Item* const item);
 };
 
 #endif

--- a/dGame/dInventory/Item.cpp
+++ b/dGame/dInventory/Item.cpp
@@ -28,7 +28,7 @@
 #include "CDPackageComponentTable.h"
 
 namespace {
-	const std::map<std::string, std::string> ExtraSettingSaveAbbreviations = {
+	const std::map<std::string, std::string> ExtraSettingAbbreviations = {
 		{ "assemblyPartLOTs", "ma" },
 		{ "blueprintID", "b" },
 		{ "userModelID", "ui" },
@@ -41,21 +41,6 @@ namespace {
 		{ "userModelMod", "um" },
 		{ "userModelOpt", "uo" },
 		{ "reforgedLOT", "rl" },
-	};
-
-	const std::map<std::string, std::string> ExtraSettingLoadAbbreviations = {
-		{ "ma", "assemblyPartLOTs" },
-		{ "b", "blueprintID" },
-		{ "ui", "userModelID" },
-		{ "un", "userModelName" },
-		{ "ud", "userModelDesc" },
-		{ "ub", "userModelHasBhvr" },
-		{ "ubh", "userModelBehaviors" },
-		{ "ubs", "userModelBehaviorSourceID" },
-		{ "up", "userModelPhysicsType" },
-		{ "um", "userModelMod" },
-		{ "uo", "userModelOpt" },
-		{ "rl", "reforgedLOT" },
 	};
 }
 
@@ -557,8 +542,8 @@ void Item::SaveConfigXml(tinyxml2::XMLElement& i) const {
 
 	for (const auto* config : this->config) {
 		const auto& key = GeneralUtils::UTF16ToWTF8(config->GetKey());
-		const auto saveKey = ExtraSettingSaveAbbreviations.find(key);
-		if (saveKey == ExtraSettingSaveAbbreviations.end()) {
+		const auto saveKey = ExtraSettingAbbreviations.find(key);
+		if (saveKey == ExtraSettingAbbreviations.end()) {
 			continue;
 		}
 
@@ -575,11 +560,11 @@ void Item::LoadConfigXml(const tinyxml2::XMLElement& i) {
 	const auto* x = i.FirstChildElement("x");
 	if (!x) return;
 
-	for (const auto& pair : ExtraSettingLoadAbbreviations) {
-		const auto* data = x->Attribute(pair.first.c_str());
+	for (const auto& pair : ExtraSettingAbbreviations) {
+		const auto* data = x->Attribute(pair.second.c_str());
 		if (!data) continue;
 
-		const auto value = pair.second + "=" + data;
+		const auto value = pair.first + "=" + data;
 		config.push_back(LDFBaseData::DataFromString(value));
 	}
 }

--- a/dGame/dInventory/Item.cpp
+++ b/dGame/dInventory/Item.cpp
@@ -27,6 +27,38 @@
 #include "CDComponentsRegistryTable.h"
 #include "CDPackageComponentTable.h"
 
+namespace {
+	const std::map<std::string, std::string> ExtraSettingSaveAbbreviations = {
+		{ "assemblyPartLOTs", "ma" },
+		{ "blueprintID", "b" },
+		{ "userModelID", "ui" },
+		{ "userModelName", "un" },
+		{ "userModelDesc", "ud" },
+		{ "userModelHasBhvr", "ub" },
+		{ "userModelBehaviors", "ubh" },
+		{ "userModelBehaviorSourceID", "ubs" },
+		{ "userModelPhysicsType", "up" },
+		{ "userModelMod", "um" },
+		{ "userModelOpt", "uo" },
+		{ "reforgedLOT", "rl" },
+	};
+
+	const std::map<std::string, std::string> ExtraSettingLoadAbbreviations = {
+		{ "ma", "assemblyPartLOTs" },
+		{ "b", "blueprintID" },
+		{ "ui", "userModelID" },
+		{ "un", "userModelName" },
+		{ "ud", "userModelDesc" },
+		{ "ub", "userModelHasBhvr" },
+		{ "ubh", "userModelBehaviors" },
+		{ "ubs", "userModelBehaviorSourceID" },
+		{ "up", "userModelPhysicsType" },
+		{ "um", "userModelMod" },
+		{ "uo", "userModelOpt" },
+		{ "rl", "reforgedLOT" },
+	};
+}
+
 Item::Item(const LWOOBJID id, const LOT lot, Inventory* inventory, const uint32_t slot, const uint32_t count, const bool bound, const std::vector<LDFBaseData*>& config, const LWOOBJID parent, LWOOBJID subKey, eLootSourceType lootSourceType) {
 	if (!Inventory::IsValidItem(lot)) {
 		return;
@@ -255,7 +287,7 @@ bool Item::Consume() {
 
 	auto skills = skillsTable->Query([this](const CDObjectSkills entry) {
 		return entry.objectTemplate == static_cast<uint32_t>(lot);
-	});
+		});
 
 	auto success = false;
 
@@ -518,4 +550,36 @@ Item::~Item() {
 	}
 
 	config.clear();
+}
+
+void Item::SaveConfigXml(tinyxml2::XMLElement& i) const {
+	tinyxml2::XMLElement* x = nullptr;
+
+	for (const auto* config : this->config) {
+		const auto& key = GeneralUtils::UTF16ToWTF8(config->GetKey());
+		const auto saveKey = ExtraSettingSaveAbbreviations.find(key);
+		if (saveKey == ExtraSettingSaveAbbreviations.end()) {
+			continue;
+		}
+
+		if (!x) {
+			x = i.InsertNewChildElement("x");
+		}
+
+		const auto dataToSave = config->GetString(false);
+		x->SetAttribute(saveKey->second.c_str(), dataToSave.c_str());
+	}
+}
+
+void Item::LoadConfigXml(const tinyxml2::XMLElement& i) {
+	const auto* x = i.FirstChildElement("x");
+	if (!x) return;
+
+	for (const auto& pair : ExtraSettingLoadAbbreviations) {
+		const auto* data = x->Attribute(pair.first.c_str());
+		if (!data) continue;
+
+		const auto value = pair.second + "=" + data;
+		config.push_back(LDFBaseData::DataFromString(value));
+	}
 }

--- a/dGame/dInventory/Item.cpp
+++ b/dGame/dInventory/Item.cpp
@@ -122,6 +122,10 @@ uint32_t Item::GetSlot() const {
 	return slot;
 }
 
+std::vector<LDFBaseData*> Item::GetConfig() const {
+	return config;
+}
+
 std::vector<LDFBaseData*>& Item::GetConfig() {
 	return config;
 }

--- a/dGame/dInventory/Item.h
+++ b/dGame/dInventory/Item.h
@@ -9,6 +9,10 @@
 #include "eInventoryType.h"
 #include "eLootSourceType.h"
 
+namespace tinyxml2 {
+	class XMLElement;
+};
+
 /**
  * An item that can be stored in an inventory and optionally consumed or equipped
  * TODO: ideally this should be a component
@@ -219,6 +223,10 @@ public:
 	 * Removes the item from the linked inventory
 	 */
 	void RemoveFromInventory();
+
+	void SaveConfigXml(tinyxml2::XMLElement& i) const;
+
+	void LoadConfigXml(const tinyxml2::XMLElement& i);
 
 private:
 	/**

--- a/dGame/dInventory/Item.h
+++ b/dGame/dInventory/Item.h
@@ -117,6 +117,12 @@ public:
 	std::vector<LDFBaseData*>& GetConfig();
 
 	/**
+	 * Returns current config info for this item, e.g. for rockets
+	 * @return current config info for this item
+	 */
+	std::vector<LDFBaseData*> GetConfig() const;
+
+	/**
 	 * Returns the database info for this item
 	 * @return the database info for this item
 	 */


### PR DESCRIPTION
Tested that the modular assembly LOTs extra data still saves rockets and cars correctly and loads them as well.

This is necessary for future PRs relating to properties which heavily rely on this feature.