### PR TITLE
Fix: Double imaginite issue resolved on mini survival games

### DIFF
--- a/dGame/dComponents/ActivityComponent.cpp
+++ b/dGame/dComponents/ActivityComponent.cpp
@@ -345,9 +345,6 @@ bool ActivityComponent::CheckCost(Entity* player) const {
 	if (inventoryComponent->GetLotCount(m_ActivityInfo.optionalCostLOT) < m_ActivityInfo.optionalCostCount)
 		return false;
 
-	//move to TakeCost
-	//inventoryComponent->RemoveItem(m_ActivityInfo.optionalCostLOT, m_ActivityInfo.optionalCostCount);
-
 	return true;
 }
 

--- a/dGame/dComponents/ActivityComponent.cpp
+++ b/dGame/dComponents/ActivityComponent.cpp
@@ -351,9 +351,14 @@ bool ActivityComponent::CheckCost(Entity* player) const {
 	return true;
 }
 
-void ActivityComponent::TakeCost(Entity* player){
-	if (CheckCost(player)) inventoryComponent->RemoveItem(m_ActivityInfo.optionalCostLOT, m_ActivityInfo.optionalCostCount);
-	else; //don't know yet
+bool ActivityComponent::TakeCost(Entity* player) const{
+	
+	auto* inventoryComponent = player->GetComponent<InventoryComponent>();
+	if (CheckCost(player)) {
+		inventoryComponent->RemoveItem(m_ActivityInfo.optionalCostLOT, m_ActivityInfo.optionalCostCount);
+		return true;
+	}
+	else return false;
 }
 
 void ActivityComponent::PlayerReady(Entity* player, bool bReady) {

--- a/dGame/dComponents/ActivityComponent.cpp
+++ b/dGame/dComponents/ActivityComponent.cpp
@@ -334,7 +334,7 @@ bool ActivityComponent::IsPlayedBy(LWOOBJID playerID) const {
 	return false;
 }
 
-bool ActivityComponent::TakeCost(Entity* player) const {
+bool ActivityComponent::CheckCost(Entity* player) const {
 	if (m_ActivityInfo.optionalCostLOT <= 0 || m_ActivityInfo.optionalCostCount <= 0)
 		return true;
 
@@ -345,9 +345,15 @@ bool ActivityComponent::TakeCost(Entity* player) const {
 	if (inventoryComponent->GetLotCount(m_ActivityInfo.optionalCostLOT) < m_ActivityInfo.optionalCostCount)
 		return false;
 
-	inventoryComponent->RemoveItem(m_ActivityInfo.optionalCostLOT, m_ActivityInfo.optionalCostCount);
+	//move to TakeCost
+	//inventoryComponent->RemoveItem(m_ActivityInfo.optionalCostLOT, m_ActivityInfo.optionalCostCount);
 
 	return true;
+}
+
+void ActivityComponent::TakeCost(Entity* player){
+	if (CheckCost(player)) inventoryComponent->RemoveItem(m_ActivityInfo.optionalCostLOT, m_ActivityInfo.optionalCostCount);
+	else; //don't know yet
 }
 
 void ActivityComponent::PlayerReady(Entity* player, bool bReady) {
@@ -382,7 +388,7 @@ ActivityInstance* ActivityComponent::NewInstance() {
 void ActivityComponent::LoadPlayersIntoInstance(ActivityInstance* instance, const std::vector<LobbyPlayer*>& lobby) const {
 	for (LobbyPlayer* player : lobby) {
 		auto* entity = player->GetEntity();
-		if (entity == nullptr || !TakeCost(entity)) {
+		if (entity == nullptr || !CheckCost(entity)) {
 			continue;
 		}
 

--- a/dGame/dComponents/ActivityComponent.h
+++ b/dGame/dComponents/ActivityComponent.h
@@ -234,10 +234,17 @@ public:
 	 */
 	bool IsPlayedBy(LWOOBJID playerID) const;
 
+	/** 
+	 * Checks if the entity has enough cost to play this activity
+	 * @param player the entity to check
+	 * @return true if the entity has enough cost to play this activity, false otherwise
+	*/
+	bool CheckCost(Entity* player) const;
+
 	/**
 	 * Removes the cost of the activity (e.g. green imaginate) for the entity that plays this activity
 	 * @param player the entity to take cost for
-	 * @return true if the cost was successfully deducted, false otherwise
+	 * @return true if the cost was taken, false otherwise
 	 */
 	bool TakeCost(Entity* player) const;
 


### PR DESCRIPTION
Fix: #1175
When the `PlayerLoadInstances()` was called it would call `TakeCosts()` to check if an item was taken before loading characters in. The problem with that is `TakeActivityCosts` is used for this exact thing after loading in when player start activity. Current solution is separate TakeCosts into a Check and Take function to be used for either purpose of either in TakeActivityCosts for starting activity or checking ability to pay for activity in PlayerLoadInstance. 