### PR TITLE
feat: add error reporting for failed charxml

### DIFF
--- a/dGame/Character.cpp
+++ b/dGame/Character.cpp
@@ -76,7 +76,7 @@ void Character::DoQuickXMLDataParse() {
 	if (m_Doc.Parse(m_XMLData.c_str(), m_XMLData.size()) == 0) {
 		LOG("Loaded xmlData for character %s (%i)!", m_Name.c_str(), m_ID);
 	} else {
-		LOG("Failed to load xmlData!");
+		LOG("Failed to load xmlData (%i) (%s) (%s)!", m_Doc.ErrorID(), m_Doc.ErrorIDToName(m_Doc.ErrorID()), m_Doc.ErrorStr());
 		//Server::rakServer->CloseConnection(m_ParentUser->GetSystemAddress(), true);
 		return;
 	}


### PR DESCRIPTION
Tested that removing an arbitrary character now logs the error info.  Will hopefully help track down a bug