### PR TITLE
fix: use simpler converter for latin1

### DIFF
--- a/dCommon/FdbToSqlite.cpp
+++ b/dCommon/FdbToSqlite.cpp
@@ -72,7 +72,7 @@ std::string FdbToSqlite::Convert::ReadString(std::istream& cdClientBuffer) {
 	const auto readString = BinaryIO::ReadU8String(cdClientBuffer);
 
 	cdClientBuffer.seekg(prevPosition);
-	return GeneralUtils::Latin1ToWTF8(readString);
+	return GeneralUtils::Latin1ToUTF8(readString);
 }
 
 int32_t FdbToSqlite::Convert::SeekPointer(std::istream& cdClientBuffer) {

--- a/dCommon/GeneralUtils.cpp
+++ b/dCommon/GeneralUtils.cpp
@@ -167,11 +167,18 @@ std::u16string GeneralUtils::ASCIIToUTF16(const std::string_view string, const s
 	return ret;
 }
 
+std::string GeneralUtils::Latin1ToUTF8(const std::u8string_view string, const size_t size) {
+	std::string toReturn{};
 
-//! Converts a (potentially-ill-formed) Latin1 string to UTF-8
+	for (const auto u : string) {
+		PushUTF8CodePoint(toReturn, u);
+	}
+	return toReturn;
+}
+
+//! Converts a (potentially-ill-formed) UTF-16 string to UTF-8
 //! See: <http://simonsapin.github.io/wtf-8/#decoding-ill-formed-utf-16>
-template<typename StringType>
-std::string ToWTF8(const StringType string, const size_t size) {
+std::string GeneralUtils::UTF16ToWTF8(const std::u16string_view string, const size_t size) {
 	const size_t newSize = MinSize(size, string);
 	std::string ret;
 	ret.reserve(newSize);
@@ -195,13 +202,6 @@ std::string ToWTF8(const StringType string, const size_t size) {
 	}
 
 	return ret;
-}
-std::string GeneralUtils::Latin1ToWTF8(const std::u8string_view string, const size_t size) {
-	return ToWTF8(string, size);
-}
-
-std::string GeneralUtils::UTF16ToWTF8(const std::u16string_view string, const size_t size) {
-	return ToWTF8(string, size);
 }
 
 bool GeneralUtils::CaseInsensitiveStringCompare(const std::string_view a, const std::string_view b) {

--- a/dCommon/GeneralUtils.h
+++ b/dCommon/GeneralUtils.h
@@ -57,7 +57,7 @@ namespace GeneralUtils {
 	  \param size A size to trim the string to. Default is SIZE_MAX (No trimming)
 	  \return An UTF-8 representation of the string
 	 */
-	std::string Latin1ToWTF8(const std::u8string_view string, const size_t size = SIZE_MAX);
+	std::string Latin1ToUTF8(const std::u8string_view string, const size_t size = SIZE_MAX);
 
 	//! Converts a UTF-16 string to a UTF-8 string
 	/*!


### PR DESCRIPTION
Still converts the cafe name

xipho is required to review this before it is merged.