### PR TITLE
fix: Cache compiler variables so external tools can recognize the compiler in use

### DIFF
--- a/cmake/toolchains/linux-clang.cmake
+++ b/cmake/toolchains/linux-clang.cmake
@@ -6,9 +6,9 @@ find_program(CLANG_CXX_COMPILER clang++-16 | clang++ REQUIRED)
 message(DEBUG "CLANG_C_COMPILER = ${CLANG_C_COMPILER}")
 message(DEBUG "CLANG_CXX_COMPILER = ${CLANG_CXX_COMPILER}")
 
-# Set compilers to clang
-set(CMAKE_C_COMPILER ${CLANG_C_COMPILER})
-set(CMAKE_CXX_COMPILER ${CLANG_CXX_COMPILER})
+# Set compilers to clang (need to cache for VSCode tools to work correctly)
+set(CMAKE_C_COMPILER ${CLANG_C_COMPILER} CACHE STRING "Set C compiler")
+set(CMAKE_CXX_COMPILER ${CLANG_CXX_COMPILER} CACHE STRING "Set C++ compiler")
 
 # Set linker to lld
 add_link_options("-fuse-ld=lld")

--- a/cmake/toolchains/linux-gnu.cmake
+++ b/cmake/toolchains/linux-gnu.cmake
@@ -4,8 +4,8 @@ find_program(GNU_CXX_COMPILER c++ | g++ REQUIRED)
 
 # Debug messages
 message(DEBUG "GNU_C_COMPILER = ${GNU_C_COMPILER}")
-message(DEBUG "GNU_CXX_COMPILER = ${GNU_C_COMPILER}")
+message(DEBUG "GNU_CXX_COMPILER = ${GNU_CXX_COMPILER}")
 
-# Set compilers to clang
-set(CMAKE_C_COMPILER ${GNU_C_COMPILER})
-set(CMAKE_CXX_COMPILER ${GNU_CXX_COMPILER})
+# Set compilers to GNU (need to cache for VSCode tools to work correctly)
+set(CMAKE_C_COMPILER ${GNU_C_COMPILER} CACHE STRING "Set C compiler")
+set(CMAKE_CXX_COMPILER ${GNU_CXX_COMPILER} CACHE STRING "Set C++ compiler")


### PR DESCRIPTION
The VSCode C++ tools need the compiler variables to be present in CMakeCachhe.txt in order for options like quick debug to work. Also, I fixed a typo or two.