### PR TITLE
Chore: split VE script up

### DIFF
--- a/dScripts/CppScripts.cpp
+++ b/dScripts/CppScripts.cpp
@@ -14,6 +14,7 @@
 #include "AgShipPlayerDeathTrigger.h"
 #include "AgShipPlayerShockServer.h"
 #include "AgSpaceStuff.h"
+#include "AgShipShake.h"
 #include "AgImagSmashable.h"
 #include "NpcNpSpacemanBob.h"
 #include "StoryBoxInteractServer.h"
@@ -341,6 +342,7 @@ namespace {
 		{ "scripts\\ai\\AG\\L_AG_SHIP_PLAYER_DEATH_TRIGGER.lua", []() { return new AgShipPlayerDeathTrigger(); } },
 		{"scripts\\ai\\NP\\L_NPC_NP_SPACEMAN_BOB.lua", []() { return new NpcNpSpacemanBob(); } },
 		{"scripts\\ai\\AG\\L_AG_SPACE_STUFF.lua", []() { return new AgSpaceStuff();} },
+		{"scripts\\ai\\AG\\L_AG_SHIP_SHAKE.lua", []() { return new AgShipShake();}},
 		{"scripts\\ai\\AG\\L_AG_SHIP_PLAYER_SHOCK_SERVER.lua", []() { return new AgShipPlayerShockServer();} },
 		{"scripts\\ai\\AG\\L_AG_IMAG_SMASHABLE.lua", []() { return new AgImagSmashable();} },
 		{"scripts\\02_server\\Map\\General\\L_STORY_BOX_INTERACT_SERVER.lua", []() { return new StoryBoxInteractServer();} },

--- a/dScripts/ai/AG/AgShipShake.cpp
+++ b/dScripts/ai/AG/AgShipShake.cpp
@@ -1,0 +1,105 @@
+#include "AgShipShake.h"
+#include "EntityInfo.h"
+#include "GeneralUtils.h"
+#include "GameMessages.h"
+#include "EntityManager.h"
+#include "RenderComponent.h"
+#include "Entity.h"
+
+void AgShipShake::OnStartup(Entity* self) {
+	EntityInfo info{};
+
+	info.pos = { -418, 585, -30 };
+	info.lot = 33;
+	info.spawnerID = self->GetObjectID();
+
+	auto* ref = Game::entityManager->CreateEntity(info);
+
+	Game::entityManager->ConstructEntity(ref);
+
+	self->SetVar(u"ShakeObject", ref->GetObjectID());
+
+	self->AddTimer("ShipShakeIdle", 2.0f);
+	self->SetVar(u"RandomTime", 10);
+}
+
+void AgShipShake::OnTimerDone(Entity* self, std::string timerName) {
+	if (timerName == "FloaterScale") {
+		int scaleType = GeneralUtils::GenerateRandomNumber<int>(1, 5);
+
+		RenderComponent::PlayAnimation(self, u"scale_0" + GeneralUtils::to_u16string(scaleType));
+		self->AddTimer("FloaterPath", 0.4);
+	} else if (timerName == "FloaterPath") {
+		int pathType = GeneralUtils::GenerateRandomNumber<int>(1, 4);
+		int randTime = GeneralUtils::GenerateRandomNumber<int>(20, 25);
+
+		RenderComponent::PlayAnimation(self, u"path_0" + (GeneralUtils::to_u16string(pathType)));
+		self->AddTimer("FloaterScale", randTime);
+	} else if (timerName == "ShipShakeExplode") {
+		DoShake(self, true);
+	} else if (timerName == "ShipShakeIdle") {
+		DoShake(self, false);
+	}
+}
+
+void AgShipShake::DoShake(Entity* self, bool explodeIdle) {
+
+	if (!explodeIdle) {
+		auto* ref = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"ShakeObject"));
+
+		const auto randomTime = self->GetVar<int>(u"RandomTime");
+		auto time = GeneralUtils::GenerateRandomNumber<int>(0, randomTime + 1);
+
+		if (time < randomTime / 2) {
+			time += randomTime / 2;
+		}
+
+		self->AddTimer("ShipShakeIdle", static_cast<float>(time));
+
+		if (ref)
+			GameMessages::SendPlayEmbeddedEffectOnAllClientsNearObject(ref, FXName, ref->GetObjectID(), 500.0f);
+
+		auto* debrisObject = GetEntityInGroup(DebrisFX);
+
+		if (debrisObject)
+			GameMessages::SendPlayFXEffect(debrisObject, -1, u"DebrisFall", "Debris", LWOOBJID_EMPTY, 1.0f, 1.0f, true);
+
+		const auto randomFx = GeneralUtils::GenerateRandomNumber<int>(0, 3);
+
+		auto* shipFxObject = GetEntityInGroup(ShipFX);
+		if (shipFxObject) {
+			std::string effectType = "shipboom" + std::to_string(randomFx);
+			GameMessages::SendPlayFXEffect(shipFxObject, 559, GeneralUtils::ASCIIToUTF16(effectType), "FX", LWOOBJID_EMPTY, 1.0f, 1.0f, true);
+		}
+
+		self->AddTimer("ShipShakeExplode", 5.0f);
+
+		auto* shipFxObject2 = GetEntityInGroup(ShipFX2);
+		if (shipFxObject2)
+			RenderComponent::PlayAnimation(shipFxObject2, u"explosion");
+	} else {
+		auto* shipFxObject = GetEntityInGroup(ShipFX);
+		auto* shipFxObject2 = GetEntityInGroup(ShipFX2);
+
+		if (shipFxObject)
+			RenderComponent::PlayAnimation(shipFxObject, u"idle");
+
+		if (shipFxObject2)
+			RenderComponent::PlayAnimation(shipFxObject2, u"idle");
+	}
+}
+
+Entity* AgShipShake::GetEntityInGroup(const std::string& group) {
+	auto entities = Game::entityManager->GetEntitiesInGroup(group);
+	Entity* en = nullptr;
+
+	for (auto entity : entities) {
+		if (entity) {
+			en = entity;
+			break;
+		}
+	}
+
+	return en;
+}
+

