### PR TITLE
fix: Make multi-config presets work again

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -11,6 +11,9 @@
 			"displayName": "Default configure step",
 			"description": "Use 'build' dir and Unix makefiles",
 			"binaryDir": "${sourceDir}/build",
+			"environment": {
+				"DLU_CONFIG_DIR": "${sourceDir}/build"
+			},
 			"generator": "Unix Makefiles"
 		},
 		{


### PR DESCRIPTION
Reverted breaking change for multiple-configuration presets that was previously included in #1669