### PR TITLE
fix: buff station dying and rotating too soon

### DIFF
--- a/dScripts/BaseSurvivalServer.cpp
+++ b/dScripts/BaseSurvivalServer.cpp
@@ -503,7 +503,7 @@ void BaseSurvivalServer::ActivateSpawnerNetwork(SpawnerNetworkCollection& spawne
 			if (!possibleSpawners.empty()) {
 				auto* spawnerObject = possibleSpawners.at(0);
 				spawnerObject->Activate();
-				spawnerObject->Reset();
+				spawnerObject->SoftReset();
 			}
 		}
 	}


### PR DESCRIPTION
Tested that the buff station now waits for a player to build it and is alive for 25 seconds before moving positions fixes #1767