### PR TITLE
fix: Ignore Script L_AG_SENTINAL_GUARD.lua

### DIFF
--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -700,7 +700,8 @@ CppScripts::Script* const CppScripts::GetScript(Entity* parent, const std::strin
 			(scriptName == "scripts\\02_server\\Enemy\\General\\L_BASE_ENEMY_SPIDERLING.lua") ||
 			(scriptName == "scripts\\ai\\FV\\L_ACT_NINJA_STUDENT.lua") ||
 			(scriptName == "scripts\\ai\\WILD\\L_WILD_GF_FROG.lua") ||
-			(scriptName == "scripts\\empty.lua")
+			(scriptName == "scripts\\empty.lua") ||
+			(scriptName == "scripts\\ai\\AG\\L_AG_SENTINEL_GUARD.lua")
 			)) LOG_DEBUG("LOT %i attempted to load CppScript for '%s', but returned InvalidScript.", parent->GetLOT(), scriptName.c_str());
 	}
 


### PR DESCRIPTION
Fixes #746 

Added `scripts\ai\AG\L_AG_SENTINEL_GUARD.lua` to the ignore list in CppScripts.cpp, as it was determined that the lua was not necessary to be included. A note will be made regarding this.

This fix obviously only addresses this single script, not the entirety of Issue #746

Tested that the script is ignored when running debug mode using sharedconfig.ini

no screenshots for you i had witnesses