### PR TITLE
fix: remove ninjago missions items for completed missions

### DIFF
--- a/dCommon/dEnums/eCharacterVersion.h
+++ b/dCommon/dEnums/eCharacterVersion.h
@@ -16,7 +16,7 @@ enum class eCharacterVersion : uint32_t {
 	VAULT_SIZE,
 	// Fixes speed base value in level component
 	SPEED_BASE,
-	UP_TO_DATE, // will become SPEED_BASE
+	UP_TO_DATE, // will become NJ_JAYMISSIONS
 };
 
 #endif  //!__ECHARACTERVERSION__H__

--- a/dCommon/dEnums/eCharacterVersion.h
+++ b/dCommon/dEnums/eCharacterVersion.h
@@ -15,6 +15,7 @@ enum class eCharacterVersion : uint32_t {
 	// Fixes vault size value
 	VAULT_SIZE,
 	// Fixes speed base value in level component
+	SPEED_BASE,
 	UP_TO_DATE, // will become SPEED_BASE
 };
 


### PR DESCRIPTION
fixes an issue where the missions were completed prior to a bug fix, causing these items to remain in the inventory.
![image](https://github.com/user-attachments/assets/7d3b13fd-01ad-4aeb-8933-fd67de8c68d7)

Tested that players with the mission completed have the item correctly removed from their inventory.