### PR TITLE
feat: add admin account creation options from cli

### DIFF
--- a/dDatabase/GameDatabase/ITables/IAccounts.h
+++ b/dDatabase/GameDatabase/ITables/IAccounts.h
@@ -33,6 +33,9 @@ public:
 
 	// Add a new account to the database.
 	virtual void InsertNewAccount(const std::string_view username, const std::string_view bcryptpassword) = 0;
+
+	// Update the GameMaster level of an account.
+	virtual void UpdateAccountGmLevel(const uint32_t accountId, const eGameMasterLevel gmLevel) = 0;
 };
 
 #endif  //!__IACCOUNTS__H__

--- a/dDatabase/GameDatabase/MySQL/MySQLDatabase.h
+++ b/dDatabase/GameDatabase/MySQL/MySQLDatabase.h
@@ -111,6 +111,7 @@ public:
 	void AddBehavior(const IBehaviors::Info& info) override;
 	std::string GetBehavior(const int32_t behaviorId) override;
 	void RemoveBehavior(const int32_t characterId) override;
+	void UpdateAccountGmLevel(const uint32_t accountId, const eGameMasterLevel gmLevel) override;
 private:
 
 	// Generic query functions that can be used for any query.

--- a/dDatabase/GameDatabase/MySQL/Tables/Accounts.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/Accounts.cpp
@@ -35,3 +35,7 @@ void MySQLDatabase::UpdateAccountPassword(const uint32_t accountId, const std::s
 void MySQLDatabase::InsertNewAccount(const std::string_view username, const std::string_view bcryptpassword) {
 	ExecuteInsert("INSERT INTO accounts (name, password, gm_level) VALUES (?, ?, ?);", username, bcryptpassword, static_cast<int32_t>(eGameMasterLevel::OPERATOR));
 }
+
+void MySQLDatabase::UpdateAccountGmLevel(const uint32_t accountId, const eGameMasterLevel gmLevel) {
+	ExecuteUpdate("UPDATE accounts SET gm_level = ? WHERE id = ?;", static_cast<int32_t>(gmLevel), accountId);
+}

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -41,6 +41,7 @@
 #include "Start.h"
 #include "Server.h"
 #include "CDZoneTableTable.h"
+#include "eGameMasterLevel.h"
 
 namespace Game {
 	Logger* logger = nullptr;
@@ -187,15 +188,20 @@ int main(int argc, char** argv) {
 		std::cout << "Enter a username: ";
 		std::cin >> username;
 
+		auto checkIsAdmin = []() {
+			std::string admin;
+			std::cout << "Should this account have administrator privileges? y will set their GameMaster level to 9, anything else will set the GameMaster level to 0. [y/n]? ";
+			std::cin >> admin;
+			return admin == "y" || admin == "yes";
+			};
+
 		auto accountId = Database::Get()->GetAccountInfo(username);
-		if (accountId) {
+		if (accountId && accountId->id != 0) {
 			LOG("Account with name \"%s\" already exists", username.c_str());
 			std::cout << "Do you want to change the password of that account? [y/n]?";
 			std::string prompt = "";
 			std::cin >> prompt;
 			if (prompt == "y" || prompt == "yes") {
-				if (accountId->id == 0) return EXIT_FAILURE;
-
 				//Read the password from the console without echoing it.
 #ifdef __linux__
 		//This function is obsolete, but it only meant to be used by the
@@ -220,6 +226,16 @@ int main(int argc, char** argv) {
 			} else {
 				LOG("Account \"%s\" was not updated.", username.c_str());
 			}
+
+			std::cout << "Update admin privileges? [y/n]? ";
+			std::string admin;
+			std::cin >> admin;
+			bool updateAdmin = admin == "y" || admin == "yes";
+			if (updateAdmin) {
+				bool isOperator = checkIsAdmin();
+				Database::Get()->UpdateAccountGmLevel(accountId->id, isOperator ? eGameMasterLevel::OPERATOR : eGameMasterLevel::CIVILIAN);
+			}
+
 			return EXIT_SUCCESS;
 		}
 
@@ -250,6 +266,13 @@ int main(int argc, char** argv) {
 		}
 
 		LOG("Account created successfully!");
+
+		accountId = Database::Get()->GetAccountInfo(username);
+		if (accountId) {
+			bool isOperator = checkIsAdmin();
+			Database::Get()->UpdateAccountGmLevel(accountId->id, isOperator ? eGameMasterLevel::OPERATOR : eGameMasterLevel::CIVILIAN);
+		}
+
 		return EXIT_SUCCESS;
 	}
 
@@ -558,7 +581,7 @@ void HandlePacket(Packet* packet) {
 			inStream.Read(sessionKey);
 			LUString username;
 			inStream.Read(username);
-	
+
 			for (auto it : activeSessions) {
 				if (it.second == username.string) {
 					activeSessions.erase(it.first);

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -190,7 +190,7 @@ int main(int argc, char** argv) {
 
 		const auto checkIsAdmin = []() {
 			std::string admin;
-			std::cout << "What level of privilege should this account have? Please enter a number between 0 and 9 inclusive. No entry will default to 0." << std::endl;
+			std::cout << "What level of privilege should this account have? Please enter a number between 0 (Player) and 9 (Admin) inclusive. No entry will default to 0." << std::endl;
 			std::cin >> admin;
 			return admin;
 			};

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -188,11 +188,11 @@ int main(int argc, char** argv) {
 		std::cout << "Enter a username: ";
 		std::cin >> username;
 
-		auto checkIsAdmin = []() {
+		const auto checkIsAdmin = []() {
 			std::string admin;
-			std::cout << "Should this account have administrator privileges? y will set their GameMaster level to 9, anything else will set the GameMaster level to 0. [y/n]? ";
+			std::cout << "What level of privilege should this account have? Please enter a number between 0 and 9 inclusive. No entry will default to 0." << std::endl;
 			std::cin >> admin;
-			return admin == "y" || admin == "yes";
+			return admin;
 			};
 
 		auto accountId = Database::Get()->GetAccountInfo(username);
@@ -232,8 +232,12 @@ int main(int argc, char** argv) {
 			std::cin >> admin;
 			bool updateAdmin = admin == "y" || admin == "yes";
 			if (updateAdmin) {
-				bool isOperator = checkIsAdmin();
-				Database::Get()->UpdateAccountGmLevel(accountId->id, isOperator ? eGameMasterLevel::OPERATOR : eGameMasterLevel::CIVILIAN);
+				auto gmLevel = GeneralUtils::TryParse<int32_t>(checkIsAdmin()).value_or(0);
+				if (gmLevel > 9 || gmLevel < 0) {
+					LOG("Invalid admin level.  Defaulting to 0");
+					gmLevel = 0;
+				}
+				Database::Get()->UpdateAccountGmLevel(accountId->id, static_cast<eGameMasterLevel>(gmLevel));
 			}
 
 			return EXIT_SUCCESS;
@@ -269,8 +273,12 @@ int main(int argc, char** argv) {
 
 		accountId = Database::Get()->GetAccountInfo(username);
 		if (accountId) {
-			bool isOperator = checkIsAdmin();
-			Database::Get()->UpdateAccountGmLevel(accountId->id, isOperator ? eGameMasterLevel::OPERATOR : eGameMasterLevel::CIVILIAN);
+			auto gmLevel = GeneralUtils::TryParse<int32_t>(checkIsAdmin()).value_or(0);
+			if (gmLevel > 9 || gmLevel < 0) {
+				LOG("Invalid admin level.  Defaulting to 0");
+				gmLevel = 0;
+			}
+			Database::Get()->UpdateAccountGmLevel(accountId->id, static_cast<eGameMasterLevel>(gmLevel));
 		}
 
 		return EXIT_SUCCESS;


### PR DESCRIPTION
Tested that creating accounts through CLI shows the option for setting admin access.
only `y` or `yes` allows for an account to be an admin, anything else results in a civilian account
updating an account now prompts for an updated gm level and updates it accordingly.