### PR TITLE
fix: Player activated switches

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -1351,11 +1351,6 @@ void Entity::OnCollisionPhantom(const LWOOBJID otherEntity) {
 		callback(other);
 	}
 
-	SwitchComponent* switchComp = GetComponent<SwitchComponent>();
-	if (switchComp) {
-		switchComp->EntityEnter(other);
-	}
-
 	TriggerEvent(eTriggerEventType::ENTER, other);
 
 	// POI system

--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -381,7 +381,7 @@ void PetComponent::Update(float deltaTime) {
 			float distance = Vector3::DistanceSquared(position, switchPosition);
 			if (distance < 3 * 3) {
 				m_Interaction = closestSwitch->GetParentEntity()->GetObjectID();
-				closestSwitch->EntityEnter(m_Parent);
+				closestSwitch->OnUse(m_Parent);
 			} else if (distance < 20 * 20) {
 				haltDistance = 1;
 

--- a/dGame/dComponents/SwitchComponent.h
+++ b/dGame/dComponents/SwitchComponent.h
@@ -22,6 +22,7 @@ public:
 	~SwitchComponent() override;
 
 	void Update(float deltaTime) override;
+	void OnUse(Entity* originator) override;
 
 	Entity* GetParentEntity() const;
 
@@ -101,6 +102,8 @@ private:
 	 * Attached pet bouncer
 	 */
 	BouncerComponent* m_PetBouncer = nullptr;
+
+	std::vector<int32_t> m_FactionsToRespondTo{};
 };
 
 #endif // SWITCHCOMPONENT_H


### PR DESCRIPTION
Tested that player activated switches are no longer activatable by pets and are no longer activated by something stepping in the vicinity.
Tested that pet switches have the same behavior as prior.