### PR TITLE
Fix mission related preconditions

### DIFF
--- a/dGame/dUtilities/Preconditions.cpp
+++ b/dGame/dUtilities/Preconditions.cpp
@@ -139,21 +139,13 @@ bool Precondition::CheckValue(Entity* player, const uint32_t value, bool evaluat
 	case PreconditionType::DoesNotHaveItem:
 		return inventoryComponent->IsEquipped(value) < count;
 	case PreconditionType::HasAchievement:
-		mission = missionComponent->GetMission(value);
-
-		return mission == nullptr || mission->GetMissionState() >= eMissionState::COMPLETE;
+		return missionComponent->GetMissionState(value) >= eMissionState::COMPLETE;
 	case PreconditionType::MissionAvailable:
-		mission = missionComponent->GetMission(value);
-
-		return mission == nullptr || mission->GetMissionState() >= eMissionState::AVAILABLE;
+		return missionComponent->GetMissionState(value) >= eMissionState::AVAILABLE;
 	case PreconditionType::OnMission:
-		mission = missionComponent->GetMission(value);
-
-		return mission == nullptr || mission->GetMissionState() >= eMissionState::ACTIVE;
+		return missionComponent->GetMissionState(value) >= eMissionState::ACTIVE;
 	case PreconditionType::MissionComplete:
-		mission = missionComponent->GetMission(value);
-
-		return mission == nullptr ? false : mission->GetMissionState() >= eMissionState::COMPLETE;
+		return missionComponent->GetMissionState(value) >= eMissionState::COMPLETE;
 	case PreconditionType::PetDeployed:
 		return false; // TODO
 	case PreconditionType::HasFlag:


### PR DESCRIPTION
The current logic registered missions that had not been accepted as passing preconditions they should not. This PR seeks to use the GetMissionState function which takes care of this case.