### PR TITLE
fix: mission states being incorrect after world load

### DIFF
--- a/dGame/dComponents/MissionComponent.cpp
+++ b/dGame/dComponents/MissionComponent.cpp
@@ -512,7 +512,7 @@ void MissionComponent::LoadFromXml(const tinyxml2::XMLDocument& doc) {
 
 		auto* mission = new Mission(this, missionId);
 
-		mission->LoadFromXml(*doneM);
+		mission->LoadFromXmlDone(*doneM);
 
 		doneM = doneM->NextSiblingElement();
 
@@ -527,9 +527,9 @@ void MissionComponent::LoadFromXml(const tinyxml2::XMLDocument& doc) {
 
 		currentM->QueryAttribute("id", &missionId);
 
-		auto* mission = new Mission(this, missionId);
+		auto* mission = m_Missions.contains(missionId) ? m_Missions[missionId] : new Mission(this, missionId);
 
-		mission->LoadFromXml(*currentM);
+		mission->LoadFromXmlCur(*currentM);
 
 		if (currentM->QueryAttribute("o", &missionOrder) == tinyxml2::XML_SUCCESS && mission->IsMission()) {
 			mission->SetUniqueMissionOrderID(missionOrder);
@@ -565,20 +565,23 @@ void MissionComponent::UpdateXml(tinyxml2::XMLDocument& doc) {
 		auto* mission = pair.second;
 
 		if (mission) {
-			const auto complete = mission->IsComplete();
+			const auto completions = mission->GetCompletions();
 
 			auto* m = doc.NewElement("m");
 
-			if (complete) {
-				mission->UpdateXml(*m);
+			if (completions > 0) {
+				mission->UpdateXmlDone(*m);
 
 				done->LinkEndChild(m);
 
-				continue;
+				if (mission->IsComplete()) continue;
+
+				m = doc.NewElement("m");
 			}
+
 			if (mission->IsMission()) m->SetAttribute("o", mission->GetUniqueMissionOrderID());
 
-			mission->UpdateXml(*m);
+			mission->UpdateXmlCur(*m);
 
 			cur->LinkEndChild(m);
 		}

--- a/dGame/dMission/Mission.cpp
+++ b/dGame/dMission/Mission.cpp
@@ -65,7 +65,7 @@ Mission::Mission(MissionComponent* missionComponent, const uint32_t missionId) {
 	}
 }
 
-void Mission::LoadFromXml(const tinyxml2::XMLElement& element) {
+void Mission::LoadFromXmlDone(const tinyxml2::XMLElement& element) {
 	// Start custom XML
 	if (element.Attribute("state") != nullptr) {
 		m_State = static_cast<eMissionState>(std::stoul(element.Attribute("state")));
@@ -76,11 +76,15 @@ void Mission::LoadFromXml(const tinyxml2::XMLElement& element) {
 		m_Completions = std::stoul(element.Attribute("cct"));
 
 		m_Timestamp = std::stoul(element.Attribute("cts"));
-
-		if (IsComplete()) {
-			return;
-		}
 	}
+}
+
+void Mission::LoadFromXmlCur(const tinyxml2::XMLElement& element) {
+	// Start custom XML
+	if (element.Attribute("state") != nullptr) {
+		m_State = static_cast<eMissionState>(std::stoul(element.Attribute("state")));
+	}
+	// End custom XML
 
 	auto* task = element.FirstChildElement();
 
@@ -132,7 +136,7 @@ void Mission::LoadFromXml(const tinyxml2::XMLElement& element) {
 	}
 }
 
-void Mission::UpdateXml(tinyxml2::XMLElement& element) {
+void Mission::UpdateXmlDone(tinyxml2::XMLElement& element) {
 	// Start custom XML
 	element.SetAttribute("state", static_cast<unsigned int>(m_State));
 	// End custom XML
@@ -141,15 +145,21 @@ void Mission::UpdateXml(tinyxml2::XMLElement& element) {
 
 	element.SetAttribute("id", static_cast<unsigned int>(info.id));
 
-	if (m_Completions > 0) {
-		element.SetAttribute("cct", static_cast<unsigned int>(m_Completions));
+	element.SetAttribute("cct", static_cast<unsigned int>(m_Completions));
 
-		element.SetAttribute("cts", static_cast<unsigned int>(m_Timestamp));
+	element.SetAttribute("cts", static_cast<unsigned int>(m_Timestamp));
+}
 
-		if (IsComplete()) {
-			return;
-		}
-	}
+void Mission::UpdateXmlCur(tinyxml2::XMLElement& element) {
+	// Start custom XML
+	element.SetAttribute("state", static_cast<unsigned int>(m_State));
+	// End custom XML
+
+	element.DeleteChildren();
+
+	element.SetAttribute("id", static_cast<unsigned int>(info.id));
+
+	if (IsComplete()) return;
 
 	for (auto* task : m_Tasks) {
 		if (task->GetType() == eMissionTaskType::COLLECTION ||

--- a/dGame/dMission/Mission.h
+++ b/dGame/dMission/Mission.h
@@ -28,8 +28,13 @@ public:
 	Mission(MissionComponent* missionComponent, uint32_t missionId);
 	~Mission();
 
-	void LoadFromXml(const tinyxml2::XMLElement& element);
-	void UpdateXml(tinyxml2::XMLElement& element);
+	// XML functions to load and save completed mission state to xml
+	void LoadFromXmlDone(const tinyxml2::XMLElement& element);
+	void UpdateXmlDone(tinyxml2::XMLElement& element);
+
+	// XML functions to load and save current mission state and task data to xml
+	void LoadFromXmlCur(const tinyxml2::XMLElement& element);
+	void UpdateXmlCur(tinyxml2::XMLElement& element);
 
 	/**
 	 * Returns the ID of this mission


### PR DESCRIPTION
fixes #1749 
Tested that done missions never leave the done xml child
Tested that when accepting as repeatable mission, it does not leave the done child and is correctly setup as its own mission in the cur xml parent
Tested that relogging with this mission active shows the correct rewards in the in-game uis
Tested that other missions are unaffected by the change
Tested that the mission can still be completed and progressed as normal.

Want to test a bit more 