### PR TITLE
fix: use macros so we can use more properties with the mysql driver

### DIFF
--- a/dDatabase/GameDatabase/MySQL/MySQLDatabase.cpp
+++ b/dDatabase/GameDatabase/MySQL/MySQLDatabase.cpp
@@ -4,6 +4,7 @@
 #include "Game.h"
 #include "dConfig.h"
 #include "Logger.h"
+#include "dPlatforms.h"
 
 namespace {
 	std::string databaseName;
@@ -39,14 +40,13 @@ void MySQLDatabase::Connect() {
 	properties["autoReconnect"] = "true";
 
 	databaseName = Game::config->GetValue("mysql_database").c_str();
-
 	// `connect(const Properties& props)` segfaults in windows debug, but
 	// `connect(const SQLString& host, const SQLString& user, const SQLString& pwd)` doesn't handle pipes/unix sockets correctly
-	if (properties.find("localSocket") != properties.end() || properties.find("pipe") != properties.end()) {
-		con = driver->connect(properties);
-	} else {
+#if defined(DARKFLAME_PLATFORM_WIN32) && defined(_DEBUG)
 		con = driver->connect(properties["hostName"].c_str(), properties["user"].c_str(), properties["password"].c_str());
-	}
+#else
+		con = driver->connect(properties);
+#endif
 	con->setSchema(databaseName.c_str());
 }
 


### PR DESCRIPTION
makes it so we can adjust many more settings since the segfault only happens in windows debug, why remove the functionality for all users? Tested that windows debug, windows RelWithDebInfo and ubuntu default all build and run without issues (will contact luxaritas about pipe testing)