### PR TITLE
fix: logging uninitialized memory

### DIFF
--- a/dNet/AuthPackets.cpp
+++ b/dNet/AuthPackets.cpp
@@ -87,6 +87,13 @@ void AuthPackets::SendHandshake(dServer* server, const SystemAddress& sysAddr, c
 	server->Send(bitStream, sysAddr, false);
 }
 
+std::string CleanReceivedString(const std::string& str) {
+	std::string toReturn = str;
+	const auto removed = std::ranges::find_if(toReturn, [](char c) { return isprint(c) == 0 && isblank(c) == 0; });
+	toReturn.erase(removed, toReturn.end());
+	return toReturn;
+}
+
 void AuthPackets::HandleLoginRequest(dServer* server, Packet* packet) {
 	CINSTREAM_SKIP_HEADER;
 
@@ -111,11 +118,11 @@ void AuthPackets::HandleLoginRequest(dServer* server, Packet* packet) {
 
 	LUWString memoryStats(256);
 	inStream.Read(memoryStats);
-	LOG_DEBUG("Memory Stats [%s]", memoryStats.GetAsString().c_str());
+	LOG_DEBUG("Memory Stats [%s]", CleanReceivedString(memoryStats.GetAsString()).c_str());
 
 	LUWString videoCard(128);
 	inStream.Read(videoCard);
-	LOG_DEBUG("VideoCard Info: [%s]", videoCard.GetAsString().c_str());
+	LOG_DEBUG("VideoCard Info: [%s]", CleanReceivedString(videoCard.GetAsString()).c_str());
 
 	// Processor/CPU info
 	uint32_t numOfProcessors;


### PR DESCRIPTION
fixes an issue where the console would halt because we printed a control code which did such