### PR TITLE
feat: Add default client_location

### DIFF
--- a/resources/sharedconfig.ini
+++ b/resources/sharedconfig.ini
@@ -24,7 +24,7 @@ dump_folder=
 
 # The location of the client
 # Either the folder with /res or with /client and /versions
-client_location=
+client_location=..
 
 # The maximum outgoing bandwidth in bits.  If your clients are having
 # issues with enemies taking a while to catch up to them, increse this value.


### PR DESCRIPTION
Since we by default expect the client to be here, may as well have it in the config by default to reduce setup steps