### PR TITLE
fix: use a default for build type if one is not specified

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,10 @@ if("${CMAKE_SOURCE_DIR}" MATCHES " ")
 	message(FATAL_ERROR "The server cannot build in the path (" ${CMAKE_SOURCE_DIR} ") because it contains a space. Please move the server to a path without spaces.")
 endif()
 
+if (NOT CMAKE_BUILD_TYPE) 
+	set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "The default build type" FORCE)
+endif()
+
 include(CTest)
 
 set(CMAKE_C_STANDARD 99)


### PR DESCRIPTION
tested that flags are set appropriately for the root folder if no cmake build type is specified, and that linux-gnu-release has its -03 flags set as per usual