### PR TITLE
fix: property entrance component optional

### DIFF
--- a/dDatabase/GameDatabase/MySQL/Tables/Property.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/Property.cpp
@@ -56,6 +56,7 @@ std::optional<IProperty::PropertyEntranceResult> MySQLDatabase::GetProperties(co
 			params.playerId
 		);
 		if (count->next()) {
+			if (!result) result = IProperty::PropertyEntranceResult();
 			result->totalEntriesMatchingQuery = count->getUInt("count");
 		}
 	} else {
@@ -109,11 +110,13 @@ std::optional<IProperty::PropertyEntranceResult> MySQLDatabase::GetProperties(co
 			params.playerSort
 		);
 		if (count->next()) {
+			if (!result) result = IProperty::PropertyEntranceResult();
 			result->totalEntriesMatchingQuery = count->getUInt("count");
 		}
 	}
 
 	while (properties->next()) {
+		if (!result) result = IProperty::PropertyEntranceResult();
 		auto& entry = result->entries.emplace_back();
 		entry.id = properties->getUInt64("id");
 		entry.ownerId = properties->getUInt64("owner_id");


### PR DESCRIPTION
Tested that the property entrance menu no longer crashes under windows debug