### PR TITLE
fix: Dockerfile vanity COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ COPY --from=build /app/build/*Server /app/
 
 # Necessary suplimentary files
 COPY --from=build /app/build/*.ini /app/configs/
-COPY --from=build /app/build/vanity/*.* /app/vanity/*
+COPY --from=build /app/build/vanity/*.* /app/vanity/
 COPY --from=build /app/build/navmeshes /app/navmeshes
 COPY --from=build /app/build/migrations /app/migrations
 COPY --from=build /app/build/*.dcf /app/
@@ -39,7 +39,7 @@ COPY --from=build /app/build/*.dcf /app/
 # backup of config and vanity files to copy to the host incase 
 # of a mount clobbering the copy from above
 COPY --from=build /app/build/*.ini /app/default-configs/ 
-COPY --from=build /app/build/vanity/*.* /app/default-vanity/*
+COPY --from=build /app/build/vanity/*.* /app/default-vanity/
 
 # needed as the container runs with the root user
 # and therefore sudo doesn't exist


### PR DESCRIPTION
The current COPY directives in the Dockerfile that add the vanity files have an unintended trailing asterisk, causing only root.xml's contents to be in there under the filename '*'.
This is obviously unintendend as this causes the vanity to be non-functional in the default docker setup.