### PR TITLE
feat: Property behaviors partially functional

### DIFF
--- a/dCommon/DluAssert.h
+++ b/dCommon/DluAssert.h
@@ -4,7 +4,7 @@
 #include <assert.h>
 
 #ifdef _DEBUG
-#	define DluAssert(expression) assert(expression)
+#	define DluAssert(expression) do { assert(expression) } while(0)
 #else
 #	define DluAssert(expression)
 #endif

--- a/dGame/dComponents/ModelComponent.cpp
+++ b/dGame/dComponents/ModelComponent.cpp
@@ -20,6 +20,17 @@ ModelComponent::ModelComponent(Entity* parent) : Component(parent) {
 
 	m_userModelID = m_Parent->GetVarAs<LWOOBJID>(u"userModelID");
 	RegisterMsg(MessageType::Game::REQUEST_USE, this, &ModelComponent::OnRequestUse);
+	RegisterMsg(MessageType::Game::RESET_MODEL_TO_DEFAULTS, this, &ModelComponent::OnResetModelToDefaults);
+}
+
+bool ModelComponent::OnResetModelToDefaults(GameMessages::GameMsg& msg) {
+	auto& reset = static_cast<GameMessages::ResetModelToDefaults&>(msg);
+	for (auto& behavior : m_Behaviors) behavior.HandleMsg(reset);
+	GameMessages::UnSmash unsmash;
+	unsmash.target = GetParent()->GetObjectID();
+	unsmash.duration = 0.0f;
+	unsmash.Send(UNASSIGNED_SYSTEM_ADDRESS);
+	return true;
 }
 
 bool ModelComponent::OnRequestUse(GameMessages::GameMsg& msg) {

--- a/dGame/dComponents/ModelComponent.cpp
+++ b/dGame/dComponents/ModelComponent.cpp
@@ -15,6 +15,8 @@
 ModelComponent::ModelComponent(Entity* parent) : Component(parent) {
 	m_OriginalPosition = m_Parent->GetDefaultPosition();
 	m_OriginalRotation = m_Parent->GetDefaultRotation();
+	m_IsPaused = false;
+	m_IsPickable = false;
 
 	m_userModelID = m_Parent->GetVarAs<LWOOBJID>(u"userModelID");
 	RegisterMsg(MessageType::Game::REQUEST_USE, this, &ModelComponent::OnRequestUse);
@@ -27,6 +29,8 @@ bool ModelComponent::OnRequestUse(GameMessages::GameMsg& msg) {
 }
 
 void ModelComponent::Update(float deltaTime) {
+	if (m_IsPaused) return;
+
 	for (auto& behavior : m_Behaviors) {
 		behavior.Update(deltaTime, *this);
 	}
@@ -59,6 +63,11 @@ void ModelComponent::LoadBehaviors() {
 	}
 }
 
+void ModelComponent::Resume() {
+	m_Dirty = true;
+	m_IsPaused = false;
+}
+
 void ModelComponent::Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) {
 	// ItemComponent Serialization.  Pets do not get this serialization.
 	if (!m_Parent->HasComponent(eReplicaComponentType::PET)) {
@@ -70,14 +79,14 @@ void ModelComponent::Serialize(RakNet::BitStream& outBitStream, bool bIsInitialU
 
 	//actual model component:
 	outBitStream.Write1(); // Yes we are writing model info
-	outBitStream.Write1(); // Is pickable
+	outBitStream.Write(m_IsPickable); // Is pickable
 	outBitStream.Write<uint32_t>(2); // Physics type
 	outBitStream.Write(m_OriginalPosition); // Original position
 	outBitStream.Write(m_OriginalRotation); // Original rotation
 
 	outBitStream.Write1(); // We are writing behavior info
 	outBitStream.Write<uint32_t>(m_Behaviors.size()); // Number of behaviors
-	outBitStream.Write0(); // Is this model paused
+	outBitStream.Write(m_IsPaused); // Is this model paused
 	if (bIsInitialUpdate) outBitStream.Write0(); // We are not writing model editing info
 }
 

--- a/dGame/dComponents/ModelComponent.cpp
+++ b/dGame/dComponents/ModelComponent.cpp
@@ -10,6 +10,7 @@
 #include "SimplePhysicsComponent.h"
 
 #include "Database.h"
+#include "DluAssert.h"
 
 ModelComponent::ModelComponent(Entity* parent) : Component(parent) {
 	m_OriginalPosition = m_Parent->GetDefaultPosition();
@@ -36,9 +37,14 @@ bool ModelComponent::OnResetModelToDefaults(GameMessages::GameMsg& msg) {
 }
 
 bool ModelComponent::OnRequestUse(GameMessages::GameMsg& msg) {
-	auto& requestUse = static_cast<GameMessages::RequestUse&>(msg);
-	for (auto& behavior : m_Behaviors) behavior.HandleMsg(requestUse);
-	return true;
+	bool toReturn = false;
+	if (!m_IsPaused) {
+		auto& requestUse = static_cast<GameMessages::RequestUse&>(msg);
+		for (auto& behavior : m_Behaviors) behavior.HandleMsg(requestUse);
+		toReturn = true;
+	}
+
+	return toReturn;
 }
 
 void ModelComponent::Update(float deltaTime) {

--- a/dGame/dComponents/ModelComponent.cpp
+++ b/dGame/dComponents/ModelComponent.cpp
@@ -16,7 +16,7 @@ ModelComponent::ModelComponent(Entity* parent) : Component(parent) {
 	m_OriginalPosition = m_Parent->GetDefaultPosition();
 	m_OriginalRotation = m_Parent->GetDefaultRotation();
 	m_IsPaused = false;
-	m_IsPickable = false;
+	m_NumListeningInteract = 0;
 
 	m_userModelID = m_Parent->GetVarAs<LWOOBJID>(u"userModelID");
 	RegisterMsg(MessageType::Game::REQUEST_USE, this, &ModelComponent::OnRequestUse);
@@ -79,7 +79,7 @@ void ModelComponent::Serialize(RakNet::BitStream& outBitStream, bool bIsInitialU
 
 	//actual model component:
 	outBitStream.Write1(); // Yes we are writing model info
-	outBitStream.Write(m_IsPickable); // Is pickable
+	outBitStream.Write(m_NumListeningInteract > 0); // Is pickable
 	outBitStream.Write<uint32_t>(2); // Physics type
 	outBitStream.Write(m_OriginalPosition); // Original position
 	outBitStream.Write(m_OriginalRotation); // Original rotation
@@ -157,4 +157,17 @@ std::array<std::pair<int32_t, std::string>, 5> ModelComponent::GetBehaviorsForSa
 		behaviorData = printer.CStr();
 	}
 	return toReturn;
+}
+
+void ModelComponent::AddInteract() {
+	LOG("adding interact %i", m_NumListeningInteract);
+	m_Dirty = true;
+	m_NumListeningInteract++;
+}
+
+void ModelComponent::RemoveInteract() {
+	DluAssert(m_NumListeningInteract > 0);
+	LOG("Removing interact %i", m_NumListeningInteract);
+	m_Dirty = true;
+	m_NumListeningInteract--;
 }

--- a/dGame/dComponents/ModelComponent.cpp
+++ b/dGame/dComponents/ModelComponent.cpp
@@ -31,6 +31,7 @@ bool ModelComponent::OnResetModelToDefaults(GameMessages::GameMsg& msg) {
 	unsmash.duration = 0.0f;
 	unsmash.Send(UNASSIGNED_SYSTEM_ADDRESS);
 	m_NumListeningInteract = 0;
+	m_NumActiveUnSmash = 0;
 	m_Dirty = true;
 	Game::entityManager->SerializeEntity(GetParent());
 	return true;
@@ -179,7 +180,7 @@ std::array<std::pair<int32_t, std::string>, 5> ModelComponent::GetBehaviorsForSa
 }
 
 void ModelComponent::AddInteract() {
-	LOG_DEBUG("adding interact %i", m_NumListeningInteract);
+	LOG_DEBUG("Adding interact %i", m_NumListeningInteract);
 	m_Dirty = true;
 	m_NumListeningInteract++;
 }
@@ -189,4 +190,16 @@ void ModelComponent::RemoveInteract() {
 	LOG_DEBUG("Removing interact %i", m_NumListeningInteract);
 	m_Dirty = true;
 	m_NumListeningInteract--;
+}
+
+void ModelComponent::AddUnSmash() {
+	LOG_DEBUG("Adding UnSmash %i", m_NumActiveUnSmash);
+	m_NumActiveUnSmash++;
+}
+
+void ModelComponent::RemoveUnSmash() {
+	// Players can assign an UnSmash without a Smash so an assert would be bad here
+	if (m_NumActiveUnSmash == 0) return;
+	LOG_DEBUG("Removing UnSmash %i", m_NumActiveUnSmash);
+	m_NumActiveUnSmash--;
 }

--- a/dGame/dComponents/ModelComponent.cpp
+++ b/dGame/dComponents/ModelComponent.cpp
@@ -10,7 +10,6 @@
 #include "SimplePhysicsComponent.h"
 
 #include "Database.h"
-#include "EntityInfo.h"
 
 ModelComponent::ModelComponent(Entity* parent) : Component(parent) {
 	m_OriginalPosition = m_Parent->GetDefaultPosition();
@@ -30,6 +29,9 @@ bool ModelComponent::OnResetModelToDefaults(GameMessages::GameMsg& msg) {
 	unsmash.target = GetParent()->GetObjectID();
 	unsmash.duration = 0.0f;
 	unsmash.Send(UNASSIGNED_SYSTEM_ADDRESS);
+	m_NumListeningInteract = 0;
+	m_Dirty = true;
+	Game::entityManager->SerializeEntity(GetParent());
 	return true;
 }
 
@@ -171,14 +173,14 @@ std::array<std::pair<int32_t, std::string>, 5> ModelComponent::GetBehaviorsForSa
 }
 
 void ModelComponent::AddInteract() {
-	LOG("adding interact %i", m_NumListeningInteract);
+	LOG_DEBUG("adding interact %i", m_NumListeningInteract);
 	m_Dirty = true;
 	m_NumListeningInteract++;
 }
 
 void ModelComponent::RemoveInteract() {
 	DluAssert(m_NumListeningInteract > 0);
-	LOG("Removing interact %i", m_NumListeningInteract);
+	LOG_DEBUG("Removing interact %i", m_NumListeningInteract);
 	m_Dirty = true;
 	m_NumListeningInteract--;
 }

--- a/dGame/dComponents/ModelComponent.h
+++ b/dGame/dComponents/ModelComponent.h
@@ -119,7 +119,8 @@ public:
 
 	const std::vector<PropertyBehavior>& GetBehaviors() const { return m_Behaviors; };
 
-	void SetIsPickable(bool pickable) { m_Dirty = m_IsPickable == pickable; m_IsPickable = pickable; }
+	void AddInteract();
+	void RemoveInteract();
 
 	void Pause() { m_Dirty = true; m_IsPaused = true; }
 
@@ -127,7 +128,7 @@ public:
 private:
 	bool m_Dirty{};
 
-	bool m_IsPickable{};
+	uint32_t m_NumListeningInteract{};
 
 	bool m_IsPaused{};
 	/**

--- a/dGame/dComponents/ModelComponent.h
+++ b/dGame/dComponents/ModelComponent.h
@@ -33,6 +33,7 @@ public:
 	void Update(float deltaTime) override;
 
 	bool OnRequestUse(GameMessages::GameMsg& msg);
+	bool OnResetModelToDefaults(GameMessages::GameMsg& msg);
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
 

--- a/dGame/dComponents/ModelComponent.h
+++ b/dGame/dComponents/ModelComponent.h
@@ -62,7 +62,7 @@ public:
 
 	/**
 	 * Main gateway for all behavior messages to be passed to their respective behaviors.
-	 * 
+	 *
 	 * @tparam Msg The message type to pass
 	 * @param args the arguments of the message to be deserialized
 	 */
@@ -71,7 +71,7 @@ public:
 		static_assert(std::is_base_of_v<BehaviorMessageBase, Msg>, "Msg must be a BehaviorMessageBase");
 		Msg msg{ args };
 		for (auto&& behavior : m_Behaviors) {
-			if (behavior.GetBehaviorId() == msg.GetBehaviorId()) { 
+			if (behavior.GetBehaviorId() == msg.GetBehaviorId()) {
 				behavior.HandleMsg(msg);
 				return;
 			}
@@ -112,14 +112,24 @@ public:
 	void SendBehaviorListToClient(AMFArrayValue& args) const;
 
 	void SendBehaviorBlocksToClient(int32_t behaviorToSend, AMFArrayValue& args) const;
-	
+
 	void VerifyBehaviors();
 
 	std::array<std::pair<int32_t, std::string>, 5> GetBehaviorsForSave() const;
 
 	const std::vector<PropertyBehavior>& GetBehaviors() const { return m_Behaviors; };
 
+	void SetIsPickable(bool pickable) { m_Dirty = m_IsPickable == pickable; m_IsPickable = pickable; }
+
+	void Pause() { m_Dirty = true; m_IsPaused = true; }
+
+	void Resume();
 private:
+	bool m_Dirty{};
+
+	bool m_IsPickable{};
+
+	bool m_IsPaused{};
 	/**
 	 * The behaviors of the model
 	 * Note: This is a vector because the order of the behaviors matters when serializing to the client.

--- a/dGame/dComponents/ModelComponent.h
+++ b/dGame/dComponents/ModelComponent.h
@@ -30,6 +30,9 @@ public:
 	ModelComponent(Entity* parent);
 
 	void LoadBehaviors();
+	void Update(float deltaTime) override;
+
+	bool OnRequestUse(GameMessages::GameMsg& msg);
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
 
@@ -113,6 +116,8 @@ public:
 	void VerifyBehaviors();
 
 	std::array<std::pair<int32_t, std::string>, 5> GetBehaviorsForSave() const;
+
+	const std::vector<PropertyBehavior>& GetBehaviors() const { return m_Behaviors; };
 
 private:
 	/**

--- a/dGame/dComponents/ModelComponent.h
+++ b/dGame/dComponents/ModelComponent.h
@@ -127,10 +127,13 @@ public:
 
 	void Resume();
 private:
+	// Whether or not this component needs to have its extra data serialized.
 	bool m_Dirty{};
 
+	// The number of strips listening for a RequestUse GM to come in.
 	uint32_t m_NumListeningInteract{};
 
+	// Whether or not the model is paused and should reject all interactions regarding behaviors.
 	bool m_IsPaused{};
 	/**
 	 * The behaviors of the model

--- a/dGame/dComponents/ModelComponent.h
+++ b/dGame/dComponents/ModelComponent.h
@@ -125,8 +125,15 @@ public:
 
 	void Pause() { m_Dirty = true; m_IsPaused = true; }
 
+	void AddUnSmash();
+	void RemoveUnSmash();
+	bool IsUnSmashing() const { return m_NumActiveUnSmash != 0; }
+
 	void Resume();
 private:
+	// Number of Actions that are awaiting an UnSmash to finish.
+	uint32_t m_NumActiveUnSmash{};
+
 	// Whether or not this component needs to have its extra data serialized.
 	bool m_Dirty{};
 

--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -262,6 +262,9 @@ void PropertyManagementComponent::OnStartBuilding() {
 			auto* modelComponent = model->GetComponent<ModelComponent>();
 			if (modelComponent) modelComponent->Pause();
 			Game::entityManager->SerializeEntity(model);
+			GameMessages::ResetModelToDefaults reset;
+			reset.target = modelID;
+			model->HandleMsg(reset);
 		}
 	}
 }
@@ -285,6 +288,9 @@ void PropertyManagementComponent::OnFinishBuilding() {
 			auto* modelComponent = model->GetComponent<ModelComponent>();
 			if (modelComponent) modelComponent->Resume();
 			Game::entityManager->SerializeEntity(model);
+			GameMessages::ResetModelToDefaults reset;
+			reset.target = modelID;
+			model->HandleMsg(reset);
 		}
 	}
 }

--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -221,8 +221,6 @@ bool PropertyManagementComponent::Claim(const LWOOBJID playerId) {
 }
 
 void PropertyManagementComponent::OnStartBuilding() {
-	m_IsBuilding = true;
-
 	auto* ownerEntity = GetOwner();
 
 	if (ownerEntity == nullptr) return;
@@ -270,8 +268,6 @@ void PropertyManagementComponent::OnStartBuilding() {
 }
 
 void PropertyManagementComponent::OnFinishBuilding() {
-	m_IsBuilding = false;
-
 	auto* ownerEntity = GetOwner();
 
 	if (ownerEntity == nullptr) return;

--- a/dGame/dComponents/PropertyManagementComponent.h
+++ b/dGame/dComponents/PropertyManagementComponent.h
@@ -239,4 +239,6 @@ private:
 	 * The privacy setting before it was changed, saved to set back after a player finishes building
 	 */
 	PropertyPrivacyOption originalPrivacyOption = PropertyPrivacyOption::Private;
+
+	bool m_IsBuilding{};
 };

--- a/dGame/dComponents/PropertyManagementComponent.h
+++ b/dGame/dComponents/PropertyManagementComponent.h
@@ -239,6 +239,4 @@ private:
 	 * The privacy setting before it was changed, saved to set back after a player finishes building
 	 */
 	PropertyPrivacyOption originalPrivacyOption = PropertyPrivacyOption::Private;
-
-	bool m_IsBuilding{};
 };

--- a/dGame/dGameMessages/GameMessageHandler.cpp
+++ b/dGame/dGameMessages/GameMessageHandler.cpp
@@ -45,6 +45,7 @@ namespace {
 	using namespace GameMessages;
 	using MessageCreator = std::function<std::unique_ptr<GameMessages::GameMsg>()>;
 	std::map<MessageType::Game, MessageCreator> g_MessageHandlers = {
+		{ REQUEST_USE, []() { return std::make_unique<RequestUse>(); }},
 		{ REQUEST_SERVER_OBJECT_INFO, []() { return std::make_unique<RequestServerObjectInfo>(); } },
 		{ SHOOTING_GALLERY_FIRE, []() { return std::make_unique<ShootingGalleryFire>(); } },
 	};
@@ -115,11 +116,6 @@ void GameMessageHandler::HandleMessage(RakNet::BitStream& inStream, const System
 
 	case MessageType::Game::RESPOND_TO_MISSION: {
 		GameMessages::HandleRespondToMission(inStream, entity);
-		break;
-	}
-
-	case MessageType::Game::REQUEST_USE: {
-		GameMessages::HandleRequestUse(inStream, entity, sysAddr);
 		break;
 	}
 

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -6442,4 +6442,18 @@ namespace GameMessages {
 		missionComponent->Progress(eMissionTaskType::TALK_TO_NPC, interactedObject->GetLOT(), interactedObject->GetObjectID());
 		missionComponent->Progress(eMissionTaskType::INTERACT, interactedObject->GetLOT(), interactedObject->GetObjectID());
 	}
+
+	void Smash::Serialize(RakNet::BitStream& stream) const {
+		stream.Write(bIgnoreObjectVisibility);
+		stream.Write(force);
+		stream.Write(ghostCapacity);
+		stream.Write(killerID);
+	}
+
+	void UnSmash::Serialize(RakNet::BitStream& stream) const {
+		stream.Write(builderID != LWOOBJID_EMPTY);
+		if (builderID != LWOOBJID_EMPTY) stream.Write(builderID);
+		stream.Write(duration != 3.0f);
+		if (builderID != 3.0f) stream.Write(duration);
+	}
 }

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -6456,4 +6456,9 @@ namespace GameMessages {
 		stream.Write(duration != 3.0f);
 		if (builderID != 3.0f) stream.Write(duration);
 	}
+
+	void PlayBehaviorSound::Serialize(RakNet::BitStream& stream) const {
+		stream.Write(soundID != -1);
+		if (soundID != -1) stream.Write(soundID);
+	}
 }

--- a/dGame/dGameMessages/GameMessages.h
+++ b/dGame/dGameMessages/GameMessages.h
@@ -801,6 +801,26 @@ namespace GameMessages {
 		// Used only for multi-interaction, is of the enum type InteractionType
 		int multiInteractType{};
 	};
+
+	struct Smash : public GameMsg {
+		Smash() : GameMsg(MessageType::Game::SMASH) {}
+
+		void Serialize(RakNet::BitStream& stream) const;
+
+		bool bIgnoreObjectVisibility{};
+		bool force{};
+		float ghostCapacity{};
+		LWOOBJID killerID{};
+	};
+
+	struct UnSmash : public GameMsg {
+		UnSmash() : GameMsg(MessageType::Game::UN_SMASH) {}
+
+		void Serialize(RakNet::BitStream& stream) const;
+
+		LWOOBJID builderID{ LWOOBJID_EMPTY };
+		float duration{ 3.0f };
+	};
 };
 
 #endif // GAMEMESSAGES_H

--- a/dGame/dGameMessages/GameMessages.h
+++ b/dGame/dGameMessages/GameMessages.h
@@ -829,6 +829,10 @@ namespace GameMessages {
 
 		int32_t soundID{ -1 };
 	};
+
+	struct ResetModelToDefaults : public GameMsg {
+		ResetModelToDefaults() : GameMsg(MessageType::Game::RESET_MODEL_TO_DEFAULTS) {}
+	};
 };
 
 #endif // GAMEMESSAGES_H

--- a/dGame/dGameMessages/GameMessages.h
+++ b/dGame/dGameMessages/GameMessages.h
@@ -821,6 +821,14 @@ namespace GameMessages {
 		LWOOBJID builderID{ LWOOBJID_EMPTY };
 		float duration{ 3.0f };
 	};
+
+	struct PlayBehaviorSound : public GameMsg {
+		PlayBehaviorSound() : GameMsg(MessageType::Game::PLAY_BEHAVIOR_SOUND) {}
+
+		void Serialize(RakNet::BitStream& stream) const;
+
+		int32_t soundID{ -1 };
+	};
 };
 
 #endif // GAMEMESSAGES_H

--- a/dGame/dGameMessages/GameMessages.h
+++ b/dGame/dGameMessages/GameMessages.h
@@ -631,7 +631,6 @@ namespace GameMessages {
 	void HandleFireEventServerSide(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 	void HandleRequestPlatformResync(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 	void HandleQuickBuildCancel(RakNet::BitStream& inStream, Entity* entity);
-	void HandleRequestUse(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 	void HandlePlayEmote(RakNet::BitStream& inStream, Entity* entity);
 	void HandleModularBuildConvertModel(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr);
 	void HandleSetFlag(RakNet::BitStream& inStream, Entity* entity);
@@ -781,6 +780,26 @@ namespace GameMessages {
 		RequestServerObjectInfo() : GameMsg(MessageType::Game::REQUEST_SERVER_OBJECT_INFO, eGameMasterLevel::DEVELOPER) {}
 		bool Deserialize(RakNet::BitStream& bitStream) override;
 		void Handle(Entity& entity, const SystemAddress& sysAddr) override;
+	};
+
+	struct RequestUse : public GameMsg {
+		RequestUse() : GameMsg(MessageType::Game::REQUEST_USE) {}
+
+		bool Deserialize(RakNet::BitStream& stream) override;
+		void Handle(Entity& entity, const SystemAddress& sysAddr) override;
+
+		LWOOBJID object{};
+
+		bool secondary{ false };
+
+		// Set to true if this coming from a multi-interaction UI on the client.
+		bool bIsMultiInteractUse{};
+
+		// Used only for multi-interaction
+		unsigned int multiInteractID{};
+
+		// Used only for multi-interaction, is of the enum type InteractionType
+		int multiInteractType{};
 	};
 };
 

--- a/dGame/dPropertyBehaviors/PropertyBehavior.cpp
+++ b/dGame/dPropertyBehaviors/PropertyBehavior.cpp
@@ -4,9 +4,13 @@
 #include "BehaviorStates.h"
 #include "ControlBehaviorMsgs.h"
 #include "tinyxml2.h"
+#include "ModelComponent.h"
+
+#include <ranges>
 
 PropertyBehavior::PropertyBehavior() {
 	m_LastEditedState = BehaviorState::HOME_STATE;
+	m_ActiveState = BehaviorState::HOME_STATE;
 }
 
 template<>
@@ -84,6 +88,11 @@ void PropertyBehavior::HandleMsg(AddMessage& msg) {
 	isLoot = m_BehaviorId != 7965;
 };
 
+template<>
+void PropertyBehavior::HandleMsg(GameMessages::RequestUse& msg) {
+	m_States[m_ActiveState].HandleMsg(msg);
+}
+
 void PropertyBehavior::SendBehaviorListToClient(AMFArrayValue& args) const {
 	args.Insert("id", std::to_string(m_BehaviorId));
 	args.Insert("name", m_Name);
@@ -152,4 +161,13 @@ void PropertyBehavior::Deserialize(const tinyxml2::XMLElement& behavior) {
 		if (stateId < 0 || stateId > 5) continue;
 		m_States[static_cast<BehaviorState>(stateId)].Deserialize(*stateElement);
 	}
+}
+
+const State& PropertyBehavior::GetState(const BehaviorState state) {
+	DluAssert(state >= BehaviorState::HOME_STATE && state <= BehaviorState::STAR_STATE);
+	return m_States[state];
+}
+
+void PropertyBehavior::Update(float deltaTime, ModelComponent& modelComponent) {
+	for (auto& state : m_States | std::views::values) state.Update(deltaTime, modelComponent);
 }

--- a/dGame/dPropertyBehaviors/PropertyBehavior.cpp
+++ b/dGame/dPropertyBehaviors/PropertyBehavior.cpp
@@ -169,11 +169,6 @@ void PropertyBehavior::Deserialize(const tinyxml2::XMLElement& behavior) {
 	}
 }
 
-const State& PropertyBehavior::GetState(const BehaviorState state) {
-	DluAssert(state >= BehaviorState::HOME_STATE && state <= BehaviorState::STAR_STATE);
-	return m_States[state];
-}
-
 void PropertyBehavior::Update(float deltaTime, ModelComponent& modelComponent) {
 	for (auto& state : m_States | std::views::values) state.Update(deltaTime, modelComponent);
 }

--- a/dGame/dPropertyBehaviors/PropertyBehavior.cpp
+++ b/dGame/dPropertyBehaviors/PropertyBehavior.cpp
@@ -93,6 +93,12 @@ void PropertyBehavior::HandleMsg(GameMessages::RequestUse& msg) {
 	m_States[m_ActiveState].HandleMsg(msg);
 }
 
+template<>
+void PropertyBehavior::HandleMsg(GameMessages::ResetModelToDefaults& msg) {
+	m_ActiveState = BehaviorState::HOME_STATE;
+	for (auto& state : m_States | std::views::values) state.HandleMsg(msg);
+}
+
 void PropertyBehavior::SendBehaviorListToClient(AMFArrayValue& args) const {
 	args.Insert("id", std::to_string(m_BehaviorId));
 	args.Insert("name", m_Name);

--- a/dGame/dPropertyBehaviors/PropertyBehavior.h
+++ b/dGame/dPropertyBehaviors/PropertyBehavior.h
@@ -10,6 +10,7 @@ namespace tinyxml2 {
 enum class BehaviorState : uint32_t;
 
 class AMFArrayValue;
+class ModelComponent;
 
 /**
  * Represents the Entity of a Property Behavior and holds data associated with the behavior
@@ -31,7 +32,16 @@ public:
 
 	void Serialize(tinyxml2::XMLElement& behavior) const;
 	void Deserialize(const tinyxml2::XMLElement& behavior);
+
+	const std::map<BehaviorState, State>& GetStates() const { return m_States; }
+	const State& GetState(const BehaviorState state);
+	const State& GetActiveState() const { return m_States.at(m_ActiveState); }
+	State& GetActiveStateMut() { return m_States.at(m_ActiveState); }
+
+	void Update(float deltaTime, ModelComponent& modelComponent);
 private:
+
+	BehaviorState m_ActiveState;
 
 	// The states this behavior has.
 	std::map<BehaviorState, State> m_States;

--- a/dGame/dPropertyBehaviors/PropertyBehavior.h
+++ b/dGame/dPropertyBehaviors/PropertyBehavior.h
@@ -33,14 +33,10 @@ public:
 	void Serialize(tinyxml2::XMLElement& behavior) const;
 	void Deserialize(const tinyxml2::XMLElement& behavior);
 
-	const std::map<BehaviorState, State>& GetStates() const { return m_States; }
-	const State& GetState(const BehaviorState state);
-	const State& GetActiveState() const { return m_States.at(m_ActiveState); }
-	State& GetActiveStateMut() { return m_States.at(m_ActiveState); }
-
 	void Update(float deltaTime, ModelComponent& modelComponent);
-private:
 
+private:
+	// The current active behavior state. Behaviors can only be in ONE state at a time.
 	BehaviorState m_ActiveState;
 
 	// The states this behavior has.

--- a/dGame/dPropertyBehaviors/State.cpp
+++ b/dGame/dPropertyBehaviors/State.cpp
@@ -122,6 +122,11 @@ void State::HandleMsg(GameMessages::RequestUse& msg) {
 	for (auto& strip : m_Strips) strip.HandleMsg(msg);
 }
 
+template<>
+void State::HandleMsg(GameMessages::ResetModelToDefaults& msg) {
+	for (auto& strip : m_Strips) strip.HandleMsg(msg);
+}
+
 bool State::IsEmpty() const {
 	for (const auto& strip : m_Strips) {
 		if (!strip.IsEmpty()) return false;

--- a/dGame/dPropertyBehaviors/State.cpp
+++ b/dGame/dPropertyBehaviors/State.cpp
@@ -117,6 +117,11 @@ void State::HandleMsg(MigrateActionsMessage& msg) {
 	}
 };
 
+template<>
+void State::HandleMsg(GameMessages::RequestUse& msg) {
+	for (auto& strip : m_Strips) strip.HandleMsg(msg);
+}
+
 bool State::IsEmpty() const {
 	for (const auto& strip : m_Strips) {
 		if (!strip.IsEmpty()) return false;
@@ -151,4 +156,8 @@ void State::Deserialize(const tinyxml2::XMLElement& state) {
 		auto& strip = m_Strips.emplace_back();
 		strip.Deserialize(*stripElement);
 	}
+}
+
+void State::Update(float deltaTime, ModelComponent& modelComponent) {
+	for (auto& strip : m_Strips) strip.Update(deltaTime, modelComponent);
 }

--- a/dGame/dPropertyBehaviors/State.h
+++ b/dGame/dPropertyBehaviors/State.h
@@ -21,11 +21,10 @@ public:
 	void Serialize(tinyxml2::XMLElement& state) const;
 	void Deserialize(const tinyxml2::XMLElement& state);
 
-	const std::vector<Strip>& GetStrips() const { return m_Strips; }
-	std::vector<Strip>& GetStripsMut() { return m_Strips; }
-
 	void Update(float deltaTime, ModelComponent& modelComponent);
 private:
+
+	// The strips contained within this state.
 	std::vector<Strip> m_Strips;
 };
 

--- a/dGame/dPropertyBehaviors/State.h
+++ b/dGame/dPropertyBehaviors/State.h
@@ -8,6 +8,7 @@ namespace tinyxml2 {
 }
 
 class AMFArrayValue;
+class ModelComponent;
 
 class State {
 public:
@@ -19,6 +20,11 @@ public:
 
 	void Serialize(tinyxml2::XMLElement& state) const;
 	void Deserialize(const tinyxml2::XMLElement& state);
+
+	const std::vector<Strip>& GetStrips() const { return m_Strips; }
+	std::vector<Strip>& GetStripsMut() { return m_Strips; }
+
+	void Update(float deltaTime, ModelComponent& modelComponent);
 private:
 	std::vector<Strip> m_Strips;
 };

--- a/dGame/dPropertyBehaviors/Strip.cpp
+++ b/dGame/dPropertyBehaviors/Strip.cpp
@@ -7,6 +7,8 @@
 #include "ModelComponent.h"
 #include "PlayerManager.h"
 
+#include "DluAssert.h"
+
 template <>
 void Strip::HandleMsg(AddStripMessage& msg) {
 	m_Actions = msg.GetActionsToAdd();
@@ -105,7 +107,7 @@ void Strip::IncrementAction() {
 
 void Strip::Spawn(LOT lot, Entity& entity) {
 	EntityInfo info{};
-	info.lot = lot; // Dark Ronin property
+	info.lot = lot;
 	info.pos = entity.GetPosition();
 	info.rot = NiQuaternionConstant::IDENTITY;
 	info.spawnerID = entity.GetObjectID();
@@ -126,17 +128,17 @@ void Strip::ProcNormalAction(float deltaTime, ModelComponent& modelComponent) {
 	auto numberAsInt = static_cast<int32_t>(number);
 	auto nextActionType = GetNextAction().GetType();
 	if (nextActionType == "SpawnStromling") {
-		Spawn(10495, entity);
+		Spawn(10495, entity); // Stromling property
 	} else if (nextActionType == "SpawnPirate") {
-		Spawn(10497, entity);
+		Spawn(10497, entity); // Maelstrom Pirate property
 	} else if (nextActionType == "SpawnRonin") {
-		Spawn(10498, entity);
+		Spawn(10498, entity); // Dark Ronin property
 	} else if (nextActionType == "DropImagination") {
-		for (; numberAsInt > 0; numberAsInt--) SpawnDrop(935, entity);
+		for (; numberAsInt > 0; numberAsInt--) SpawnDrop(935, entity); // 1 Imagination powerup
 	} else if (nextActionType == "DropHealth") {
-		for (; numberAsInt > 0; numberAsInt--) SpawnDrop(177, entity);
+		for (; numberAsInt > 0; numberAsInt--) SpawnDrop(177, entity); // 1 Life powerup
 	} else if (nextActionType == "DropArmor") {
-		for (; numberAsInt > 0; numberAsInt--) SpawnDrop(6431, entity);
+		for (; numberAsInt > 0; numberAsInt--) SpawnDrop(6431, entity); // 1 Armor powerup
 	} else if (nextActionType == "Smash") {
 		GameMessages::Smash smash{};
 		smash.target = entity.GetObjectID();
@@ -157,10 +159,10 @@ void Strip::ProcNormalAction(float deltaTime, ModelComponent& modelComponent) {
 		sound.soundID = numberAsInt;
 		sound.Send(UNASSIGNED_SYSTEM_ADDRESS);
 	} else {
-		static std::set<std::string> g_PlayedSounds;
-		if (!g_PlayedSounds.contains(nextActionType.data())) {
+		static std::set<std::string> g_WarnedActions;
+		if (!g_WarnedActions.contains(nextActionType.data())) {
 			LOG("Tried to play action (%s) which is not supported.", nextActionType.data());
-			g_PlayedSounds.insert(nextActionType.data());
+			g_WarnedActions.insert(nextActionType.data());
 		}
 		return;
 	}
@@ -233,6 +235,10 @@ void Strip::Deserialize(const tinyxml2::XMLElement& strip) {
 		auto& action = m_Actions.emplace_back();
 		action.Deserialize(*actionElement);
 	}
+}
+
+const Action& Strip::GetNextAction() const {
+	DluAssert(m_NextActionIndex < m_Actions.size()); return m_Actions[m_NextActionIndex];
 }
 
 const Action& Strip::GetPreviousAction() const {

--- a/dGame/dPropertyBehaviors/Strip.cpp
+++ b/dGame/dPropertyBehaviors/Strip.cpp
@@ -82,6 +82,8 @@ void Strip::HandleMsg(MigrateActionsMessage& msg) {
 
 template<>
 void Strip::HandleMsg(GameMessages::RequestUse& msg) {
+	if (m_PausedTime > 0.0f) return;
+
 	if (m_Actions[m_NextActionIndex].GetType() == "OnInteract") {
 		IncrementAction();
 		m_WaitingForAction = false;

--- a/dGame/dPropertyBehaviors/Strip.cpp
+++ b/dGame/dPropertyBehaviors/Strip.cpp
@@ -3,6 +3,9 @@
 #include "Amf3.h"
 #include "ControlBehaviorMsgs.h"
 #include "tinyxml2.h"
+#include "dEntity/EntityInfo.h"
+#include "ModelComponent.h"
+#include "PlayerManager.h"
 
 template <>
 void Strip::HandleMsg(AddStripMessage& msg) {
@@ -75,7 +78,54 @@ void Strip::HandleMsg(MigrateActionsMessage& msg) {
 	} else {
 		m_Actions.insert(m_Actions.begin() + msg.GetDstActionIndex(), msg.GetMigratedActions().begin(), msg.GetMigratedActions().end());
 	}
-};
+}
+
+template<>
+void Strip::HandleMsg(GameMessages::RequestUse& msg) {
+	if (m_Actions[m_NextActionIndex].GetType() == "OnInteract") IncrementAction();
+}
+
+void Strip::IncrementAction() {
+	if (m_Actions.empty()) return;
+	m_NextActionIndex++;
+	m_NextActionIndex %= m_Actions.size();
+}
+
+void Strip::Spawn(LOT lot, Entity& entity) {
+	EntityInfo info{};
+	info.lot = lot; // Dark Ronin property
+	info.pos = entity.GetPosition();
+	info.rot = NiQuaternionConstant::IDENTITY;
+	info.spawnerID = entity.GetObjectID();
+	Game::entityManager->ConstructEntity(Game::entityManager->CreateEntity(info, nullptr, &entity));
+	IncrementAction();
+}
+
+// Spawns a specific drop for all
+void Strip::SpawnDrop(LOT dropLOT, Entity& entity) {
+	for (auto* const player : PlayerManager::GetAllPlayers()) {
+		GameMessages::SendDropClientLoot(player, entity.GetObjectID(), dropLOT, 0, entity.GetPosition());
+	}
+	IncrementAction();
+}
+
+void Strip::Update(float deltaTime, ModelComponent& modelComponent) {
+	auto& entity = *modelComponent.GetParent();
+	auto number = static_cast<int32_t>(GetNextAction().GetValueParameterDouble());
+	if (GetNextAction().GetType() == "SpawnStromling") {
+		Spawn(10495, entity);
+	} else if (GetNextAction().GetType() == "SpawnPirate") {
+		Spawn(10497, entity);
+	} else if (GetNextAction().GetType() == "SpawnRonin") {
+		Spawn(10498, entity);
+	} else if (GetNextAction().GetType() == "DropImagination") {
+		for (; number > 0; number--) SpawnDrop(935, entity);
+	} else if (GetNextAction().GetType() == "DropHealth") {
+		for (; number > 0; number--) SpawnDrop(177, entity);
+	} else if (GetNextAction().GetType() == "DropArmor") {
+		for (; number > 0; number--) SpawnDrop(6431, entity);
+	}
+}
 
 void Strip::SendBehaviorBlocksToClient(AMFArrayValue& args) const {
 	m_Position.SendBehaviorBlocksToClient(args);

--- a/dGame/dPropertyBehaviors/Strip.cpp
+++ b/dGame/dPropertyBehaviors/Strip.cpp
@@ -88,6 +88,13 @@ void Strip::HandleMsg(GameMessages::RequestUse& msg) {
 	}
 }
 
+template<>
+void Strip::HandleMsg(GameMessages::ResetModelToDefaults& msg) {
+	m_WaitingForAction = false;
+	m_PausedTime = 0.0f;
+	m_NextActionIndex = 0;
+}
+
 void Strip::IncrementAction() {
 	if (m_Actions.empty()) return;
 	m_NextActionIndex++;

--- a/dGame/dPropertyBehaviors/Strip.h
+++ b/dGame/dPropertyBehaviors/Strip.h
@@ -4,6 +4,8 @@
 #include "Action.h"
 #include "StripUiPosition.h"
 
+#include "DluAssert.h"
+
 #include <vector>
 
 namespace tinyxml2 {
@@ -11,6 +13,7 @@ namespace tinyxml2 {
 }
 
 class AMFArrayValue;
+class ModelComponent;
 
 class Strip {
 public:
@@ -22,7 +25,16 @@ public:
 
 	void Serialize(tinyxml2::XMLElement& strip) const;
 	void Deserialize(const tinyxml2::XMLElement& strip);
+
+	const std::vector<Action>& GetActions() const { return m_Actions; }
+	const Action& GetNextAction() const { DluAssert(m_NextActionIndex < m_Actions.size()); return m_Actions[m_NextActionIndex]; }
+
+	void IncrementAction();
+	void Spawn(LOT object, Entity& entity);
+	void Update(float deltaTime, ModelComponent& modelComponent);
+	void SpawnDrop(LOT dropLOT, Entity& entity);
 private:
+	size_t m_NextActionIndex{ 0 };
 	std::vector<Action> m_Actions;
 	StripUiPosition m_Position;
 };

--- a/dGame/dPropertyBehaviors/Strip.h
+++ b/dGame/dPropertyBehaviors/Strip.h
@@ -28,13 +28,16 @@ public:
 
 	const std::vector<Action>& GetActions() const { return m_Actions; }
 	const Action& GetNextAction() const { DluAssert(m_NextActionIndex < m_Actions.size()); return m_Actions[m_NextActionIndex]; }
+	const Action& GetPreviousAction() const;
 
 	void IncrementAction();
 	void Spawn(LOT object, Entity& entity);
 	void Update(float deltaTime, ModelComponent& modelComponent);
 	void SpawnDrop(LOT dropLOT, Entity& entity);
 	void ProcNormalAction(float deltaTime, ModelComponent& modelComponent);
+	void RemoveStates(ModelComponent& modelComponent) const;
 private:
+	bool m_WaitingForAction{ false };
 	float m_PausedTime{ 0.0f };
 	size_t m_NextActionIndex{ 0 };
 	std::vector<Action> m_Actions;

--- a/dGame/dPropertyBehaviors/Strip.h
+++ b/dGame/dPropertyBehaviors/Strip.h
@@ -4,8 +4,6 @@
 #include "Action.h"
 #include "StripUiPosition.h"
 
-#include "DluAssert.h"
-
 #include <vector>
 
 namespace tinyxml2 {
@@ -26,8 +24,7 @@ public:
 	void Serialize(tinyxml2::XMLElement& strip) const;
 	void Deserialize(const tinyxml2::XMLElement& strip);
 
-	const std::vector<Action>& GetActions() const { return m_Actions; }
-	const Action& GetNextAction() const { DluAssert(m_NextActionIndex < m_Actions.size()); return m_Actions[m_NextActionIndex]; }
+	const Action& GetNextAction() const;
 	const Action& GetPreviousAction() const;
 
 	void IncrementAction();
@@ -37,10 +34,19 @@ public:
 	void ProcNormalAction(float deltaTime, ModelComponent& modelComponent);
 	void RemoveStates(ModelComponent& modelComponent) const;
 private:
+	// Indicates this Strip is waiting for an action to be taken upon it to progress to its actions
 	bool m_WaitingForAction{ false };
+
+	// The amount of time this strip is paused for.  Any interactions with this strip should be bounced if this is greater than 0.
 	float m_PausedTime{ 0.0f };
+
+	// The index of the next action to be played. This should always be within range of [0, m_Actions.size()).
 	size_t m_NextActionIndex{ 0 };
+
+	// The list of actions to be executed on this behavior.
 	std::vector<Action> m_Actions;
+
+	// The location of this strip on the UGBehaviorEditor UI
 	StripUiPosition m_Position;
 };
 

--- a/dGame/dPropertyBehaviors/Strip.h
+++ b/dGame/dPropertyBehaviors/Strip.h
@@ -33,6 +33,7 @@ public:
 	void Spawn(LOT object, Entity& entity);
 	void Update(float deltaTime, ModelComponent& modelComponent);
 	void SpawnDrop(LOT dropLOT, Entity& entity);
+	void ProcNormalAction(float deltaTime, ModelComponent& modelComponent);
 private:
 	float m_PausedTime{ 0.0f };
 	size_t m_NextActionIndex{ 0 };

--- a/dGame/dPropertyBehaviors/Strip.h
+++ b/dGame/dPropertyBehaviors/Strip.h
@@ -34,6 +34,7 @@ public:
 	void Update(float deltaTime, ModelComponent& modelComponent);
 	void SpawnDrop(LOT dropLOT, Entity& entity);
 private:
+	float m_PausedTime{ 0.0f };
 	size_t m_NextActionIndex{ 0 };
 	std::vector<Action> m_Actions;
 	StripUiPosition m_Position;


### PR DESCRIPTION
Have tested that the following behaviors function:
On Interact
Drop Life Powerup
Drop Imagination Powerup
Drop Armor Powerup
Spawn Stroming
Spawn Pirate
Spawn Ronin
Play Sound
Smash
Wait
UnSmash

The model resets its state correctly when entering build mode and ceases playing further Actions
The model is not able to be interacted with if there are zero strips which have an OnInteract next
The model is able to be interacted with when one or more strips have OnInteract next
The model executes only its own actions and does not start other strips actions
The models behaviors do not interfere with each other and operate independently from one another
