### PR TITLE
fix: skill desync when picking up powerups or casting server side calculations

### DIFF
--- a/dGame/dBehaviors/BehaviorContext.cpp
+++ b/dGame/dBehaviors/BehaviorContext.cpp
@@ -105,7 +105,7 @@ void BehaviorContext::ExecuteUpdates() {
 	this->scheduledUpdates.clear();
 }
 
-void BehaviorContext::SyncBehavior(const uint32_t syncId, RakNet::BitStream& bitStream) {
+bool BehaviorContext::SyncBehavior(const uint32_t syncId, RakNet::BitStream& bitStream) {
 	BehaviorSyncEntry entry;
 	auto found = false;
 
@@ -128,7 +128,7 @@ void BehaviorContext::SyncBehavior(const uint32_t syncId, RakNet::BitStream& bit
 	if (!found) {
 		LOG("Failed to find behavior sync entry with sync id (%i)!", syncId);
 
-		return;
+		return false;
 	}
 
 	auto* behavior = entry.behavior;
@@ -137,10 +137,11 @@ void BehaviorContext::SyncBehavior(const uint32_t syncId, RakNet::BitStream& bit
 	if (behavior == nullptr) {
 		LOG("Invalid behavior for sync id (%i)!", syncId);
 
-		return;
+		return false;
 	}
 
 	behavior->Sync(this, bitStream, branch);
+	return true;
 }
 
 

--- a/dGame/dBehaviors/BehaviorContext.h
+++ b/dGame/dBehaviors/BehaviorContext.h
@@ -93,7 +93,7 @@ struct BehaviorContext
 
 	void ExecuteUpdates();
 
-	void SyncBehavior(uint32_t syncId, RakNet::BitStream& bitStream);
+	bool SyncBehavior(uint32_t syncId, RakNet::BitStream& bitStream);
 
 	void Update(float deltaTime);
 

--- a/dGame/dComponents/SkillComponent.h
+++ b/dGame/dComponents/SkillComponent.h
@@ -188,7 +188,7 @@ private:
 	/**
 	 * All of the active skills mapped by their unique ID.
 	 */
-	std::map<uint32_t, BehaviorContext*> m_managedBehaviors;
+	std::multimap<uint32_t, BehaviorContext*> m_managedBehaviors;
 
 	/**
 	 * All active projectiles.


### PR DESCRIPTION
From static analysis it appears that the client and server need to be keeping track of their own skillUIds as inside the client, there are GameMessages for CastLocalSkill which increment the client side skillUId counter `0x00d45300` alongside the same tracker being used for tracking the ones the client sends to the server `0x00d44980`.  With no way for the server to actually know the clients actual skill tracker value, I believe it is safe to assume that the two are ok to overlap and you just have to keep track of both.  This PR utilizes a multimap to accomplish this task.  

Tested that battling on Crux Prime using a wormholer, bat lord helm and picking up powerups constantly from boxes does not cause my character to become permanently slowed, nor do I permanently gain as money magnet.
Tested that loading into Avant Gardens and destroying the piles of debris at this location with the wormholer, a speedboost and a money magnet active results in
- wormholer doing damage
- speedboosts actually going away
- money magnet actually going away
instead of
- wormholer sometimes not doing damage, causing invisible objects
- speedboosts, both positive and negative going away
- money magnet staying permanently
![image](https://github.com/DarkflameUniverse/DarkflameServer/assets/39972741/3974b825-13d3-47f0-ba1f-d579265dbb11)
