### PR TITLE
fix: pending names can be duplicates

### DIFF
--- a/dDatabase/GameDatabase/ITables/ICharInfo.h
+++ b/dDatabase/GameDatabase/ITables/ICharInfo.h
@@ -44,6 +44,8 @@ public:
 
 	// Updates the given character ids last login to be right now.
 	virtual void UpdateLastLoggedInCharacter(const uint32_t characterId) = 0;
+
+	virtual bool IsNameInUse(const std::string_view name) = 0;
 };
 
 #endif  //!__ICHARINFO__H__

--- a/dDatabase/GameDatabase/MySQL/MySQLDatabase.h
+++ b/dDatabase/GameDatabase/MySQL/MySQLDatabase.h
@@ -124,8 +124,9 @@ public:
 	void IncrementTimesPlayed(const uint32_t playerId, const uint32_t gameId) override;
 	void InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<uint32_t> characterId) override;
 	void DeleteUgcBuild(const LWOOBJID bigId) override;
-	sql::PreparedStatement* CreatePreppedStmt(const std::string& query);
 	uint32_t GetAccountCount() override;
+	bool IsNameInUse(const std::string_view name) override;
+	sql::PreparedStatement* CreatePreppedStmt(const std::string& query);
 private:
 
 	// Generic query functions that can be used for any query.

--- a/dDatabase/GameDatabase/MySQL/Tables/CharInfo.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/CharInfo.cpp
@@ -76,3 +76,9 @@ void MySQLDatabase::SetPendingCharacterName(const uint32_t characterId, const st
 void MySQLDatabase::UpdateLastLoggedInCharacter(const uint32_t characterId) {
 	ExecuteUpdate("UPDATE charinfo SET last_login = ? WHERE id = ? LIMIT 1", static_cast<uint32_t>(time(NULL)), characterId);
 }
+
+bool MySQLDatabase::IsNameInUse(const std::string_view name) {
+	auto result = ExecuteSelect("SELECT name FROM charinfo WHERE name = ? or pending_name = ? LIMIT 1;", name, name);
+
+	return result->next();
+}

--- a/dDatabase/GameDatabase/SQLite/SQLiteDatabase.h
+++ b/dDatabase/GameDatabase/SQLite/SQLiteDatabase.h
@@ -123,6 +123,7 @@ public:
 	void InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<uint32_t> characterId) override;
 	void DeleteUgcBuild(const LWOOBJID bigId) override;
 	uint32_t GetAccountCount() override;
+	bool IsNameInUse(const std::string_view name) override;
 private:
 	CppSQLite3Statement CreatePreppedStmt(const std::string& query);
 

--- a/dDatabase/GameDatabase/SQLite/Tables/CharInfo.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/CharInfo.cpp
@@ -77,3 +77,9 @@ void SQLiteDatabase::SetPendingCharacterName(const uint32_t characterId, const s
 void SQLiteDatabase::UpdateLastLoggedInCharacter(const uint32_t characterId) {
 	ExecuteUpdate("UPDATE charinfo SET last_login = ? WHERE id = ?;", static_cast<uint32_t>(time(NULL)), characterId);
 }
+
+bool SQLiteDatabase::IsNameInUse(const std::string_view name) {
+	auto [_, result] = ExecuteSelect("SELECT name FROM charinfo WHERE name = ? or pending_name = ? LIMIT 1;", name, name);
+
+	return result.eof();
+}

--- a/dDatabase/GameDatabase/TestSQL/TestSQLDatabase.h
+++ b/dDatabase/GameDatabase/TestSQL/TestSQLDatabase.h
@@ -102,6 +102,8 @@ class TestSQLDatabase : public GameDatabase {
 	void InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<uint32_t> characterId) override {};
 	void DeleteUgcBuild(const LWOOBJID bigId) override {};
 	uint32_t GetAccountCount() override { return 0; };
+
+	bool IsNameInUse(const std::string_view name) override { return false; };
 };
 
 #endif  //!TESTSQLDATABASE_H


### PR DESCRIPTION
fixes #1746 

Tested that creating a character with an already existing name, and an already existing predefined name is still blocked
Tested that now trying to create a character with a name pending approval is now rejected.  