### PR TITLE
fix: sys addr for private zones

### DIFF
--- a/dMasterServer/InstanceManager.cpp
+++ b/dMasterServer/InstanceManager.cpp
@@ -273,6 +273,16 @@ Instance* InstanceManager::FindInstance(LWOMAPID mapID, LWOINSTANCEID instanceID
 	return nullptr;
 }
 
+Instance* InstanceManager::FindInstanceWithPrivate(LWOMAPID mapID, LWOINSTANCEID instanceID) {
+	for (Instance* i : m_Instances) {
+		if (i && i->GetMapID() == mapID && i->GetInstanceID() == instanceID && !i->GetShutdownComplete() && !i->GetIsShuttingDown()) {
+			return i;
+		}
+	}
+
+	return nullptr;
+}
+
 Instance* InstanceManager::CreatePrivateInstance(LWOMAPID mapID, LWOCLONEID cloneID, const std::string& password) {
 	auto* instance = FindPrivateInstance(password);
 

--- a/dMasterServer/InstanceManager.h
+++ b/dMasterServer/InstanceManager.h
@@ -125,6 +125,7 @@ public:
 
 	Instance* FindInstance(LWOMAPID mapID, bool isFriendTransfer, LWOCLONEID cloneId = 0);
 	Instance* FindInstance(LWOMAPID mapID, LWOINSTANCEID instanceID);
+	Instance* FindInstanceWithPrivate(LWOMAPID mapID, LWOINSTANCEID instanceID);
 
 	Instance* CreatePrivateInstance(LWOMAPID mapID, LWOCLONEID cloneID, const std::string& password);
 	Instance* FindPrivateInstance(const std::string& password);


### PR DESCRIPTION
Checked in logs and private instances no longer have a random system address