### PR TITLE
fix: chat server crash

### DIFF
--- a/dChatServer/PlayerContainer.cpp
+++ b/dChatServer/PlayerContainer.cpp
@@ -148,9 +148,8 @@ void PlayerContainer::CreateTeamServer(Packet* packet) {
 
 	if (team != nullptr) {
 		team->zoneId = zoneId;
+		UpdateTeamsOnWorld(team, false);
 	}
-
-	UpdateTeamsOnWorld(team, false);
 }
 
 void PlayerContainer::BroadcastMuteUpdate(LWOOBJID player, time_t time) {


### PR DESCRIPTION
tested that sending an empty packet with this messageID no longer crashes the chat server