--- a/dScripts/ai/AG/AgShipShake.cpp
+++ b/dScripts/ai/AG/AgShipShake.cpp
@@ -24,27 +24,7 @@ void AgShipShake::OnStartup(Entity* self) {
 }
 
 void AgShipShake::OnTimerDone(Entity* self, std::string timerName) {
-	if (timerName == "FloaterScale") {
-		int scaleType = GeneralUtils::GenerateRandomNumber<int>(1, 5);
-
-		RenderComponent::PlayAnimation(self, u"scale_0" + GeneralUtils::to_u16string(scaleType));
-		self->AddTimer("FloaterPath", 0.4);
-	} else if (timerName == "FloaterPath") {
-		int pathType = GeneralUtils::GenerateRandomNumber<int>(1, 4);
-		int randTime = GeneralUtils::GenerateRandomNumber<int>(20, 25);
-
-		RenderComponent::PlayAnimation(self, u"path_0" + (GeneralUtils::to_u16string(pathType)));
-		self->AddTimer("FloaterScale", randTime);
-	} else if (timerName == "ShipShakeExplode") {
-		DoShake(self, true);
-	} else if (timerName == "ShipShakeIdle") {
-		DoShake(self, false);
-	}
-}
-
-void AgShipShake::DoShake(Entity* self, bool explodeIdle) {
-
-	if (!explodeIdle) {
+	if (timerName == "ShipShakeIdle") {
 		auto* ref = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"ShakeObject"));
 
 		const auto randomTime = self->GetVar<int>(u"RandomTime");
@@ -77,15 +57,13 @@ void AgShipShake::DoShake(Entity* self, bool explodeIdle) {
 		auto* shipFxObject2 = GetEntityInGroup(ShipFX2);
 		if (shipFxObject2)
 			RenderComponent::PlayAnimation(shipFxObject2, u"explosion");
-	} else {
+	} else if (timerName == "ShipShakeExplode") {
 		auto* shipFxObject = GetEntityInGroup(ShipFX);
 		auto* shipFxObject2 = GetEntityInGroup(ShipFX2);
 
-		if (shipFxObject)
-			RenderComponent::PlayAnimation(shipFxObject, u"idle");
+		if (shipFxObject) { RenderComponent::PlayAnimation(shipFxObject, u"idle"); }
 
-		if (shipFxObject2)
-			RenderComponent::PlayAnimation(shipFxObject2, u"idle");
+		if (shipFxObject2) { RenderComponent::PlayAnimation(shipFxObject2, u"idle"); }
 	}
 }
 

--- a/dScripts/ai/AG/AgShipShake.cpp
+++ b/dScripts/ai/AG/AgShipShake.cpp
@@ -24,6 +24,9 @@ void AgShipShake::OnStartup(Entity* self) {
 }
 
 void AgShipShake::OnTimerDone(Entity* self, std::string timerName) {
+	auto* shipFxObject = GetEntityInGroup(ShipFX);
+	auto* shipFxObject2 = GetEntityInGroup(ShipFX2);
+	auto* debrisObject = GetEntityInGroup(DebrisFX);
 	if (timerName == "ShipShakeIdle") {
 		auto* ref = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"ShakeObject"));
 
