### PR TITLE
fix: stack traces work again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if(UNIX)
 	endif()
 
 	if(${DYNAMIC} AND CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-		add_compile_options("-rdynamic")
+		add_link_options("-export-dynamic")
 	endif()
 
 	if(${GGDB})


### PR DESCRIPTION
idk man stack traces work again
-rdynamic is === -export-dynamic 
the former is the compiler passing the latter to the linker, dont know why the order matters for this one but this works