### PR TITLE
fix: invert sqlite lookup result to fix name in use lookup errors

### DIFF
--- a/dDatabase/GameDatabase/SQLite/Tables/CharInfo.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/CharInfo.cpp
@@ -81,5 +81,5 @@ void SQLiteDatabase::UpdateLastLoggedInCharacter(const uint32_t characterId) {
 bool SQLiteDatabase::IsNameInUse(const std::string_view name) {
 	auto [_, result] = ExecuteSelect("SELECT name FROM charinfo WHERE name = ? or pending_name = ? LIMIT 1;", name, name);
 
-	return result.eof();
+	return !result.eof();
 }


### PR DESCRIPTION
SQLite name in use checks currently do not function correctly. Inverting the result of this function causes them to work as intended