@@ -39,14 +42,12 @@ void AgShipShake::OnTimerDone(Entity* self, std::string timerName) {
 		if (ref)
 			GameMessages::SendPlayEmbeddedEffectOnAllClientsNearObject(ref, FXName, ref->GetObjectID(), 500.0f);
 
-		auto* debrisObject = GetEntityInGroup(DebrisFX);
 
 		if (debrisObject)
 			GameMessages::SendPlayFXEffect(debrisObject, -1, u"DebrisFall", "Debris", LWOOBJID_EMPTY, 1.0f, 1.0f, true);
 
 		const auto randomFx = GeneralUtils::GenerateRandomNumber<int>(0, 3);
 
-		auto* shipFxObject = GetEntityInGroup(ShipFX);
 		if (shipFxObject) {
 			std::string effectType = "shipboom" + std::to_string(randomFx);
 			GameMessages::SendPlayFXEffect(shipFxObject, 559, GeneralUtils::ASCIIToUTF16(effectType), "FX", LWOOBJID_EMPTY, 1.0f, 1.0f, true);
@@ -54,15 +55,9 @@ void AgShipShake::OnTimerDone(Entity* self, std::string timerName) {
 
 		self->AddTimer("ShipShakeExplode", 5.0f);
 
-		auto* shipFxObject2 = GetEntityInGroup(ShipFX2);
-		if (shipFxObject2)
-			RenderComponent::PlayAnimation(shipFxObject2, u"explosion");
+		if (shipFxObject2) { RenderComponent::PlayAnimation(shipFxObject2, u"explosion"); }
 	} else if (timerName == "ShipShakeExplode") {
-		auto* shipFxObject = GetEntityInGroup(ShipFX);
-		auto* shipFxObject2 = GetEntityInGroup(ShipFX2);
-
 		if (shipFxObject) { RenderComponent::PlayAnimation(shipFxObject, u"idle"); }
-
 		if (shipFxObject2) { RenderComponent::PlayAnimation(shipFxObject2, u"idle"); }
 	}
 }

--- a/dScripts/ai/AG/AgShipShake.cpp
+++ b/dScripts/ai/AG/AgShipShake.cpp
@@ -55,10 +55,13 @@ void AgShipShake::OnTimerDone(Entity* self, std::string timerName) {
 
 		self->AddTimer("ShipShakeExplode", 5.0f);
 
-		if (shipFxObject2) { RenderComponent::PlayAnimation(shipFxObject2, u"explosion"); }
+		if (shipFxObject2)
+			RenderComponent::PlayAnimation(shipFxObject2, u"explosion");
 	} else if (timerName == "ShipShakeExplode") {
-		if (shipFxObject) { RenderComponent::PlayAnimation(shipFxObject, u"idle"); }
-		if (shipFxObject2) { RenderComponent::PlayAnimation(shipFxObject2, u"idle"); }
+		if (shipFxObject)
+			RenderComponent::PlayAnimation(shipFxObject, u"idle");
+		if (shipFxObject2)
+			RenderComponent::PlayAnimation(shipFxObject2, u"idle");
 	}
 }
 

--- a/dScripts/ai/AG/AgShipShake.h
+++ b/dScripts/ai/AG/AgShipShake.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "CppScripts.h"
+
+class AgShipShake : public CppScripts::Script {
+public:
+	void OnStartup(Entity* self) override;
+	void OnTimerDone(Entity* self, std::string timerName) override;
+	void DoShake(Entity* self, bool explodeIdle);
+
+	std::string DebrisFX = "DebrisFX";
+	std::string ShipFX = "ShipFX";
+	std::string ShipFX2 = "ShipFX2";
+	std::u16string FXName = u"camshake-bridge";
+
+private:
+	Entity* GetEntityInGroup(const std::string& group);
+};

