### PR TITLE
fix: lastUpdatedTime updating

### DIFF
--- a/dDatabase/GameDatabase/ITables/IProperty.h
+++ b/dDatabase/GameDatabase/ITables/IProperty.h
@@ -53,6 +53,9 @@ public:
 	// Update the property details for the given property id.
 	virtual void UpdatePropertyDetails(const IProperty::Info& info) = 0;
 
+	// Update the last updated time for the given property id.
+	virtual void UpdateLastSave(const IProperty::Info& info) = 0;
+
 	// Update the property performance cost for the given property id.
 	virtual void UpdatePerformanceCost(const LWOZONEID& zoneId, const float performanceCost) = 0;
 	

--- a/dDatabase/GameDatabase/MySQL/MySQLDatabase.h
+++ b/dDatabase/GameDatabase/MySQL/MySQLDatabase.h
@@ -70,6 +70,7 @@ public:
 	std::optional<IProperty::Info> GetPropertyInfo(const LWOMAPID mapId, const LWOCLONEID cloneId) override;
 	void UpdatePropertyModerationInfo(const IProperty::Info& info) override;
 	void UpdatePropertyDetails(const IProperty::Info& info) override;
+	void UpdateLastSave(const IProperty::Info& info) override;
 	void InsertNewProperty(const IProperty::Info& info, const uint32_t templateId, const LWOZONEID& zoneId) override;
 	std::vector<IPropertyContents::Model> GetPropertyModels(const LWOOBJID& propertyId) override;
 	void RemoveUnreferencedUgcModels() override;

--- a/dDatabase/GameDatabase/MySQL/Tables/Property.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/Property.cpp
@@ -173,6 +173,10 @@ void MySQLDatabase::UpdatePropertyDetails(const IProperty::Info& info) {
 	ExecuteUpdate("UPDATE properties SET name = ?, description = ? WHERE id = ? LIMIT 1;", info.name, info.description, info.id);
 }
 
+void MySQLDatabase::UpdateLastSave(const IProperty::Info& info) {
+	ExecuteUpdate("UPDATE properties SET last_updated = ? WHERE id = ?;", info.lastUpdatedTime, info.id);
+}
+
 void MySQLDatabase::UpdatePerformanceCost(const LWOZONEID& zoneId, const float performanceCost) {
 	ExecuteUpdate("UPDATE properties SET performance_cost = ? WHERE zone_id = ? AND clone_id = ? LIMIT 1;", performanceCost, zoneId.GetMapID(), zoneId.GetCloneID());
 }

--- a/dDatabase/GameDatabase/SQLite/SQLiteDatabase.h
+++ b/dDatabase/GameDatabase/SQLite/SQLiteDatabase.h
@@ -68,6 +68,7 @@ public:
 	std::optional<IProperty::Info> GetPropertyInfo(const LWOMAPID mapId, const LWOCLONEID cloneId) override;
 	void UpdatePropertyModerationInfo(const IProperty::Info& info) override;
 	void UpdatePropertyDetails(const IProperty::Info& info) override;
+	void UpdateLastSave(const IProperty::Info& info) override;
 	void InsertNewProperty(const IProperty::Info& info, const uint32_t templateId, const LWOZONEID& zoneId) override;
 	std::vector<IPropertyContents::Model> GetPropertyModels(const LWOOBJID& propertyId) override;
 	void RemoveUnreferencedUgcModels() override;

--- a/dDatabase/GameDatabase/SQLite/Tables/Property.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/Property.cpp
@@ -175,6 +175,10 @@ void SQLiteDatabase::UpdatePropertyDetails(const IProperty::Info& info) {
 	ExecuteUpdate("UPDATE properties SET name = ?, description = ? WHERE id = ?;", info.name, info.description, info.id);
 }
 
+void SQLiteDatabase::UpdateLastSave(const IProperty::Info& info) {
+	ExecuteUpdate("UPDATE properties SET last_updated = ? WHERE id = ?;", info.lastUpdatedTime, info.id);
+}
+
 void SQLiteDatabase::UpdatePerformanceCost(const LWOZONEID& zoneId, const float performanceCost) {
 	ExecuteUpdate("UPDATE properties SET performance_cost = ? WHERE zone_id = ? AND clone_id = ?;", performanceCost, zoneId.GetMapID(), zoneId.GetCloneID());
 }

--- a/dDatabase/GameDatabase/TestSQL/TestSQLDatabase.cpp
+++ b/dDatabase/GameDatabase/TestSQL/TestSQLDatabase.cpp
@@ -148,6 +148,10 @@ void TestSQLDatabase::UpdatePropertyDetails(const IProperty::Info& info) {
 
 }
 
