### PR TITLE
Buyback inventory overflow glitch fix

### DIFF
--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -95,7 +95,7 @@ public:
 	 * @param preferredSlot the preferred slot to store this item
 	 * @param lootSourceType The source of the loot.  Defaults to none.
 	 */
-	void AddItem(
+	std::vector<LWOOBJID> AddItem(
 		LOT lot,
 		uint32_t count,
 		eLootSourceType lootSourceType = eLootSourceType::NONE,
@@ -367,7 +367,7 @@ public:
 	 */
 	void UnequipScripts(Item* unequippedItem);
 
-	std::map<BehaviorSlot, uint32_t> GetSkills(){ return m_Skills; };
+	std::map<BehaviorSlot, uint32_t> GetSkills() { return m_Skills; };
 
 	bool SetSkill(int slot, uint32_t skillId);
 	bool SetSkill(BehaviorSlot slot, uint32_t skillId);
@@ -379,7 +379,7 @@ private:
 	 * All the inventory this entity possesses
 	 */
 	std::map<eInventoryType, Inventory*> m_Inventories;
-
+	std::vector<LWOOBJID> invTransferred;
 	/**
 	 * The skills that this entity currently has active
 	 */

--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -477,6 +477,8 @@ private:
 	 * @param document the xml doc to load from
 	 */
 	void UpdatePetXml(tinyxml2::XMLDocument& document);
+	void ManageVendorBuybackInventory(std::vector<LWOOBJID>& itemVector, Item* newItem, Inventory* inventory, bool removeItem);
+	bool RemoveItemById(LWOOBJID itemId, eInventoryType inventoryType, const bool ignoreBound, const bool silent);
 };
 
 #endif


### PR DESCRIPTION
Currently still a work in progress. I have something that may be very similar to what we want, and need to go through it and likely simplify things, remove logs, etc, but for the time being ive kept all those for debugging. 

There is an issue with leaving a single inventory slot open at all times, which may be acceptable for the fix or not, as either way i could see how it could behave that way. That being said, it shouldnt be too hard of a change to get it to not include that empty space, i just need to go through and figure out what causes that specifically. 

Tested using a variety of random items and stacks, and i know some modifications will definitely be requested and made, again this is just very rough unfinished code.

Thanks for the feedback