### PR TITLE
feat: Remove reinterpret_casts from AG race timer script and add method and chat command to get current server uptime

### DIFF
--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -1056,6 +1056,15 @@ void SlashCommandHandler::Startup() {
 	};
 	RegisterCommand(InstanceInfoCommand);
 
+	Command ServerUptimeCommand{
+		.help = "Display the time the current server has been active",
+		.info = "Display the time the current server has been active",
+		.aliases = { "serveruptime", "uptime" },
+		.handle = GMZeroCommands::ServerUptime,
+		.requiredLevel = eGameMasterLevel::CIVILIAN
+	};
+	RegisterCommand(ServerUptimeCommand);
+
 	//Commands that are handled by the client
 
 	Command faqCommand{

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -1061,7 +1061,7 @@ void SlashCommandHandler::Startup() {
 		.info = "Display the time the current world server has been active",
 		.aliases = { "uptime" },
 		.handle = GMZeroCommands::ServerUptime,
-		.requiredLevel = eGameMasterLevel::CIVILIAN
+		.requiredLevel = eGameMasterLevel::FORUM_MODERATOR
 	};
 	RegisterCommand(ServerUptimeCommand);
 

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -1057,9 +1057,9 @@ void SlashCommandHandler::Startup() {
 	RegisterCommand(InstanceInfoCommand);
 
 	Command ServerUptimeCommand{
-		.help = "Display the time the current server has been active",
-		.info = "Display the time the current server has been active",
-		.aliases = { "serveruptime", "uptime" },
+		.help = "Display the time the current world server has been active",
+		.info = "Display the time the current world server has been active",
+		.aliases = { "uptime" },
 		.handle = GMZeroCommands::ServerUptime,
 		.requiredLevel = eGameMasterLevel::CIVILIAN
 	};

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -1061,7 +1061,7 @@ void SlashCommandHandler::Startup() {
 		.info = "Display the time the current world server has been active",
 		.aliases = { "uptime" },
 		.handle = GMZeroCommands::ServerUptime,
-		.requiredLevel = eGameMasterLevel::FORUM_MODERATOR
+		.requiredLevel = eGameMasterLevel::DEVELOPER
 	};
 	RegisterCommand(ServerUptimeCommand);
 

--- a/dGame/dUtilities/SlashCommands/GMZeroCommands.cpp
+++ b/dGame/dUtilities/SlashCommands/GMZeroCommands.cpp
@@ -225,8 +225,13 @@ namespace GMZeroCommands {
 		ChatPackets::SendSystemMessage(sysAddr, u"Map: " + (GeneralUtils::to_u16string(zoneId.GetMapID())) + u"\nClone: " + (GeneralUtils::to_u16string(zoneId.GetCloneID())) + u"\nInstance: " + (GeneralUtils::to_u16string(zoneId.GetInstanceID())));
 	}
 
+	// Display the server uptime
+	void ServerUptime(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto time = Game::server->GetUptime();
+		const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(time).count();
+		ChatPackets::SendSystemMessage(sysAddr, u"Server has been up for " + GeneralUtils::to_u16string(seconds) + u" s");
+	}
+
 	//For client side commands
 	void ClientHandled(Entity* entity, const SystemAddress& sysAddr, const std::string args) {}
-
 };
-

--- a/dGame/dUtilities/SlashCommands/GMZeroCommands.h
+++ b/dGame/dUtilities/SlashCommands/GMZeroCommands.h
@@ -15,6 +15,7 @@ namespace GMZeroCommands {
 	void LeaveZone(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void Resurrect(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void InstanceInfo(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void ServerUptime(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void ClientHandled(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 }
 

--- a/dNet/dServer.h
+++ b/dNet/dServer.h
@@ -81,7 +81,10 @@ public:
 
 	const ServerType GetServerType() const { return mServerType; }
 
-	[[nodiscard]] std::chrono::time_point<std::chrono::steady_clock> GetStartTime() const { return m_startTime; }
+	[[nodiscard]]
+	std::chrono::steady_clock::duration GetUptime() const {
+		return std::chrono::steady_clock::now() - mStartTime;
+	}
 
 private:
 	bool Startup();
@@ -117,5 +120,5 @@ protected:
 	SystemAddress mMasterSystemAddress;
 	std::string mMasterIP;
 	int mMasterPort;
-	std::chrono::time_point<std::chrono::steady_clock> m_startTime = std::chrono::steady_clock::now();
+	std::chrono::steady_clock::time_point mStartTime = std::chrono::steady_clock::now();
 };

--- a/dNet/dServer.h
+++ b/dNet/dServer.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <chrono>
 #include <csignal>
 #include "RakPeerInterface.h"
 #include "ReplicaManager.h"
@@ -80,6 +81,8 @@ public:
 
 	const ServerType GetServerType() const { return mServerType; }
 
+	[[nodiscard]] std::chrono::time_point<std::chrono::steady_clock> GetStartTime() const { return m_startTime; }
+
 private:
 	bool Startup();
 	void Shutdown();
@@ -114,4 +117,5 @@ protected:
 	SystemAddress mMasterSystemAddress;
 	std::string mMasterIP;
 	int mMasterPort;
+	std::chrono::time_point<std::chrono::steady_clock> m_startTime = std::chrono::steady_clock::now();
 };

--- a/dScripts/02_server/Map/AG/NpcAgCourseStarter.cpp
+++ b/dScripts/02_server/Map/AG/NpcAgCourseStarter.cpp
@@ -3,23 +3,17 @@
 #include "ScriptedActivityComponent.h"
 #include "GameMessages.h"
 #include "LeaderboardManager.h"
+#include "dServer.h"
 #include "eMissionTaskType.h"
 #include "eMissionState.h"
 #include "MissionComponent.h"
-#include <ctime>
 #include <chrono>
-#include "dServer.h"
 
-void NpcAgCourseStarter::OnStartup(Entity* self) {
-
-}
+void NpcAgCourseStarter::OnStartup(Entity* self) {}
 
 void NpcAgCourseStarter::OnUse(Entity* self, Entity* user) {
-	auto* scriptedActivityComponent = self->GetComponent<ScriptedActivityComponent>();
-
-	if (scriptedActivityComponent == nullptr) {
-		return;
-	}
+	auto* const scriptedActivityComponent = self->GetComponent<ScriptedActivityComponent>();
+	if (!scriptedActivityComponent) return;
 
 	if (scriptedActivityComponent->GetActivityPlayerData(user->GetObjectID()) != nullptr) {
 		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"exit", 0, 0, LWOOBJID_EMPTY, "", user->GetSystemAddress());
@@ -29,15 +23,11 @@ void NpcAgCourseStarter::OnUse(Entity* self, Entity* user) {
 }
 
 void NpcAgCourseStarter::OnMessageBoxResponse(Entity* self, Entity* sender, int32_t button, const std::u16string& identifier, const std::u16string& userData) {
-	auto* scriptedActivityComponent = self->GetComponent<ScriptedActivityComponent>();
-
-	if (scriptedActivityComponent == nullptr) {
-		return;
-	}
+	auto* const scriptedActivityComponent = self->GetComponent<ScriptedActivityComponent>();
+	if (!scriptedActivityComponent) return;
 
 	if (identifier == u"player_dialog_cancel_course" && button == 1) {
 		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"stop_timer", 0, 0, LWOOBJID_EMPTY, "", sender->GetSystemAddress());
-
 		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"cancel_timer", 0, 0, LWOOBJID_EMPTY, "", sender->GetSystemAddress());
 
 		scriptedActivityComponent->RemoveActivityPlayerData(sender->GetObjectID());
@@ -45,17 +35,15 @@ void NpcAgCourseStarter::OnMessageBoxResponse(Entity* self, Entity* sender, int3
 		Game::entityManager->SerializeEntity(self);
 	} else if (identifier == u"player_dialog_start_course" && button == 1) {
 		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"start_timer", 0, 0, LWOOBJID_EMPTY, "", sender->GetSystemAddress());
-
 		GameMessages::SendActivityStart(self->GetObjectID(), sender->GetSystemAddress());
 
-		auto* data = scriptedActivityComponent->AddActivityPlayerData(sender->GetObjectID());
+		auto* const data = scriptedActivityComponent->AddActivityPlayerData(sender->GetObjectID());
 		if (data->values[1] != 0) return;
 
 		const auto raceStartTime = std::chrono::steady_clock::now() - Game::server->GetStartTime()
 			+ std::chrono::seconds(4);  // Offset for starting timer
 		const auto fRaceStartTime = std::chrono::duration<float, std::ratio<1>>(raceStartTime).count();
 		data->values[1] = fRaceStartTime;
-		LOG_DEBUG("Race started at: %0.f s", fRaceStartTime);
 
 		Game::entityManager->SerializeEntity(self);
 	} else if (identifier == u"FootRaceCancel") {
@@ -72,11 +60,11 @@ void NpcAgCourseStarter::OnMessageBoxResponse(Entity* self, Entity* sender, int3
 }
 
 void NpcAgCourseStarter::OnFireEventServerSide(Entity* self, Entity* sender, std::string args, int32_t param1, int32_t param2, int32_t param3) {
-	auto* scriptedActivityComponent = self->GetComponent<ScriptedActivityComponent>();
-	if (scriptedActivityComponent == nullptr) return;
+	auto* const scriptedActivityComponent = self->GetComponent<ScriptedActivityComponent>();
+	if (!scriptedActivityComponent) return;
 
-	auto* data = scriptedActivityComponent->GetActivityPlayerData(sender->GetObjectID());
-	if (data == nullptr) return;
+	auto* const data = scriptedActivityComponent->GetActivityPlayerData(sender->GetObjectID());
+	if (!data) return;
 
 	if (args == "course_cancel") {
 		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"cancel_timer", 0, 0,
@@ -86,11 +74,9 @@ void NpcAgCourseStarter::OnFireEventServerSide(Entity* self, Entity* sender, std
 		const auto raceEndTime = std::chrono::steady_clock::now() - Game::server->GetStartTime();
 		const auto fRaceEndTime = std::chrono::duration<float, std::ratio<1>>(raceEndTime).count();
 		const auto raceTimeElapsed = fRaceEndTime - data->values[1];
-
 		data->values[2] = raceTimeElapsed;
-		LOG_DEBUG("Race time elapsed: %0.f s", raceTimeElapsed);
 
-		auto* missionComponent = sender->GetComponent<MissionComponent>();
+		auto* const missionComponent = sender->GetComponent<MissionComponent>();
 		if (missionComponent != nullptr) {
 			missionComponent->ForceProgressTaskType(1884, 1, 1, false);
 			missionComponent->Progress(eMissionTaskType::PERFORM_ACTIVITY, -raceTimeElapsed, self->GetObjectID(),

--- a/dScripts/02_server/Map/AG/NpcAgCourseStarter.cpp
+++ b/dScripts/02_server/Map/AG/NpcAgCourseStarter.cpp
@@ -17,7 +17,7 @@ void NpcAgCourseStarter::OnUse(Entity* self, Entity* user) {
 
 	const auto selfId = self->GetObjectID();
 	const auto userId = user->GetObjectID();
-	const auto userSysAddr = user->GetSystemAddress();
+	const auto& userSysAddr = user->GetSystemAddress();
 
 	if (scriptedActivityComponent->GetActivityPlayerData(userId) != nullptr) {
 		GameMessages::SendNotifyClientObject(selfId, u"exit", 0, 0, LWOOBJID_EMPTY, "", userSysAddr);
@@ -32,7 +32,7 @@ void NpcAgCourseStarter::OnMessageBoxResponse(Entity* self, Entity* sender, int3
 
 	const auto selfId = self->GetObjectID();
 	const auto senderId = sender->GetObjectID();
-	const auto senderSysAddr = sender->GetSystemAddress();
+	const auto& senderSysAddr = sender->GetSystemAddress();
 
 	if (identifier == u"player_dialog_cancel_course" && button == 1) {
 		GameMessages::SendNotifyClientObject(selfId, u"stop_timer", 0, 0, LWOOBJID_EMPTY, "", senderSysAddr);
@@ -72,7 +72,7 @@ void NpcAgCourseStarter::OnFireEventServerSide(Entity* self, Entity* sender, std
 
 	const auto selfId = self->GetObjectID();
 	const auto senderId = sender->GetObjectID();
-	const auto senderSysAddr = sender->GetSystemAddress();
+	const auto& senderSysAddr = sender->GetSystemAddress();
 
 	auto* const data = scriptedActivityComponent->GetActivityPlayerData(senderId);
 	if (!data) return;

--- a/dScripts/02_server/Map/AG/NpcAgCourseStarter.cpp
+++ b/dScripts/02_server/Map/AG/NpcAgCourseStarter.cpp
@@ -15,10 +15,13 @@ void NpcAgCourseStarter::OnUse(Entity* self, Entity* user) {
 	auto* const scriptedActivityComponent = self->GetComponent<ScriptedActivityComponent>();
 	if (!scriptedActivityComponent) return;
 
+	const auto selfId = self->GetObjectID();
+	const auto userSysAddr = user->GetSystemAddress();
+
 	if (scriptedActivityComponent->GetActivityPlayerData(user->GetObjectID()) != nullptr) {
-		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"exit", 0, 0, LWOOBJID_EMPTY, "", user->GetSystemAddress());
+		GameMessages::SendNotifyClientObject(selfId, u"exit", 0, 0, LWOOBJID_EMPTY, "", userSysAddr);
 	} else {
-		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"start", 0, 0, LWOOBJID_EMPTY, "", user->GetSystemAddress());
+		GameMessages::SendNotifyClientObject(selfId, u"start", 0, 0, LWOOBJID_EMPTY, "", userSysAddr);
 	}
 }
 
@@ -26,36 +29,39 @@ void NpcAgCourseStarter::OnMessageBoxResponse(Entity* self, Entity* sender, int3
 	auto* const scriptedActivityComponent = self->GetComponent<ScriptedActivityComponent>();
 	if (!scriptedActivityComponent) return;
 
-	if (identifier == u"player_dialog_cancel_course" && button == 1) {
-		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"stop_timer", 0, 0, LWOOBJID_EMPTY, "", sender->GetSystemAddress());
-		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"cancel_timer", 0, 0, LWOOBJID_EMPTY, "", sender->GetSystemAddress());
+	const auto selfId = self->GetObjectID();
+	const auto senderId = sender->GetObjectID();
+	const auto senderSysAddr = sender->GetSystemAddress();
 
-		scriptedActivityComponent->RemoveActivityPlayerData(sender->GetObjectID());
+	if (identifier == u"player_dialog_cancel_course" && button == 1) {
+		GameMessages::SendNotifyClientObject(selfId, u"stop_timer", 0, 0, LWOOBJID_EMPTY, "", senderSysAddr);
+		GameMessages::SendNotifyClientObject(selfId, u"cancel_timer", 0, 0, LWOOBJID_EMPTY, "", senderSysAddr);
+
+		scriptedActivityComponent->RemoveActivityPlayerData(senderId);
 
 		Game::entityManager->SerializeEntity(self);
 	} else if (identifier == u"player_dialog_start_course" && button == 1) {
-		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"start_timer", 0, 0, LWOOBJID_EMPTY, "", sender->GetSystemAddress());
-		GameMessages::SendActivityStart(self->GetObjectID(), sender->GetSystemAddress());
+		GameMessages::SendNotifyClientObject(selfId, u"start_timer", 0, 0, LWOOBJID_EMPTY, "", senderSysAddr);
+		GameMessages::SendActivityStart(selfId, senderSysAddr);
 
-		auto* const data = scriptedActivityComponent->AddActivityPlayerData(sender->GetObjectID());
+		auto* const data = scriptedActivityComponent->AddActivityPlayerData(selfId);
 		if (data->values[1] != 0) return;
 
-		const auto raceStartTime = std::chrono::steady_clock::now() - Game::server->GetStartTime()
-			+ std::chrono::seconds(4);  // Offset for starting timer
+		const auto raceStartTime = Game::server->GetUptime() + std::chrono::seconds(4); // Offset for starting timer
 		const auto fRaceStartTime = std::chrono::duration<float, std::ratio<1>>(raceStartTime).count();
 		data->values[1] = fRaceStartTime;
 
 		Game::entityManager->SerializeEntity(self);
 	} else if (identifier == u"FootRaceCancel") {
-		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"stop_timer", 0, 0, LWOOBJID_EMPTY, "", sender->GetSystemAddress());
+		GameMessages::SendNotifyClientObject(selfId, u"stop_timer", 0, 0, LWOOBJID_EMPTY, "", senderSysAddr);
 
-		if (scriptedActivityComponent->GetActivityPlayerData(sender->GetObjectID()) != nullptr) {
-			GameMessages::SendNotifyClientObject(self->GetObjectID(), u"exit", 0, 0, LWOOBJID_EMPTY, "", sender->GetSystemAddress());
+		if (scriptedActivityComponent->GetActivityPlayerData(senderId) != nullptr) {
+			GameMessages::SendNotifyClientObject(selfId, u"exit", 0, 0, LWOOBJID_EMPTY, "", senderSysAddr);
 		} else {
-			GameMessages::SendNotifyClientObject(self->GetObjectID(), u"start", 0, 0, LWOOBJID_EMPTY, "", sender->GetSystemAddress());
+			GameMessages::SendNotifyClientObject(selfId, u"start", 0, 0, LWOOBJID_EMPTY, "", senderSysAddr);
 		}
 
-		scriptedActivityComponent->RemoveActivityPlayerData(sender->GetObjectID());
+		scriptedActivityComponent->RemoveActivityPlayerData(senderId);
 	}
 }
 
@@ -63,15 +69,19 @@ void NpcAgCourseStarter::OnFireEventServerSide(Entity* self, Entity* sender, std
 	auto* const scriptedActivityComponent = self->GetComponent<ScriptedActivityComponent>();
 	if (!scriptedActivityComponent) return;
 
-	auto* const data = scriptedActivityComponent->GetActivityPlayerData(sender->GetObjectID());
+	const auto selfId = self->GetObjectID();
+	const auto senderId = sender->GetObjectID();
+	const auto senderSysAddr = sender->GetSystemAddress();
+
+	auto* const data = scriptedActivityComponent->GetActivityPlayerData(senderId);
 	if (!data) return;
 
 	if (args == "course_cancel") {
-		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"cancel_timer", 0, 0,
-			LWOOBJID_EMPTY, "", sender->GetSystemAddress());
-		scriptedActivityComponent->RemoveActivityPlayerData(sender->GetObjectID());
+		GameMessages::SendNotifyClientObject(selfId, u"cancel_timer", 0, 0,
+			LWOOBJID_EMPTY, "", senderSysAddr);
+		scriptedActivityComponent->RemoveActivityPlayerData(senderId);
 	} else if (args == "course_finish") {
-		const auto raceEndTime = std::chrono::steady_clock::now() - Game::server->GetStartTime();
+		const auto raceEndTime = Game::server->GetUptime();
 		const auto fRaceEndTime = std::chrono::duration<float, std::ratio<1>>(raceEndTime).count();
 		const auto raceTimeElapsed = fRaceEndTime - data->values[1];
 		data->values[2] = raceTimeElapsed;
@@ -79,19 +89,19 @@ void NpcAgCourseStarter::OnFireEventServerSide(Entity* self, Entity* sender, std
 		auto* const missionComponent = sender->GetComponent<MissionComponent>();
 		if (missionComponent != nullptr) {
 			missionComponent->ForceProgressTaskType(1884, 1, 1, false);
-			missionComponent->Progress(eMissionTaskType::PERFORM_ACTIVITY, -raceTimeElapsed, self->GetObjectID(),
+			missionComponent->Progress(eMissionTaskType::PERFORM_ACTIVITY, -raceTimeElapsed, selfId,
 				"performact_time");
 		}
 
 		Game::entityManager->SerializeEntity(self);
-		LeaderboardManager::SaveScore(sender->GetObjectID(), scriptedActivityComponent->GetActivityID(), raceTimeElapsed);
+		LeaderboardManager::SaveScore(senderId, scriptedActivityComponent->GetActivityID(), raceTimeElapsed);
 
-		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"ToggleLeaderBoard",
-			scriptedActivityComponent->GetActivityID(), 0, sender->GetObjectID(),
-			"", sender->GetSystemAddress());
-		GameMessages::SendNotifyClientObject(self->GetObjectID(), u"stop_timer", 1, raceTimeElapsed, LWOOBJID_EMPTY, "",
-			sender->GetSystemAddress());
+		GameMessages::SendNotifyClientObject(selfId, u"ToggleLeaderBoard",
+			scriptedActivityComponent->GetActivityID(), 0, senderId,
+			"", senderSysAddr);
+		GameMessages::SendNotifyClientObject(selfId, u"stop_timer", 1, raceTimeElapsed, LWOOBJID_EMPTY, "",
+			senderSysAddr);
 
-		scriptedActivityComponent->RemoveActivityPlayerData(sender->GetObjectID());
+		scriptedActivityComponent->RemoveActivityPlayerData(senderId);
 	}
 }

--- a/dScripts/02_server/Map/AG/NpcAgCourseStarter.cpp
+++ b/dScripts/02_server/Map/AG/NpcAgCourseStarter.cpp
@@ -16,9 +16,10 @@ void NpcAgCourseStarter::OnUse(Entity* self, Entity* user) {
 	if (!scriptedActivityComponent) return;
 
 	const auto selfId = self->GetObjectID();
+	const auto userId = user->GetObjectID();
 	const auto userSysAddr = user->GetSystemAddress();
 
-	if (scriptedActivityComponent->GetActivityPlayerData(user->GetObjectID()) != nullptr) {
+	if (scriptedActivityComponent->GetActivityPlayerData(userId) != nullptr) {
 		GameMessages::SendNotifyClientObject(selfId, u"exit", 0, 0, LWOOBJID_EMPTY, "", userSysAddr);
 	} else {
 		GameMessages::SendNotifyClientObject(selfId, u"start", 0, 0, LWOOBJID_EMPTY, "", userSysAddr);
@@ -44,7 +45,7 @@ void NpcAgCourseStarter::OnMessageBoxResponse(Entity* self, Entity* sender, int3
 		GameMessages::SendNotifyClientObject(selfId, u"start_timer", 0, 0, LWOOBJID_EMPTY, "", senderSysAddr);
 		GameMessages::SendActivityStart(selfId, senderSysAddr);
 
-		auto* const data = scriptedActivityComponent->AddActivityPlayerData(selfId);
+		auto* const data = scriptedActivityComponent->AddActivityPlayerData(senderId);
 		if (data->values[1] != 0) return;
 
 		const auto raceStartTime = Game::server->GetUptime() + std::chrono::seconds(4); // Offset for starting timer

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -45,7 +45,7 @@
 |setannmsg|`/setannmsg <title>`|Sets the message of an announcement.|8|
 |setanntitle|`/setanntitle <title>`|Sets the title of an announcement.|8|
 |shutdownuniverse|`/shutdownuniverse`|Sends a shutdown message to the master server. This will send an announcement to all players that the universe will shut down in 10 minutes.|9|
-|uptime|`/uptime`|Displays the time the current world server has been active.|10|
+|uptime|`/uptime`|Displays the time the current world server has been active.|8|
 
 ## Development Commands
 

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -45,6 +45,7 @@
 |setannmsg|`/setannmsg <title>`|Sets the message of an announcement.|8|
 |setanntitle|`/setanntitle <title>`|Sets the title of an announcement.|8|
 |shutdownuniverse|`/shutdownuniverse`|Sends a shutdown message to the master server. This will send an announcement to all players that the universe will shut down in 10 minutes.|9|
+|uptime|`/uptime`|Displays the time the current world server has been active.|10|
 
 ## Development Commands
 


### PR DESCRIPTION
Tested in game by running the race and verified that mission 1884 is correctly marked as completed when race is finished