+void TestSQLDatabase::UpdateLastSave(const IProperty::Info& info) {
+
+}
+
 void TestSQLDatabase::InsertNewProperty(const IProperty::Info& info, const uint32_t templateId, const LWOZONEID& zoneId) {
 
 }

--- a/dDatabase/GameDatabase/TestSQL/TestSQLDatabase.h
+++ b/dDatabase/GameDatabase/TestSQL/TestSQLDatabase.h
@@ -47,6 +47,7 @@ class TestSQLDatabase : public GameDatabase {
 	std::optional<IProperty::Info> GetPropertyInfo(const LWOMAPID mapId, const LWOCLONEID cloneId) override;
 	void UpdatePropertyModerationInfo(const IProperty::Info& info) override;
 	void UpdatePropertyDetails(const IProperty::Info& info) override;
+	void UpdateLastSave(const IProperty::Info& info) override;
 	void InsertNewProperty(const IProperty::Info& info, const uint32_t templateId, const LWOZONEID& zoneId) override;
 	std::vector<IPropertyContents::Model> GetPropertyModels(const LWOOBJID& propertyId) override;
 	void RemoveUnreferencedUgcModels() override;

--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -688,6 +688,12 @@ void PropertyManagementComponent::Save() {
 
 		Database::Get()->RemoveModel(model.id);
 	}
+//temp block
+	IProperty::Info info;
+	info.id = propertyId;
+	info.LastUpdatedTime = std::chrono::system_clock::now();
+	Database::Get()->UpdateLastSave(info);
+//
 }
 
 void PropertyManagementComponent::AddModel(LWOOBJID modelId, LWOOBJID spawnerId) {

--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -688,12 +688,12 @@ void PropertyManagementComponent::Save() {
 
 		Database::Get()->RemoveModel(model.id);
 	}
-//temp block
+	//temp block
 	IProperty::Info info;
 	info.id = propertyId;
-	info.LastUpdatedTime = std::chrono::system_clock::now();
+	info.lastUpdatedTime = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 	Database::Get()->UpdateLastSave(info);
-//
+	//
 }
 
 void PropertyManagementComponent::AddModel(LWOOBJID modelId, LWOOBJID spawnerId) {

--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -165,7 +165,9 @@ void PropertyManagementComponent::UpdatePropertyDetails(std::string name, std::s
 	info.id = propertyId;
 	info.name = propertyName;
 	info.description = propertyDescription;
-
+	info.lastUpdatedTime = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+	
+	Database::Get()->UpdateLastSave(info);
 	Database::Get()->UpdatePropertyDetails(info);
 
 	OnQueryPropertyData(GetOwner(), UNASSIGNED_SYSTEM_ADDRESS);
@@ -688,12 +690,10 @@ void PropertyManagementComponent::Save() {
 
 		Database::Get()->RemoveModel(model.id);
 	}
-	//temp block
 	IProperty::Info info;
 	info.id = propertyId;
 	info.lastUpdatedTime = std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 	Database::Get()->UpdateLastSave(info);
-	//
 }
 
 void PropertyManagementComponent::AddModel(LWOOBJID modelId, LWOOBJID spawnerId) {


### PR DESCRIPTION
Fixes #1774

Conducted testing on property changes and confirmed bug after saving button pressed no changes are made to Block yard UI.
![Block Yard](https://github.com/user-attachments/assets/5294d3d5-5c97-4fbb-bf90-f20cb4b7d650)

I created a new query with `LastSaveUpdate()` under all db files that `UpdatePropertyDetails()`  apper in so that it can be used for the save() button but also for future uses down the line like `UpdatePropertyModerationInfo()` `UpdatePropertyDetails()` or 'SetPrivacyOption()'.

I can commit these changes if wanted but know my original task was to just bind it to save which is only called during `OnFinishBuilding()`

after applying changes tests came back as resolved:
![AD_4nXcDikKylu_AYXMwYjzpKyolrnG2IHx27FC6NPNvqPHby8AUawE7RtkdTh90plq36erH4zWTsjGViGbY5394kLHXc14nSaisDHUo6pv5R6zbfwbhQX7yw2mx](https://github.com/user-attachments/assets/91a5e786-29c0-48ce-91db-6828f36c5e52)
![RevvverB's](https://github.com/user-attachments/assets/8371a08e-ff21-4fcf-94fd-b19b252115c5)


