### PR TITLE
fix: nullptr crashes in PetComponent AddDrainImaginationTimer and Deactivate

### DIFF
--- a/dGame/dComponents/PetComponent.h
+++ b/dGame/dComponents/PetComponent.h
@@ -205,7 +205,7 @@ public:
 	 *
 	 * @param item The item that represents this pet in the inventory.
 	 */
-	void AddDrainImaginationTimer(Item* item, bool fromTaming = false);
+	void AddDrainImaginationTimer(bool fromTaming = false);
 
 private:
 


### PR DESCRIPTION
Resolves an issue where item is null but is accessed but not doing that code and instead consulting the EntityManager for a valid Entity, alongside nullifying the m_Owner objectID should the pet be destroyed and timer still exist.
