### PR TITLE
fix: add larger behavior fields for saving

### DIFF
--- a/migrations/dlu/16_big_behaviors.sql
+++ b/migrations/dlu/16_big_behaviors.sql
@@ -1,0 +1,1 @@
+ALTER TABLE behaviors MODIFY behavior_info LONGTEXT DEFAULT NULL;


### PR DESCRIPTION
You can make some big behaviors and TEXT doesn't allow for enough data to be stored.  Changes the column do big text can be stored.