### PR TITLE
feat: auto reject empty properties config option

### DIFF
--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -26,6 +26,7 @@
 #include <vector>
 #include "CppScripts.h"
 #include <ranges>
+#include "dConfig.h"
 
 PropertyManagementComponent* PropertyManagementComponent::instance = nullptr;
 
@@ -151,7 +152,11 @@ void PropertyManagementComponent::SetPrivacyOption(PropertyPrivacyOption value) 
 	info.rejectionReason = rejectionReason;
 	info.modApproved = 0;
 
-	Database::Get()->UpdatePropertyModerationInfo(info);
+	if (models.empty() && Game::config->GetValue("auto_reject_empty_properties") == "1") {
+		UpdateApprovedStatus(false, "Your property is empty. Please place a model to have a public property.");
+	} else {
+		Database::Get()->UpdatePropertyModerationInfo(info);
+	}
 }
 
 void PropertyManagementComponent::UpdatePropertyDetails(std::string name, std::string description) {
@@ -565,14 +570,14 @@ void PropertyManagementComponent::DeleteModel(const LWOOBJID id, const int delet
 	}
 }
 
-void PropertyManagementComponent::UpdateApprovedStatus(const bool value) {
+void PropertyManagementComponent::UpdateApprovedStatus(const bool value, const std::string& rejectionReason) {
 	if (owner == LWOOBJID_EMPTY) return;
 
 	IProperty::Info info;
 	info.id = propertyId;
 	info.modApproved = value;
 	info.privacyOption = static_cast<uint32_t>(privacyOption);
-	info.rejectionReason = "";
+	info.rejectionReason = rejectionReason;
 
 	Database::Get()->UpdatePropertyModerationInfo(info);
 }

--- a/dGame/dComponents/PropertyManagementComponent.h
+++ b/dGame/dComponents/PropertyManagementComponent.h
@@ -135,7 +135,7 @@ public:
 	 * Updates whether or not this property is approved by a moderator
 	 * @param value true if the property should be approved, false otherwise
 	 */
-	void UpdateApprovedStatus(bool value);
+	void UpdateApprovedStatus(bool value, const std::string& rejectionReason = "");
 
 	/**
 	 * Loads all the models on this property from the database

--- a/resources/worldconfig.ini
+++ b/resources/worldconfig.ini
@@ -77,3 +77,6 @@ allow_players_to_skip_cinematics=0
 # Customizable message for what to say when there is a cdclient fdb mismatch
 cdclient_mismatch_title=Version out of date
 cdclient_mismatch_message=We detected that your client is out of date. Please update your client to the latest version.
+
+# Auto reject properties which contain no models | must be 1 in order to auto reject.
+auto_reject_empty_properties=0


### PR DESCRIPTION
Tested that having the config option set to 1 and having an empty property auto-rejected it.  Tested that having a model on the property or having the new config option set to 0 auto approved the property (as per live)
closes #1752 