### PR TITLE
feat: Migrations only flag

### DIFF
--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -213,6 +213,13 @@ int main(int argc, char** argv) {
 	// Run migrations should any need to be run.
 	MigrationRunner::RunSQLiteMigrations();
 
+	// Check for the --migrations-only flag
+	if ((argc > 1 &&
+		(strcmp(argv[1], "--migrations-only") == 0 || strcmp(argv[1], "-m") == 0))) {
+		LOG("Migrations only flag detected.  Exiting.");
+		return EXIT_SUCCESS;
+	}
+
 	//If the first command line argument is -a or --account then make the user
 	//input a username and password, with the password being hidden.
 	bool createAccount = Database::Get()->GetAccountCount() == 0 && Game::config->GetValue("skip_account_creation") != "1";


### PR DESCRIPTION
This pull requests seeks to add a flag to the master server for an early exit after the migrations has run.

This is for a special usecase for nejlika, but I believe it could be generally useful to test that the connections to the databases work.