### PR TITLE
fix: playing an emote not showing on all clients

### DIFF
--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -942,6 +942,11 @@ void PetComponent::Command(const NiPoint3& position, const LWOOBJID source, cons
 	if (commandType == 1) {
 		// Emotes
 		GameMessages::SendPlayEmote(m_Parent->GetObjectID(), typeId, owner->GetObjectID(), UNASSIGNED_SYSTEM_ADDRESS);
+		GameMessages::EmotePlayed msg;
+		msg.target = owner->GetObjectID();
+		msg.emoteID = typeId;
+		msg.targetID = 0; // Or set to the intended target entity's ID, or 0 if no target
+		msg.Send(UNASSIGNED_SYSTEM_ADDRESS);
 	} else if (commandType == 3) {
 		// Follow me, ???
 	} else if (commandType == 6) {

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -4958,7 +4958,7 @@ void GameMessages::HandleQuickBuildCancel(RakNet::BitStream& inStream, Entity* e
 }
 
 void GameMessages::HandlePlayEmote(RakNet::BitStream& inStream, Entity* entity) {
-	int emoteID;
+	int32_t emoteID;
 	LWOOBJID targetID;
 
 	inStream.Read(emoteID);
@@ -4979,7 +4979,7 @@ void GameMessages::HandlePlayEmote(RakNet::BitStream& inStream, Entity* entity) 
 
 	GameMessages::EmotePlayed msg;
 	msg.target = entity->GetObjectID();
-	msg.emoteID = static_cast<int32_t>(emoteID);
+	msg.emoteID = emoteID;
 	msg.targetID = targetID;      // The emote’s target entity or 0 if none
 	msg.Send(UNASSIGNED_SYSTEM_ADDRESS);  // Broadcast to all clients
 

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -4977,7 +4977,6 @@ void GameMessages::HandlePlayEmote(RakNet::BitStream& inStream, Entity* entity) 
 		if (emote) sAnimationName = emote->animationName;
 	}
 
-	//RenderComponent::PlayAnimation(entity, sAnimationName);
 	GameMessages::EmotePlayed msg;
 	msg.target = entity->GetObjectID();
 	msg.emoteID = static_cast<int32_t>(emoteID);

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -4977,7 +4977,12 @@ void GameMessages::HandlePlayEmote(RakNet::BitStream& inStream, Entity* entity) 
 		if (emote) sAnimationName = emote->animationName;
 	}
 
-	RenderComponent::PlayAnimation(entity, sAnimationName);
+	//RenderComponent::PlayAnimation(entity, sAnimationName);
+	GameMessages::EmotePlayed msg;
+	msg.target = entity->GetObjectID();
+	msg.emoteID = static_cast<int32_t>(emoteID);
+	msg.targetID = targetID;      // The emote’s target entity or 0 if none
+	msg.Send(UNASSIGNED_SYSTEM_ADDRESS);  // Broadcast to all clients
 
 	MissionComponent* missionComponent = entity->GetComponent<MissionComponent>();
 	if (!missionComponent) return;
@@ -6463,5 +6468,10 @@ namespace GameMessages {
 	void PlayBehaviorSound::Serialize(RakNet::BitStream& stream) const {
 		stream.Write(soundID != -1);
 		if (soundID != -1) stream.Write(soundID);
+	}
+
+	void EmotePlayed::Serialize(RakNet::BitStream& stream) const {
+		stream.Write(emoteID);
+		stream.Write(targetID);
 	}
 }

--- a/dGame/dGameMessages/GameMessages.h
+++ b/dGame/dGameMessages/GameMessages.h
@@ -835,7 +835,7 @@ namespace GameMessages {
 	};
 
 	struct EmotePlayed : public GameMsg {
-		EmotePlayed() : GameMsg(MessageType::Game::EMOTE_PLAYED), emoteID(emoteID), targetID(targetID) {}
+		EmotePlayed() : GameMsg(MessageType::Game::EMOTE_PLAYED), emoteID(0), targetID(0) {}
 	
 		void Serialize(RakNet::BitStream& stream) const override;
 	

--- a/dGame/dGameMessages/GameMessages.h
+++ b/dGame/dGameMessages/GameMessages.h
@@ -833,6 +833,15 @@ namespace GameMessages {
 	struct ResetModelToDefaults : public GameMsg {
 		ResetModelToDefaults() : GameMsg(MessageType::Game::RESET_MODEL_TO_DEFAULTS) {}
 	};
-};
 
+	struct EmotePlayed : public GameMsg {
+		EmotePlayed() : GameMsg(MessageType::Game::EMOTE_PLAYED), emoteID(emoteID), targetID(targetID) {}
+	
+		void Serialize(RakNet::BitStream& stream) const override;
+	
+		int32_t emoteID;
+		LWOOBJID targetID;
+	};
+
+};
 #endif // GAMEMESSAGES_H


### PR DESCRIPTION
(Fix #1342)

Thanks to @EmosewaMC 's suggestions,

I Created new structure for EmotePlayed with the `Game::MessageType::EMOTEPLAYED` that already exists in `DGame.h`
With the targetID for whom the emote is directed to and the emoteID for what type of emote is played which client handles with locale.xml (I believe atleast).

Then a serialize function was made in the GameMessage class to take advantage of boiler plate headers for serializing and sending.

implementation requires identifying the target through a 'LWOOBJID' of entity that started emote, the emoteID for emote type, and targetID if there is a target given.

For [PetComponent::Command] I forced targetID as 0 since I don't yet know if there are any emotes directed to other entities or if they are all just broadcast. If wanted I can keep it to be Owner entity.(https://github.com/DarkflameUniverse/DarkflameServer/blob/main/dGame/dComponents/PetComponent.cpp#L944)