### PR TITLE
fix: laggy property models (and probably more)

### DIFF
--- a/dGame/dComponents/ModelComponent.cpp
+++ b/dGame/dComponents/ModelComponent.cpp
@@ -7,6 +7,7 @@
 #include "BehaviorStates.h"
 #include "ControlBehaviorMsgs.h"
 #include "tinyxml2.h"
+#include "SimplePhysicsComponent.h"
 
 #include "Database.h"
 
@@ -95,12 +96,24 @@ void ModelComponent::AddBehavior(AddMessage& msg) {
 	for (auto& behavior : m_Behaviors) if (behavior.GetBehaviorId() == msg.GetBehaviorId()) return;
 	m_Behaviors.insert(m_Behaviors.begin() + msg.GetBehaviorIndex(), PropertyBehavior());
 	m_Behaviors.at(msg.GetBehaviorIndex()).HandleMsg(msg);
+	auto* const simplePhysComponent = m_Parent->GetComponent<SimplePhysicsComponent>();
+	if (simplePhysComponent) {
+		simplePhysComponent->SetPhysicsMotionState(1);
+		Game::entityManager->SerializeEntity(m_Parent);
+	}
 }
 
 void ModelComponent::MoveToInventory(MoveToInventoryMessage& msg) {
 	if (msg.GetBehaviorIndex() >= m_Behaviors.size() || m_Behaviors.at(msg.GetBehaviorIndex()).GetBehaviorId() != msg.GetBehaviorId()) return;
 	m_Behaviors.erase(m_Behaviors.begin() + msg.GetBehaviorIndex());
 	// TODO move to the inventory
+	if (m_Behaviors.empty()) {
+		auto* const simplePhysComponent = m_Parent->GetComponent<SimplePhysicsComponent>();
+		if (simplePhysComponent) {
+			simplePhysComponent->SetPhysicsMotionState(4);
+			Game::entityManager->SerializeEntity(m_Parent);
+		}
+	}
 }
 
 std::array<std::pair<int32_t, std::string>, 5> ModelComponent::GetBehaviorsForSave() const {

--- a/dGame/dComponents/SimplePhysicsComponent.cpp
+++ b/dGame/dComponents/SimplePhysicsComponent.cpp
@@ -27,6 +27,7 @@ SimplePhysicsComponent::SimplePhysicsComponent(Entity* parent, uint32_t componen
 	} else {
 		SetClimbableType(eClimbableType::CLIMBABLE_TYPE_NOT);
 	}
+	m_PhysicsMotionState = m_Parent->GetVarAs<uint32_t>(u"motionType");
 }
 
 SimplePhysicsComponent::~SimplePhysicsComponent() {
@@ -47,11 +48,9 @@ void SimplePhysicsComponent::Serialize(RakNet::BitStream& outBitStream, bool bIs
 	}
 
 	// Physics motion state
-	if (m_PhysicsMotionState != 0) {
-		outBitStream.Write1();
+	outBitStream.Write(m_DirtyPhysicsMotionState || bIsInitialUpdate);
+	if (m_DirtyPhysicsMotionState || bIsInitialUpdate) {
 		outBitStream.Write<uint32_t>(m_PhysicsMotionState);
-	} else {
-		outBitStream.Write0();
 	}
 	PhysicsComponent::Serialize(outBitStream, bIsInitialUpdate);
 }
@@ -61,5 +60,6 @@ uint32_t SimplePhysicsComponent::GetPhysicsMotionState() const {
 }
 
 void SimplePhysicsComponent::SetPhysicsMotionState(uint32_t value) {
+	m_DirtyPhysicsMotionState = m_PhysicsMotionState != value;
 	m_PhysicsMotionState = value;
 }

--- a/dGame/dComponents/SimplePhysicsComponent.cpp
+++ b/dGame/dComponents/SimplePhysicsComponent.cpp
@@ -51,6 +51,7 @@ void SimplePhysicsComponent::Serialize(RakNet::BitStream& outBitStream, bool bIs
 	outBitStream.Write(m_DirtyPhysicsMotionState || bIsInitialUpdate);
 	if (m_DirtyPhysicsMotionState || bIsInitialUpdate) {
 		outBitStream.Write<uint32_t>(m_PhysicsMotionState);
+		m_DirtyPhysicsMotionState = false;
 	}
 	PhysicsComponent::Serialize(outBitStream, bIsInitialUpdate);
 }

--- a/dGame/dComponents/SimplePhysicsComponent.h
+++ b/dGame/dComponents/SimplePhysicsComponent.h
@@ -102,7 +102,9 @@ private:
 	/**
 	 * The current physics motion state
 	 */
-	uint32_t m_PhysicsMotionState = 0;
+	uint32_t m_PhysicsMotionState = 5;
+
+	bool m_DirtyPhysicsMotionState = true;
 
 	/**
 	 * Whether or not the entity is climbable

--- a/dScripts/ai/MINIGAME/SG_GF/SERVER/SGCannon.cpp
+++ b/dScripts/ai/MINIGAME/SG_GF/SERVER/SGCannon.cpp
@@ -61,6 +61,7 @@ void SGCannon::OnStartup(Entity* self) {
 	if (simplePhysicsComponent != nullptr) {
 		simplePhysicsComponent->SetPhysicsMotionState(5);
 	}
+	Game::entityManager->SerializeEntity(self);
 }
 
 void SGCannon::OnPlayerLoaded(Entity* self, Entity* player) {


### PR DESCRIPTION
global fix correcting the initial physics motion state from 0 to 5 (confirmed in client).  packet captures from a few worlds (didnt scan more than 5 files) show that the value for simple physics was either 5 as the default, or 4 for property models, or 1 for property models with behaviors.

properties with pre-built models no longer lag and values of physics types should be correct across the board. Not sure what else this fixes but probably more stuff related to performance