--- a/dScripts/ai/AG/AgShipShake.h
+++ b/dScripts/ai/AG/AgShipShake.h
@@ -5,7 +5,6 @@ class AgShipShake : public CppScripts::Script {
 public:
 	void OnStartup(Entity* self) override;
 	void OnTimerDone(Entity* self, std::string timerName) override;
-	void DoShake(Entity* self, bool explodeIdle);
 
 	std::string DebrisFX = "DebrisFX";
 	std::string ShipFX = "ShipFX";

--- a/dScripts/ai/AG/AgSpaceStuff.cpp
+++ b/dScripts/ai/AG/AgSpaceStuff.cpp
@@ -8,21 +8,6 @@
 
 void AgSpaceStuff::OnStartup(Entity* self) {
 	self->AddTimer("FloaterScale", 5.0f);
-
-	EntityInfo info{};
-
-	info.pos = { -418, 585, -30 };
-	info.lot = 33;
-	info.spawnerID = self->GetObjectID();
-
-	auto* ref = Game::entityManager->CreateEntity(info);
-
-	Game::entityManager->ConstructEntity(ref);
-
-	self->SetVar(u"ShakeObject", ref->GetObjectID());
-
-	self->AddTimer("ShipShakeIdle", 2.0f);
-	self->SetVar(u"RandomTime", 10);
 }
 
 void AgSpaceStuff::OnTimerDone(Entity* self, std::string timerName) {
@@ -37,70 +22,5 @@ void AgSpaceStuff::OnTimerDone(Entity* self, std::string timerName) {
 
 		RenderComponent::PlayAnimation(self, u"path_0" + (GeneralUtils::to_u16string(pathType)));
 		self->AddTimer("FloaterScale", randTime);
-	} else if (timerName == "ShipShakeExplode") {
-		DoShake(self, true);
-	} else if (timerName == "ShipShakeIdle") {
-		DoShake(self, false);
 	}
-}
-
-void AgSpaceStuff::DoShake(Entity* self, bool explodeIdle) {
-
-	if (!explodeIdle) {
-		auto* ref = Game::entityManager->GetEntity(self->GetVar<LWOOBJID>(u"ShakeObject"));
-
-		const auto randomTime = self->GetVar<int>(u"RandomTime");
-		auto time = GeneralUtils::GenerateRandomNumber<int>(0, randomTime + 1);
-
-		if (time < randomTime / 2) {
-			time += randomTime / 2;
-		}
-
-		self->AddTimer("ShipShakeIdle", static_cast<float>(time));
-
-		if (ref)
-			GameMessages::SendPlayEmbeddedEffectOnAllClientsNearObject(ref, FXName, ref->GetObjectID(), 500.0f);
-
-		auto* debrisObject = GetEntityInGroup(DebrisFX);
-
-		if (debrisObject)
-			GameMessages::SendPlayFXEffect(debrisObject, -1, u"DebrisFall", "Debris", LWOOBJID_EMPTY, 1.0f, 1.0f, true);
-
-		const auto randomFx = GeneralUtils::GenerateRandomNumber<int>(0, 3);
-
-		auto* shipFxObject = GetEntityInGroup(ShipFX);
-		if (shipFxObject) {
-			std::string effectType = "shipboom" + std::to_string(randomFx);
-			GameMessages::SendPlayFXEffect(shipFxObject, 559, GeneralUtils::ASCIIToUTF16(effectType), "FX", LWOOBJID_EMPTY, 1.0f, 1.0f, true);
-		}
-
-		self->AddTimer("ShipShakeExplode", 5.0f);
-
-		auto* shipFxObject2 = GetEntityInGroup(ShipFX2);
-		if (shipFxObject2)
-			RenderComponent::PlayAnimation(shipFxObject2, u"explosion");
-	} else {
-		auto* shipFxObject = GetEntityInGroup(ShipFX);
-		auto* shipFxObject2 = GetEntityInGroup(ShipFX2);
-
-		if (shipFxObject)
-			RenderComponent::PlayAnimation(shipFxObject, u"idle");
-
-		if (shipFxObject2)
-			RenderComponent::PlayAnimation(shipFxObject2, u"idle");
-	}
-}
-
-Entity* AgSpaceStuff::GetEntityInGroup(const std::string& group) {
-	auto entities = Game::entityManager->GetEntitiesInGroup(group);
-	Entity* en = nullptr;
-
-	for (auto entity : entities) {
-		if (entity) {
-			en = entity;
-			break;
-		}
-	}
-
-	return en;
 }

--- a/dScripts/ai/AG/AgSpaceStuff.h
+++ b/dScripts/ai/AG/AgSpaceStuff.h
@@ -5,14 +5,5 @@ class AgSpaceStuff : public CppScripts::Script {
 public:
 	void OnStartup(Entity* self);
 	void OnTimerDone(Entity* self, std::string timerName);
-	void DoShake(Entity* self, bool explodeIdle);
-
-	std::string DebrisFX = "DebrisFX";
-	std::string ShipFX = "ShipFX";
-	std::string ShipFX2 = "ShipFX2";
-	std::u16string FXName = u"camshake-bridge";
-
-private:
-	Entity* GetEntityInGroup(const std::string& group);
 };
 

--- a/dScripts/ai/AG/CMakeLists.txt
+++ b/dScripts/ai/AG/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(DSCRIPTS_SOURCES_AI_AG 
 	"AgShipPlayerDeathTrigger.cpp"
 	"AgSpaceStuff.cpp"
+    "AgShipShake.cpp"
 	"AgShipPlayerShockServer.cpp"
 	"AgImagSmashable.cpp"
 	"ActSharkPlayerDeathTrigger.cpp"


### PR DESCRIPTION
Issue #746 

Splitting AgSpaceStuff into AgSpaceStuff and AgShipShake to match their respective luas.

This is based on their LUA counterparts, rather than the current combination of the two which was previously AgSpaceStuff.

Added AgShipShake.cpp and AgShipShake.h, and incorporated them in CppScripts.cpp.  

Tested by compiling, going to venture explorer, and witnessing the intended shake and explosion fx behaviors. 

Did not mess with lot 33 lego piece, will do that laters