### PR TITLE
fix: players using non-car skills in a race

### DIFF
--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -25,6 +25,7 @@
 #include "LeaderboardManager.h"
 #include "dZoneManager.h"
 #include "CDActivitiesTable.h"
+#include "eStateChangeType.h"
 #include <ctime>
 
 #ifndef M_PI
@@ -76,6 +77,9 @@ void RacingControlComponent::OnPlayerLoaded(Entity* player) {
 	}
 
 	m_LoadedPlayers++;
+
+	// not live accurate to stun the player but prevents them from using skills during the race that are not meant to be used.
+	GameMessages::SendSetStunned(player->GetObjectID(), eStateChangeType::PUSH, player->GetSystemAddress(), LWOOBJID_EMPTY, true, true, true, true, true, true, true, true, true);
 
 	LOG("Loading player %i",
 		m_LoadedPlayers);


### PR DESCRIPTION
No its not live accurate but i've no clue how live did this after a ton of static analysis.  

Tested that players can no longer use a Dancin' hat or imagination potions to gain imagination at the start of a race.
Tested that after dying, players still cannot use skills at the start of a race
Tested that players can still smash imagination crates, collect orbs, use boost, smash smashables on the track and collect flags without issues