### PR TITLE
fix: crash on character create screen; character order

### DIFF
--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -1001,7 +1001,6 @@ void HandlePacket(Packet* packet) {
 
 	case eWorldMessageType::CHARACTER_DELETE_REQUEST: {
 		UserManager::Instance()->DeleteCharacter(packet->systemAddress, packet);
-		UserManager::Instance()->RequestCharacterList(packet->systemAddress);
 		break;
 	}
 


### PR DESCRIPTION
pretend you are NinjaOfLU from the hit AAA video game LEGO Universe
please extend the following text with descriptors that bring it to 500 words
"Fixes an issue where deleting 2 characters would crash the game and also fixes an issue where the order of minifigures was incorrect after deleting a character"

ChatGPT:
ChatGPT
Certainly, let’s expand this to a full 500-word description, as if spoken by NinjaOfLU from the LEGO Universe game.

"Hello there, fellow adventurers! I’m here to share some exciting updates that are sure to make your journey through LEGO Universe smoother than ever before. We’ve been hard at work refining the game and making it more stable and enjoyable for all players. Here’s the scoop on the latest fixes!

First up, we’ve squashed a pesky issue that was causing a crash whenever players attempted to delete two characters in quick succession. It seems that when you tried to tidy up your roster and get rid of some minifigures, the game got a bit too emotional, leading to unexpected crashes. This bug was a troublesome one, but we’re pleased to announce it’s been thoroughly addressed. You can now delete characters as needed without worrying that the game will suddenly close on you. So go ahead, manage your roster to your heart's content, and enjoy a more reliable experience!

Additionally, we tackled another curious bug affecting the order of minifigures. Before this update, players who deleted a character noticed that the remaining minifigures would sometimes get shuffled around in unexpected ways. Imagine building a minifigure team lineup exactly how you want, only to delete one and have the others suddenly shift out of order. We know that keeping your favorite minifigures organized just the way you like is essential for gameplay, so we’ve corrected this issue. Now, when you remove a character, the rest will stay right where you left them, making it easier than ever to jump back into the action with your perfectly arranged squad!

Both of these fixes are part of our ongoing efforts to enhance stability and polish the LEGO Universe experience. Whether you’re exploring the hidden secrets of Gnarled Forest, defending Avant Gardens from the Maelstrom, or building your own unique creations, we want every moment you spend in the game to be enjoyable and uninterrupted.

Rest assured, our team is committed to listening to your feedback and addressing any issues that arise. This update may seem small, but each tweak brings us one step closer to providing the ultimate experience for our community of builders, explorers, and heroes. Thank you for your patience as we continue to refine and improve LEGO Universe!

We’re excited to keep growing and enhancing the game with your help, so if you encounter any other issues or have suggestions, don’t hesitate to reach out. And keep your eyes peeled – there’s plenty more to come in the world of LEGO Universe! Who knows what new adventures await?

So go forth, adventurers! Enjoy a more seamless experience, customize your character lineup without worry, and dive back into the thrill of LEGO Universe with confidence. We’ll see you out there – and remember, only together can we overcome the Maelstrom!"

There you go, a complete message ready for our favorite LEGO Universe community hero, NinjaOfLU!






あなた:
throw in some pirate phrases
ChatGPT:
ChatGPT
Certainly! Here’s NinjaOfLU, channeling a bit of pirate flair as they update players on the bug fixes:

"Ahoy there, mateys and fellow adventurers! Gather ’round as I share a tale o’ triumph over a few pesky bugs that tried to sink our ship in the grand world o’ LEGO Universe! We’ve been hard at work swabbin’ the decks and patchin’ things up so ye can set sail on smoother seas.

First off, we’ve fixed a nasty bug that was causin’ the game to crash whenever players tried deletin’ two characters at once. Aye, it seemed that when ye tried to clear some space in yer roster, the game took a dive overboard faster than a scallywag can blink! But worry not, for we’ve hunted down that troublesome beastie, and ye can now delete characters without fear o’ bein’ tossed back to port! Manage yer roster freely, and keep yer favorite crew at the ready.

But that ain’t all! There was another bug that was throwin' yer precious minifigure lineup all outta whack. Before, when ye deleted a character, the rest o’ the lineup would shuffle like a deck o’ cards in the hands of a landlubber! Imagine plannin' yer perfect crew only to see 'em get jumbled up like a barrel o' monkeys. Well, no more! Now, when ye send a character to Davy Jones’ Locker, the rest o' yer crew will stay in the order ye left 'em. Ye can go about plunderin’ and adventurin’ with yer line-up lookin’ shipshape and organized!

These fixes be part o’ our ongoing mission to keep the LEGO Universe experience smooth as a fresh wind in yer sails. Whether ye be journeyin’ through Gnarled Forest or fendin’ off the Maelstrom, we want ye to have a fine voyage without any interruptions from these bothersome glitches.

Rest easy knowin' that we be listenin' to yer feedback and keepin' a weather eye on any other troubles that arise. Each fix we make brings us closer to givin' ye the grand adventure ye deserve on these virtual seas. So if ye spy any more problems or have suggestions, be sure to shout 'em from the crow’s nest! And mark me words, there be even more exciting things comin’ yer way in LEGO Universe. Who knows what treasures lie ahead, just waitin’ for brave souls like yerselves to discover 'em?

So hoist yer sails, and enjoy these fixes, mates! Clear out yer crew roster, keep yer minifigures shipshape, and jump right back into the thrill of LEGO Universe! We’ll see ye out there on the high seas of adventure – and remember, only together can we best the Maelstrom and claim the treasure that awaits!

Fair winds and happy adventurin’, ye brave builders! Arrr!"

There you go! NinjaOfLU, with a hearty pirate twist, ready to rally the crew in LEGO Universe! 🏴‍☠️