### PR TITLE
fix: use current binary directory mariadb shared object and dont override env variable

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,6 +43,7 @@ jobs:
           build/*/*.ini
           build/*/*.so
           build/*/*.dll
+          build/*/*.dylib
           build/*/vanity/
           build/*/navmeshes/
           build/*/migrations/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ set(RECASTNAVIGATION_EXAMPLES OFF CACHE BOOL "" FORCE)
 # Disabled no-register
 # Disabled unknown pragmas because Linux doesn't understand Windows pragmas.
 if(UNIX)
+	add_link_options("-Wl,-rpath,$ORIGIN/")
 	add_compile_options("-fPIC")
 	add_compile_definitions(_GLIBCXX_USE_CXX11_ABI=0 _GLIBCXX_USE_CXX17_ABI=0)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,9 +11,6 @@
 			"displayName": "Default configure step",
 			"description": "Use 'build' dir and Unix makefiles",
 			"binaryDir": "${sourceDir}/build",
-			"environment": {
-				"DLU_CONFIG_DIR": "${sourceDir}/build"
-			},
 			"generator": "Unix Makefiles"
 		},
 		{

--- a/dDatabase/CMakeLists.txt
+++ b/dDatabase/CMakeLists.txt
@@ -2,6 +2,12 @@ add_subdirectory(CDClientDatabase)
 add_subdirectory(GameDatabase)
 
 add_library(dDatabase STATIC "MigrationRunner.cpp")
+
+add_custom_target(conncpp_dylib
+	${CMAKE_COMMAND} -E copy $<TARGET_FILE:MariaDB::ConnCpp> ${PROJECT_BINARY_DIR})
+
+add_dependencies(dDatabase conncpp_dylib)
+
 target_include_directories(dDatabase PUBLIC ".")
 target_link_libraries(dDatabase
 	PUBLIC dDatabaseCDClient dDatabaseGame)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,15 +4,6 @@ enable_testing()
 find_package(GoogleTest REQUIRED)
 include(GoogleTest)
 
-if(APPLE)
-	set(CMAKE_INSTALL_RPATH_USE_LINK_PATH True)
-	set(CMAKE_BUILD_WITH_INSTALL_RPATH True)
-	set(CMAKE_INSTALL_RPATH "@executable_path")
-endif()
-
-add_custom_target(conncpp_tests
-	${CMAKE_COMMAND} -E copy $<TARGET_FILE:MariaDB::ConnCpp> ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-
 # Add the subdirectories
 add_subdirectory(dCommonTests)
 add_subdirectory(dGameTests)

--- a/tests/dCommonTests/CMakeLists.txt
+++ b/tests/dCommonTests/CMakeLists.txt
@@ -17,18 +17,13 @@ list(APPEND DCOMMONTEST_SOURCES ${DENUMS_TESTS})
 
 # Set our executable
 add_executable(dCommonTests ${DCOMMONTEST_SOURCES})
-add_dependencies(dCommonTests conncpp_tests)
 
-# Apple needs some special linkage for the mariadb connector for tests.
+# Needs to be in binary dir for ctest 
 if(APPLE)
-add_custom_command(TARGET dCommonTests POST_BUILD
-	COMMAND otool ARGS -l dCommonTests
-	COMMAND otool ARGS -L dCommonTests
-	COMMAND ls
-	COMMAND otool ARGS -D libmariadbcpp.dylib
-	COMMAND install_name_tool ARGS -change libmariadbcpp.dylib @rpath/libmariadbcpp.dylib dCommonTests
-	COMMAND otool ARGS -L dCommonTests
-	WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+	add_custom_target(dCommonTestsLink
+		${CMAKE_COMMAND} -E copy $<TARGET_FILE:MariaDB::ConnCpp> ${CMAKE_CURRENT_BINARY_DIR})
+
+	add_dependencies(dCommonTests dCommonTestsLink)
 endif()
 
 # Link needed libraries

--- a/tests/dGameTests/CMakeLists.txt
+++ b/tests/dGameTests/CMakeLists.txt
@@ -13,14 +13,12 @@ file(COPY ${COMPONENT_TEST_DATA} DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 
 # Add the executable.  Remember to add all tests above this!
 add_executable(dGameTests ${DGAMETEST_SOURCES})
-add_dependencies(dGameTests conncpp_tests)
 
-# Apple needs some special linkage for the mariadb connector for tests.
 if(APPLE)
-add_custom_command(TARGET dGameTests POST_BUILD
-	COMMAND install_name_tool ARGS -change libmariadbcpp.dylib @rpath/libmariadbcpp.dylib dGameTests
-	COMMAND otool ARGS -L dGameTests
-	WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+	add_custom_target(dGameTestsLink
+		${CMAKE_COMMAND} -E copy $<TARGET_FILE:MariaDB::ConnCpp> ${CMAKE_CURRENT_BINARY_DIR})
+
+	add_dependencies(dGameTests dGameTestsLink)
 endif()
 
 target_link_libraries(dGameTests ${COMMON_LIBRARIES} GTest::gtest_main


### PR DESCRIPTION
we were overwriting the users environment variable with the build directory always, resulting in inis always being placed in the incorrect spot if a preset was specified, or if the user had an environment variable where they stored the inis.

Also, assuming it passes ci, made it so we use the shared library in the binary directory as opposed to the one

mac please