### PR TITLE
fix: use generic exception catching

### DIFF
--- a/dAuthServer/AuthServer.cpp
+++ b/dAuthServer/AuthServer.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
 
 	try {
 		Database::Connect();
-	} catch (sql::SQLException& ex) {
+	} catch (std::exception& ex) {
 		LOG("Got an error while connecting to the database: %s", ex.what());
 		Database::Destroy("AuthServer");
 		delete Game::server;

--- a/dChatServer/ChatServer.cpp
+++ b/dChatServer/ChatServer.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv) {
 	//Connect to the MySQL Database
 	try {
 		Database::Connect();
-	} catch (sql::SQLException& ex) {
+	} catch (std::exception& ex) {
 		LOG("Got an error while connecting to the database: %s", ex.what());
 		Database::Destroy("ChatServer");
 		delete Game::server;

--- a/dCommon/BrickByBrickFix.cpp
+++ b/dCommon/BrickByBrickFix.cpp
@@ -123,7 +123,7 @@ uint32_t BrickByBrickFix::UpdateBrickByBrickModelsToSd0() {
 				Database::Get()->UpdateUgcModelData(model.id, outputStringStream);
 				LOG("Updated model %i to sd0", model.id);
 				updatedModels++;
-			} catch (sql::SQLException exception) {
+			} catch (std::exception& exception) {
 				LOG("Failed to update model %i.  This model should be inspected manually to see why."
 					"The database error is %s", model.id, exception.what());
 			}

--- a/dDatabase/MigrationRunner.cpp
+++ b/dDatabase/MigrationRunner.cpp
@@ -34,7 +34,7 @@ Migration LoadMigration(std::string path) {
 void MigrationRunner::RunMigrations() {
 	Database::Get()->CreateMigrationHistoryTable();
 
-	sql::SQLString finalSQL = "";
+	std::string finalSQL = "";
 	bool runSd0Migrations = false;
 	for (const auto& entry : GeneralUtils::GetSqlFileNamesFromFolder((BinaryPathFinder::GetBinaryDir() / "./migrations/dlu/").string())) {
 		auto migration = LoadMigration("dlu/" + entry);
@@ -61,12 +61,12 @@ void MigrationRunner::RunMigrations() {
 	}
 
 	if (!finalSQL.empty()) {
-		auto migration = GeneralUtils::SplitString(static_cast<std::string>(finalSQL), ';');
+		auto migration = GeneralUtils::SplitString(finalSQL, ';');
 		for (auto& query : migration) {
 			try {
 				if (query.empty()) continue;
-				Database::Get()->ExecuteCustomQuery(query.c_str());
-			} catch (sql::SQLException& e) {
+				Database::Get()->ExecuteCustomQuery(query);
+			} catch (std::exception& e) {
 				LOG("Encountered error running migration: %s", e.what());
 			}
 		}

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -103,7 +103,7 @@ int main(int argc, char** argv) {
 	//Connect to the MySQL Database
 	try {
 		Database::Connect();
-	} catch (sql::SQLException& ex) {
+	} catch (std::exception& ex) {
 		LOG("Got an error while connecting to the database: %s", ex.what());
 		LOG("Migrations not run");
 		return EXIT_FAILURE;
@@ -264,7 +264,7 @@ int main(int argc, char** argv) {
 		//Create account
 		try {
 			Database::Get()->InsertNewAccount(username, std::string(hash, BCRYPT_HASHSIZE));
-		} catch (sql::SQLException& e) {
+		} catch (std::exception& e) {
 			LOG("A SQL error occurred!:\n %s", e.what());
 			return EXIT_FAILURE;
 		}

--- a/dMasterServer/PersistentIDManager.cpp
+++ b/dMasterServer/PersistentIDManager.cpp
@@ -24,9 +24,9 @@ void PersistentIDManager::Initialize() {
 			LOG("Invalid persistent object ID in database. Aborting to prevent bad id generation.");
 			throw std::runtime_error("Invalid persistent object ID in database. Aborting to prevent bad id generation.");
 		}
-	} catch (sql::SQLException& e) {
+	} catch (std::exception& e) {
 		LOG("Unable to fetch max persistent object ID in use. This will cause issues. Aborting to prevent collisions.");
-		LOG("SQL error: %s", e.what());
+		LOG("Error: %s", e.what());
 		throw e;
 	}
 }

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -194,7 +194,7 @@ int main(int argc, char** argv) {
 	//Connect to the MySQL Database:
 	try {
 		Database::Connect();
-	} catch (sql::SQLException& ex) {
+	} catch (std::exception& ex) {
 		LOG("Got an error while connecting to the database: %s", ex.what());
 		return EXIT_FAILURE;
 	}


### PR DESCRIPTION
further removes database specific code from the database.

Tested that all 4 servers hit their catch block with a non-running mariadb instance
Tested that a failed object_id_tracker fetch (i.e. missing table) hit the catch
Tested that a bad migration hit the catch.