### PR TITLE
Fixed Misspelling for Treasure in PetComponent files

### DIFF
--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -88,7 +88,7 @@ PetComponent::PetComponent(Entity* parentEntity, uint32_t componentId) : Compone
 	m_Ability = ePetAbilityType::Invalid;
 	m_StartPosition = NiPoint3Constant::ZERO;
 	m_MovementAI = nullptr;
-	m_TresureTime = 0;
+	m_TreasureTime = 0;
 
 	std::string checkPreconditions = GeneralUtils::UTF16ToWTF8(parentEntity->GetVar<std::u16string>(u"CheckPrecondition"));
 
@@ -319,27 +319,27 @@ void PetComponent::Update(float deltaTime) {
 		return;
 	}
 
-	if (m_TresureTime > 0) {
-		auto* tresure = Game::entityManager->GetEntity(m_Interaction);
+	if (m_TreasureTime > 0) {
+		auto* treasure = Game::entityManager->GetEntity(m_Interaction);
 
-		if (tresure == nullptr) {
-			m_TresureTime = 0;
+		if (treasure == nullptr) {
+			m_TreasureTime = 0;
 
 			return;
 		}
 
-		m_TresureTime -= deltaTime;
+		m_TreasureTime -= deltaTime;
 
 		m_MovementAI->Stop();
 
-		if (m_TresureTime <= 0) {
+		if (m_TreasureTime <= 0) {
 			m_Parent->SetOwnerOverride(m_Owner);
 
-			tresure->Smash(m_Parent->GetObjectID());
+			treasure->Smash(m_Parent->GetObjectID());
 
 			m_Interaction = LWOOBJID_EMPTY;
 
-			m_TresureTime = 0;
+			m_TreasureTime = 0;
 		}
 
 		return;
@@ -396,30 +396,30 @@ void PetComponent::Update(float deltaTime) {
 	// Determine if the "Lost Tags" mission has been completed and digging has been unlocked
 	const bool digUnlocked = missionComponent->GetMissionState(842) == eMissionState::COMPLETE;
 
-	Entity* closestTresure = PetDigServer::GetClosestTresure(position);
+	Entity* closestTreasure = PetDigServer::GetClosestTreasure(position);
 
-	if (closestTresure != nullptr && digUnlocked) {
+	if (closestTreasure != nullptr && digUnlocked) {
 		// Skeleton Dragon Pat special case for bone digging
-		if (closestTresure->GetLOT() == 12192 && m_Parent->GetLOT() != 13067) {
-			goto skipTresure;
+		if (closestTreasure->GetLOT() == 12192 && m_Parent->GetLOT() != 13067) {
+			goto skipTreasure;
 		}
 
-		NiPoint3 tresurePosition = closestTresure->GetPosition();
-		float distance = Vector3::DistanceSquared(position, tresurePosition);
+		NiPoint3 treasurePosition = closestTreasure->GetPosition();
+		float distance = Vector3::DistanceSquared(position, treasurePosition);
 		if (distance < 5 * 5) {
-			m_Interaction = closestTresure->GetObjectID();
+			m_Interaction = closestTreasure->GetObjectID();
 
 			Command(NiPoint3Constant::ZERO, LWOOBJID_EMPTY, 1, 202, true);
 
-			m_TresureTime = 2;
+			m_TreasureTime = 2;
 		} else if (distance < 10 * 10) {
 			haltDistance = 1;
 
-			destination = tresurePosition;
+			destination = treasurePosition;
 		}
 	}
 
-skipTresure:
+skipTreasure:
 
 	m_MovementAI->SetHaltDistance(haltDistance);
 

--- a/dGame/dComponents/PetComponent.h
+++ b/dGame/dComponents/PetComponent.h
@@ -329,7 +329,7 @@ private:
 	 * Timer that tracks how long a pet has been digging up some treasure, required to spawn the treasure contents
 	 * on time
 	 */
-	float m_TresureTime;
+	float m_TreasureTime;
 
 	/**
 	 * The position that this pet was spawned at

--- a/dScripts/02_server/Map/General/PetDigServer.cpp
+++ b/dScripts/02_server/Map/General/PetDigServer.cpp
@@ -215,20 +215,20 @@ void PetDigServer::SpawnPet(Entity* self, const Entity* owner, const DigInfo dig
 	Game::entityManager->ConstructEntity(spawnedPet);
 }
 
-Entity* PetDigServer::GetClosestTresure(NiPoint3 position) {
+Entity* PetDigServer::GetClosestTreasure(NiPoint3 position) {
 	float closestDistance = 0;
 	Entity* closest = nullptr;
 
-	for (const auto tresureId : treasures) {
-		auto* tresure = Game::entityManager->GetEntity(tresureId);
+	for (const auto treasureId : treasures) {
+		auto* treasure = Game::entityManager->GetEntity(treasureId);
 
-		if (tresure == nullptr) continue;
+		if (treasure == nullptr) continue;
 
-		float distance = Vector3::DistanceSquared(tresure->GetPosition(), position);
+		float distance = Vector3::DistanceSquared(treasure->GetPosition(), position);
 
 		if (closest == nullptr || distance < closestDistance) {
 			closestDistance = distance;
-			closest = tresure;
+			closest = treasure;
 		}
 	}
 

--- a/dScripts/02_server/Map/General/PetDigServer.h
+++ b/dScripts/02_server/Map/General/PetDigServer.h
@@ -17,7 +17,7 @@ public:
 	void OnStartup(Entity* self) override;
 	void OnDie(Entity* self, Entity* killer) override;
 
-	static Entity* GetClosestTresure(NiPoint3 position);
+	static Entity* GetClosestTreasure(NiPoint3 position);
 
 private:
 	static void ProgressPetDigMissions(const Entity* owner, const Entity* chest);


### PR DESCRIPTION
Basically title. Original pet treasure variables were Tresure, which was a misspelling. All I did was rename each instance to Treasure, and changed the associated methods as well. 

Tested by opening server and digging pet treasures to ensure nothing was conflicting. Pet treasure digs perform as intended still. 

motivation: clean up code a bit