### PR TITLE
fix: (workaround for client bug) closing news screen too quickly making items not appear

### DIFF
--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -1141,6 +1141,25 @@ void InventoryComponent::AddItemSkills(const LOT lot) {
 	SetSkill(slot, skill);
 }
 
+void InventoryComponent::FixInvisibleItems() {
+	const auto numberItemsLoadedPerFrame = 12.0f;
+	const auto callbackTime = 0.125f;
+	const auto arbitaryInventorySize = 300.0f; // max in live + dlu is less than 300, seems like a good number.
+	auto* const items = GetInventory(eInventoryType::ITEMS);
+	if (!items) return;
+
+	// Add an extra update to make sure the client can see all the items.
+	const auto something = static_cast<int32_t>(std::ceil(items->GetItems().size() / arbitaryInventorySize)) + 1;
+	LOG_DEBUG("Fixing invisible items with %i updates", something);
+
+	for (int32_t i = 1; i < something + 1; i++) {
+		// client loads 12 items every 1/8 seconds, we're adding a small hack to fix invisible inventory items due to closing the news screen too fast.
+		m_Parent->AddCallbackTimer((arbitaryInventorySize / numberItemsLoadedPerFrame) * callbackTime * i, [this]() {
+			GameMessages::SendUpdateInventoryUi(m_Parent->GetObjectID(), m_Parent->GetSystemAddress());
+			});
+	}
+}
+
 void InventoryComponent::RemoveItemSkills(const LOT lot) {
 	const auto info = Inventory::FindItemComponent(lot);
 

--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -404,6 +404,8 @@ public:
 	void UpdateGroup(const GroupUpdate& groupUpdate);
 	void RemoveGroup(const std::string& groupId);
 
+	void FixInvisibleItems();
+
 	~InventoryComponent() override;
 
 private:

--- a/dGame/dGameMessages/GameMessageHandler.cpp
+++ b/dGame/dGameMessages/GameMessageHandler.cpp
@@ -104,6 +104,18 @@ void GameMessageHandler::HandleMessage(RakNet::BitStream& inStream, const System
 		break;
 	}
 
+	// Currently not actually used for our implementation, however its used right now to get around invisible inventory items in the client.
+	case MessageType::Game::SELECT_SKILL: {
+		auto var = entity->GetVar<bool>(u"dlu_first_time_load");
+		if (var) {
+			entity->SetVar<bool>(u"dlu_first_time_load", false);
+			InventoryComponent* inventoryComponent = entity->GetComponent<InventoryComponent>();
+			
+			if (inventoryComponent) inventoryComponent->FixInvisibleItems();
+		}
+		break;
+	}
+
 	case MessageType::Game::PLAYER_LOADED: {
 		GameMessages::SendRestoreToPostLoadStats(entity, sysAddr);
 		entity->SetPlayerReadyForUpdates();

--- a/dGame/dGameMessages/GameMessages.h
+++ b/dGame/dGameMessages/GameMessages.h
@@ -677,6 +677,9 @@ namespace GameMessages {
 	void HandleUpdateInventoryGroup(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 	void HandleUpdateInventoryGroupContents(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 	void SendForceCameraTargetCycle(Entity* entity, bool bForceCycling, eCameraTargetCyclingMode cyclingMode, LWOOBJID optionalTargetID);
+
+	// This is a client gm however its default values are exactly what we need to get around the invisible inventory item issues.
+	void SendUpdateInventoryUi(LWOOBJID objectId, const SystemAddress& sysAddr);
 };
 
 #endif // GAMEMESSAGES_H


### PR DESCRIPTION
very hacky way to make it so player items are at the very least loaded after they close the news screen.

tested that closing the news screen too quickly no longer causes items in the inventory to be invisible.
performance impact from this is minimal and only happens on the initial login to a character. world transfers are unaffected.

yummy hacky code