### PR TITLE
Added spawn management commands, along with some minor bugfixes.

### DIFF
--- a/dGame/EntityManager.cpp
+++ b/dGame/EntityManager.cpp
@@ -271,6 +271,18 @@ std::vector<Entity*> EntityManager::GetEntitiesInGroup(const std::string& group)
 	return entitiesInGroup;
 }
 
+std::vector<Entity*> EntityManager::GetEntitiesBySpawnerID(const LWOOBJID& objectID) const {
+	std::vector<Entity*> entitiesSpawnedBy;
+	if (!GetEntity(objectID)) return entitiesSpawnedBy;
+	for (auto* entity : m_Entities | std::views::values) {
+		if (!(entity->GetSpawnerID() == objectID)) continue;
+
+		entitiesSpawnedBy.push_back(entity);
+	}
+
+	return entitiesSpawnedBy;
+}
+
 std::vector<Entity*> EntityManager::GetEntitiesByComponent(const eReplicaComponentType componentType) const {
 	std::vector<Entity*> withComp;
 	if (componentType != eReplicaComponentType::INVALID) {

--- a/dGame/EntityManager.h
+++ b/dGame/EntityManager.h
@@ -26,6 +26,7 @@ public:
 	void DestroyEntity(Entity* entity);
 	Entity* GetEntity(const LWOOBJID& objectId) const;
 	std::vector<Entity*> GetEntitiesInGroup(const std::string& group);
+	std::vector<Entity*> GetEntitiesBySpawnerID(const LWOOBJID& objectID) const;
 	std::vector<Entity*> GetEntitiesByComponent(eReplicaComponentType componentType) const;
 	std::vector<Entity*> GetEntitiesByLOT(const LOT& lot) const;
 	std::vector<Entity*> GetEntitiesByProximity(NiPoint3 reference, float radius) const;

--- a/dGame/dUtilities/SlashCommandHandler.cpp
+++ b/dGame/dUtilities/SlashCommandHandler.cpp
@@ -448,6 +448,15 @@ void SlashCommandHandler::Startup() {
 	};
 	RegisterCommand(GetNavmeshHeightCommand);
 
+	Command GetPlayerIDCommand{
+		.help = "Print player objectID to chat. If no player name is provided, yours is assumed.",
+		.info = "Print player objectID to chat",
+		.aliases = { "getplayerid", "playerid" },
+		.handle = DEVGMCommands::GetPlayerID,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(GetPlayerIDCommand);
+
 	Command GiveUScoreCommand{
 		.help = "Gives uscore",
 		.info = "Gives uscore",
@@ -646,6 +655,25 @@ void SlashCommandHandler::Startup() {
 	};
 	RegisterCommand(SpawnCommand);
 
+	Command DespawnCommand{
+		.help = "Despawns an object by object ID",
+		.info = "Despawns an object by object ID",
+		.aliases = { "despawn", "destroy" },
+		.handle = DEVGMCommands::Despawn,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(DespawnCommand);
+
+	Command InspectDespawnCommand{
+		.help = "Despawns the nearest object with a given component. Most visible objects have a component with ID 2.",
+		.info = "Despawns the nearest object with a given component.",
+		.aliases = { "inspectdespawn", "inspect-despawn", "despawnnear", "despawn-near",
+					 "inspectdestroy", "inspect-destroy", "destroynear", "destroy-near" },
+		.handle = DEVGMCommands::InspectDespawn,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(InspectDespawnCommand);
+
 	Command SpawnGroupCommand{
 		.help = "",
 		.info = "",
@@ -807,6 +835,142 @@ void SlashCommandHandler::Startup() {
 		.requiredLevel = eGameMasterLevel::DEVELOPER
 	};
 	RegisterCommand(DeleteInvenCommand);
+
+	// Spawn management commands.
+	Command ListGroupCommand{
+		.help = "Lists all entities in the specified group",
+		.info = "Lists all entities in the specified group",
+		.aliases = { "listgroup", "list-group" },
+		.handle = DEVGMCommands::ListGroup,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(ListGroupCommand);
+
+	Command ListSpawnedByPlayerCommand{
+		.help = "Lists all entities spawned by a player (name provided)",
+		.info = "Lists all entities spawned by a player",
+		.aliases = { "listspawnedbyplayer", "list-spawned-by-player" },
+		.handle = DEVGMCommands::ListSpawnedByPlayer,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(ListSpawnedByPlayerCommand);
+
+	Command ListSpawnedBySenderCommand{
+		.help = "Lists all entities you have spawned",
+		.info = "Lists all entities you have spawned",
+		.aliases = { "myspawns", "my-spawns", "listmyspawns", "list-my-spawns" },
+		.handle = DEVGMCommands::ListSpawnedBySender,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(ListSpawnedBySenderCommand);
+
+	Command ListSpawnedBySpawnerIDCommand{
+		.help = "Lists all entities spawned by the specified object ID. Player object IDs can be found with `/getplayerid <playername>`.",
+		.info = "Lists all entities spawned by the specified object ID",
+		.aliases = { "listspawnedbyid", "list-spawned-by-id" },
+		.handle = DEVGMCommands::ListSpawnedBySpawnerID,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(ListSpawnedBySpawnerIDCommand);
+
+	Command ListAllPlayerSpawnsCommand{
+		.help = "Lists all entities spawned by current players",
+		.info = "Lists all entities spawned by current players",
+		.aliases = { "listallplayerspawns", "list-all-player-spawns" },
+		.handle = DEVGMCommands::ListAllPlayerSpawns,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(ListAllPlayerSpawnsCommand);
+
+	Command DespawnGroupCommand{
+		.help = "Despawns all entities in the specified group",
+		.info = "Despawns all entities in the specified group",
+		.aliases = { "despawngroup", "despawn-group", "deletegroup", "delete-group" },
+		.handle = DEVGMCommands::DespawnGroup,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(DespawnGroupCommand);
+
+	Command DespawnSpawnedByPlayerCommand{
+		.help = "Despawns all entities spawned by a player (name provided)",
+		.info = "Despawns all entities spawned by a player",
+		.aliases = { "despawnplayerspawns", "despawn-player-spawns", "deleteplayerspawns", "delete-player-spawns" },
+		.handle = DEVGMCommands::DespawnSpawnedByPlayer,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(DespawnSpawnedByPlayerCommand);
+
+	Command DespawnSpawnedBySenderCommand{
+		.help = "Despawns all entities you have spawned",
+		.info = "Despawns all entities you have spawned",
+		.aliases = { "despawnmyspawns", "despawn-my-spawns", "deletemyspawns", "delete-my-spawns" },
+		.handle = DEVGMCommands::DespawnSpawnedBySender,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(DespawnSpawnedBySenderCommand);
+
+	Command DespawnSpawnedBySpawnerIDCommand{
+		.help = "Despawns all entities spawned by the specified object ID. Player object IDs can be found with `/getplayerid <playername>`.",
+		.info = "Despawns all entities spawned by the specified object ID",
+		.aliases = { "despawnbyspawnerid", "despawn-by-spawner-id", "deletebyspawnerid", "delete-by-spawner-id" },
+		.handle = DEVGMCommands::DespawnSpawnedBySpawnerID,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(DespawnSpawnedBySpawnerIDCommand);
+
+	Command DespawnAllPlayerSpawnsCommand{
+		.help = "Despawns all entities spawned by current players",
+		.info = "Despawns all entities spawned by current players",
+		.aliases = { "despawnallplayerspawns", "despawn-all-player-spawns", "deleteallplayerspawns", "delete-all-player-spawns" },
+		.handle = DEVGMCommands::DespawnAllPlayerSpawns,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(DespawnAllPlayerSpawnsCommand);
+
+	Command SaveGroupCommand{
+		.help = "Saves all entities in the specified group to the Bug Report Table",
+		.info = "Saves all entities in the specified group to the Bug Report Table",
+		.aliases = { "savegroup", "save-group" },
+		.handle = DEVGMCommands::SaveGroup,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(SaveGroupCommand);
+
+	Command SaveSpawnedByPlayerCommand{
+		.help = "Saves all entities spawned by a player (name provided) to the Bug Report Table",
+		.info = "Saves all entities spawned by a player to the Bug Report Table",
+		.aliases = { "saveplayerspawns", "save-player-spawns" },
+		.handle = DEVGMCommands::SaveSpawnedByPlayer,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(SaveSpawnedByPlayerCommand);
+
+	Command SaveSpawnedBySenderCommand{
+		.help = "Saves all entities you have spawned to the Bug Report Table",
+		.info = "Saves all entities you have spawned to the Bug Report Table",
+		.aliases = { "savemyspawns", "save-my-spawns" },
+		.handle = DEVGMCommands::SaveSpawnedBySender,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(SaveSpawnedBySenderCommand);
+
+	Command SaveSpawnedBySpawnerIDCommand{
+		.help = "Saves all entities spawned by the specified object ID to the Bug Report Table. Player object IDs can be found with `/getplayerid <playername>`.",
+		.info = "Saves all entities spawned by the specified object ID to the Bug Report Table",
+		.aliases = { "savebyspawnerid", "save-by-spawner-id" },
+		.handle = DEVGMCommands::SaveSpawnedBySpawnerID,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(SaveSpawnedBySpawnerIDCommand);
+
+	Command SaveAllPlayerSpawnsCommand{
+		.help = "Saves all entities spawned by current players to the Bug Report Table",
+		.info = "Saves all entities spawned by current players to the Bug Report Table",
+		.aliases = { "saveallplayerspawns", "save-all-player-spawns" },
+		.handle = DEVGMCommands::SaveAllPlayerSpawns,
+		.requiredLevel = eGameMasterLevel::DEVELOPER
+	};
+	RegisterCommand(SaveAllPlayerSpawnsCommand);
 
 	// Register Greater Than Zero Commands
 

--- a/dGame/dUtilities/SlashCommands/DEVGMCommands.cpp
+++ b/dGame/dUtilities/SlashCommands/DEVGMCommands.cpp
@@ -121,7 +121,7 @@ namespace DEVGMCommands {
 
 	void ResetMission(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		const auto missionId = GeneralUtils::TryParse<uint32_t>(splitArgs[0]);
 		if (!missionId) {
@@ -184,7 +184,7 @@ namespace DEVGMCommands {
 
 	void PlayAnimation(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		std::u16string anim = GeneralUtils::ASCIIToUTF16(splitArgs[0], splitArgs[0].size());
 		RenderComponent::PlayAnimation(entity, anim);
@@ -205,7 +205,7 @@ namespace DEVGMCommands {
 
 	void UnlockEmote(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		const auto emoteID = GeneralUtils::TryParse<int32_t>(splitArgs[0]);
 
@@ -223,7 +223,7 @@ namespace DEVGMCommands {
 
 	void Kill(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		ChatPackets::SendSystemMessage(sysAddr, u"Brutally murdering that player, if online on this server.");
 
@@ -240,7 +240,7 @@ namespace DEVGMCommands {
 
 	void SpeedBoost(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		const auto boostOptional = GeneralUtils::TryParse<float>(splitArgs[0]);
 		if (!boostOptional) {
@@ -283,7 +283,7 @@ namespace DEVGMCommands {
 
 	void SetControlScheme(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		const auto scheme = GeneralUtils::TryParse<uint32_t>(splitArgs[0]);
 
@@ -299,7 +299,7 @@ namespace DEVGMCommands {
 
 	void SetUiState(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		AMFArrayValue uiState;
 
@@ -312,7 +312,7 @@ namespace DEVGMCommands {
 
 	void Toggle(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		AMFArrayValue amfArgs;
 
@@ -325,7 +325,7 @@ namespace DEVGMCommands {
 
 	void SetInventorySize(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		const auto sizeOptional = GeneralUtils::TryParse<uint32_t>(splitArgs[0]);
 		if (!sizeOptional) {
@@ -366,7 +366,7 @@ namespace DEVGMCommands {
 
 	void RunMacro(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		// Only process if input does not contain separator charaters
 		if (splitArgs[0].find("/") != std::string::npos) return;
@@ -394,7 +394,7 @@ namespace DEVGMCommands {
 
 	void AddMission(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		const auto missionID = GeneralUtils::TryParse<uint32_t>(splitArgs.at(0));
 
@@ -409,7 +409,7 @@ namespace DEVGMCommands {
 
 	void CompleteMission(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		const auto missionID = GeneralUtils::TryParse<uint32_t>(splitArgs.at(0));
 
@@ -452,7 +452,7 @@ namespace DEVGMCommands {
 
 	void ClearFlag(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		const auto flagId = GeneralUtils::TryParse<int32_t>(splitArgs.at(0));
 
@@ -478,7 +478,7 @@ namespace DEVGMCommands {
 
 	void StopEffect(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		GameMessages::SendStopFXEffect(entity, true, splitArgs[0]);
 	}
@@ -686,7 +686,7 @@ namespace DEVGMCommands {
 
 	void StartCelebration(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		const auto celebration = GeneralUtils::TryParse<int32_t>(splitArgs.at(0));
 
@@ -739,8 +739,16 @@ namespace DEVGMCommands {
 	}
 
 	void Spawn(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		// Takes arguments:
+		// Spawn(LOT)
+		// Spawn(LOT, groupName)
+		// Spawn(LOT, x, y, z)
+		// Spawn(LOT, x, y, z, groupName)
+		// Spawn(LOT, x, y, z, rotw, rotx, roty, rotz)
+		// Spawn(LOT, x, y, z, rotw, rotx, roty, rotz, groupName)
+		if (args == "") return ChatPackets::SendSystemMessage(sysAddr, u"No lot provided.");
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		const auto argCount = splitArgs.size();
 
 		ControllablePhysicsComponent* comp = static_cast<ControllablePhysicsComponent*>(entity->GetComponent(eReplicaComponentType::CONTROLLABLE_PHYSICS));
 		if (!comp) return;
@@ -748,14 +756,84 @@ namespace DEVGMCommands {
 		const auto lot = GeneralUtils::TryParse<uint32_t>(splitArgs[0]);
 
 		if (!lot) {
-			ChatPackets::SendSystemMessage(sysAddr, u"Invalid lot.");
+			ChatPackets::SendSystemMessage(sysAddr, u"Failed to parse lot.");
 			return;
+		}
+
+		std::string groupName = "";
+		if (argCount == 2) {
+			groupName = splitArgs[1];
+		} else if (argCount == 5) {
+			groupName = splitArgs[4];
+		} else if (argCount == 9) {
+			groupName = splitArgs[8];
+		}
+
+		NiPoint3 pos{};
+		if (argCount >= 4) {
+			const auto x = GeneralUtils::TryParse<float>(splitArgs[1]);
+			if (!x) {
+				ChatPackets::SendSystemMessage(sysAddr, u"Failed to parse x position.");
+				return;
+			}
+
+			const auto y = GeneralUtils::TryParse<float>(splitArgs[2]);
+			if (!y) {
+				ChatPackets::SendSystemMessage(sysAddr, u"Failed to parse y position.");
+				return;
+			}
+
+			const auto z = GeneralUtils::TryParse<float>(splitArgs[3]);
+			if (!z) {
+				ChatPackets::SendSystemMessage(sysAddr, u"Failed to parse z position.");
+				return;
+			}
+
+			pos.SetX(x.value());
+			pos.SetY(y.value());
+			pos.SetZ(z.value());
+		} else {
+			pos = comp->GetPosition();
+		}
+
+		NiQuaternion rot{};
+		if (argCount >= 8) {
+			const auto w = GeneralUtils::TryParse<float>(splitArgs[4]);
+			if (!w) {
+				ChatPackets::SendSystemMessage(sysAddr, u"Failed to parse w component of rotation quaternion.");
+				return;
+			}
+
+			const auto x = GeneralUtils::TryParse<float>(splitArgs[5]);
+			if (!x) {
+				ChatPackets::SendSystemMessage(sysAddr, u"Failed to parse x component of rotation quaternion.");
+				return;
+			}
+
+			const auto y = GeneralUtils::TryParse<float>(splitArgs[6]);
+			if (!y) {
+				ChatPackets::SendSystemMessage(sysAddr, u"Failed to parse y component of rotation quaternion.");
+				return;
+			}
+
+			const auto z = GeneralUtils::TryParse<float>(splitArgs[7]);
+			if (!z) {
+				ChatPackets::SendSystemMessage(sysAddr, u"Failed to parse z component of rotation quaternion.");
+				return;
+			}
+
+			rot.SetW(w.value());
+			rot.SetX(x.value());
+			rot.SetY(y.value());
+			rot.SetZ(z.value());
+		} else {
+			rot = comp->GetRotation();
 		}
 
 		EntityInfo info;
 		info.lot = lot.value();
-		info.pos = comp->GetPosition();
-		info.rot = comp->GetRotation();
+		info.pos = pos;
+		info.rot = rot;
 		info.spawner = nullptr;
 		info.spawnerID = entity->GetObjectID();
 		info.spawnerNodeID = 0;
@@ -767,7 +845,304 @@ namespace DEVGMCommands {
 			return;
 		}
 
+		newEntity->AddToGroup(groupName);
+
 		Game::entityManager->ConstructEntity(newEntity);
+	}
+
+	void GetPlayerID(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+		auto targetPlayer = entity;
+		std::string targetName = "Your character";
+
+		if (args != "") {
+			targetName = splitArgs[0];
+			targetPlayer = PlayerManager::GetPlayer(targetName);
+		}
+
+		if (!targetPlayer) {
+			return ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16("Player not found."));
+		}
+
+		LWOOBJID objectID = targetPlayer->GetObjectID();
+
+		std::stringstream msg;
+		msg << targetName << " has object ID " << std::to_string(objectID) << ".";
+		ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16(msg.str()));
+	}
+
+	static void SendEntityList(const SystemAddress& sysAddr, std::vector<Entity*> entityList) {
+		for (auto* entity : entityList) {
+			std::stringstream entry;
+			entry << "[" << std::to_string(entity->GetObjectID()) << "], LOT " << std::to_string(entity->GetLOT());
+			const auto spawnerID = entity->GetSpawnerID();
+			const auto spawner = Game::entityManager->GetEntity(spawnerID);
+			if (spawner->IsPlayer()) {
+				entry << ", Spawned by " << spawner->GetCharacter()->GetName() << ".";
+			} else {
+				entry << ", SpawnerID " << std::to_string(spawnerID) << ".";
+			}
+			ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16(entry.str()));
+		}
+	}
+
+	static void DespawnEntityList(const SystemAddress& sysAddr, std::vector<Entity*> entityList) {
+		for (auto* entity : entityList) {
+			Game::entityManager->DestroyEntity(entity);
+		}
+	}
+
+	static void SaveEntityList(Entity* entity, const SystemAddress& sysAddr, std::vector<Entity*> entityList) {
+		IBugReports::Info reportInfo;
+		auto character = entity->GetCharacter();
+
+		if (entityList.empty()) return ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16("No spawns found."));
+
+		std::stringstream entityInfo;
+		for (auto* entity : entityList) {
+			LOT lot = entity->GetLOT();
+			const NiPoint3 entityPosition = entity->GetPosition();
+			const auto x = entityPosition.GetX();
+			const auto y = entityPosition.GetY();
+			const auto z = entityPosition.GetZ();
+			const NiQuaternion entityRotation = entity->GetRotation();
+			const auto rotw = entityRotation.GetW();
+			const auto rotx = entityRotation.GetX();
+			const auto roty = entityRotation.GetY();
+			const auto rotz = entityRotation.GetZ();
+
+			entityInfo << "/spawn " << std::to_string(lot) << " ";
+			entityInfo << std::to_string(x) << " " << std::to_string(y) << " " << std::to_string(z) << " ";
+			entityInfo << std::to_string(rotw) << " " << std::to_string(rotx) << " " << std::to_string(roty) << " " << std::to_string(rotz) << " ";
+			entityInfo << "groupName\n ";
+		}
+		reportInfo.body = entityInfo.str();
+		reportInfo.clientVersion = "N/A";
+		reportInfo.otherPlayer = "N/A";
+		reportInfo.selection = "Saved spawn command.";
+		if (character) reportInfo.characterId = character->GetID();
+
+		Database::Get()->InsertNewBugReport(reportInfo);
+
+		ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16("List saved to Bug Report table."));
+	}
+
+	void ListGroup(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+		if (args == "") return;
+
+		const std::string groupName = splitArgs[0];
+
+		const auto groupEntities = Game::entityManager->GetEntitiesInGroup(groupName);
+
+		std::stringstream header;
+		header << "Listing entities in group " << groupName << ":";
+		ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16(header.str()));
+
+		SendEntityList(sysAddr, groupEntities);
+	}
+
+	void DespawnGroup(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+		if (args == "") return;
+
+		const std::string groupName = splitArgs[0];
+
+		const auto groupEntities = Game::entityManager->GetEntitiesInGroup(groupName);
+
+		DespawnEntityList(sysAddr, groupEntities);
+	}
+
+	void SaveGroup(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+		if (args == "") return;
+
+		const std::string groupName = splitArgs[0];
+
+		const auto groupEntities = Game::entityManager->GetEntitiesInGroup(groupName);
+
+		SaveEntityList(entity, sysAddr, groupEntities);
+	}
+
+	static void SendEntitiesSpawnedByID(const SystemAddress& sysAddr, LWOOBJID& spawnerID) {
+		if (!Game::entityManager->GetEntity(spawnerID)) return;
+
+		const auto spawnedEntities = Game::entityManager->GetEntitiesBySpawnerID(spawnerID);
+
+		SendEntityList(sysAddr, spawnedEntities);
+	}
+
+	static void DespawnEntitiesSpawnedByID(const SystemAddress& sysAddr, LWOOBJID& spawnerID) {
+		if (!Game::entityManager->GetEntity(spawnerID)) return;
+
+		const auto spawnedEntities = Game::entityManager->GetEntitiesBySpawnerID(spawnerID);
+
+		DespawnEntityList(sysAddr, spawnedEntities);
+	}
+
+	static void SaveEntitiesSpawnedByID(Entity* entity, const SystemAddress& sysAddr, LWOOBJID& spawnerID) {
+		if (!Game::entityManager->GetEntity(spawnerID)) return;
+
+		const auto spawnedEntities = Game::entityManager->GetEntitiesBySpawnerID(spawnerID);
+
+		SaveEntityList(entity, sysAddr, spawnedEntities);
+	}
+
+	void ListSpawnedByPlayer(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+		auto* spawner = entity;
+
+		if (args != "") {
+			spawner = PlayerManager::GetPlayer(splitArgs[0]);
+		}
+		if (!spawner) {
+			return ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16("Player not found."));
+		}
+
+		auto spawnerID = spawner->GetObjectID();
+
+		SendEntitiesSpawnedByID(sysAddr, spawnerID);
+	}
+
+	void DespawnSpawnedByPlayer(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+		auto* spawner = entity;
+
+		if (args != "") {
+			spawner = PlayerManager::GetPlayer(splitArgs[0]);
+		}
+		if (!spawner) {
+			return ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16("Player not found."));
+		}
+
+		auto spawnerID = spawner->GetObjectID();
+
+		DespawnEntitiesSpawnedByID(sysAddr, spawnerID);
+	}
+
+	void SaveSpawnedByPlayer(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+		auto* spawner = entity;
+
+		if (args != "") {
+			spawner = PlayerManager::GetPlayer(splitArgs[0]);
+		}
+		if (!spawner) {
+			return ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16("Player not found."));
+		}
+
+		auto spawnerID = spawner->GetObjectID();
+
+		SaveEntitiesSpawnedByID(entity, sysAddr, spawnerID);
+	}
+
+	void ListSpawnedBySender(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+
+		auto spawnerID = entity->GetObjectID();
+
+		SendEntitiesSpawnedByID(sysAddr, spawnerID);
+	}
+
+	void DespawnSpawnedBySender(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+
+		auto spawnerID = entity->GetObjectID();
+
+		DespawnEntitiesSpawnedByID(sysAddr, spawnerID);
+	}
+
+	void SaveSpawnedBySender(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+
+		auto spawnerID = entity->GetObjectID();
+
+		SaveEntitiesSpawnedByID(entity, sysAddr, spawnerID);
+	}
+
+	void ListSpawnedBySpawnerID(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+
+		auto spawnerID = GeneralUtils::TryParse<LWOOBJID>(splitArgs[0]);
+
+		if (!spawnerID) {
+			ChatPackets::SendSystemMessage(sysAddr, u"Invalid object ID.");
+			return;
+		}
+
+		SendEntitiesSpawnedByID(sysAddr, spawnerID.value());
+	}
+
+	void DespawnSpawnedBySpawnerID(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+
+		auto spawnerID = GeneralUtils::TryParse<LWOOBJID>(splitArgs[0]);
+
+		if (!spawnerID) {
+			ChatPackets::SendSystemMessage(sysAddr, u"Invalid object ID.");
+			return;
+		}
+
+		DespawnEntitiesSpawnedByID(sysAddr, spawnerID.value());
+	}
+
+	void SaveSpawnedBySpawnerID(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+
+		auto spawnerID = GeneralUtils::TryParse<LWOOBJID>(splitArgs[0]);
+
+		if (!spawnerID) {
+			ChatPackets::SendSystemMessage(sysAddr, u"Invalid object ID.");
+			return;
+		}
+
+		SaveEntitiesSpawnedByID(entity, sysAddr, spawnerID.value());
+	}
+
+	void ListAllPlayerSpawns(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		for (auto* player : PlayerManager::GetAllPlayers()) {
+			auto spawnerID = player->GetObjectID();
+			SendEntitiesSpawnedByID(sysAddr, spawnerID);
+		}
+	}
+
+	void DespawnAllPlayerSpawns(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		for (auto* player : PlayerManager::GetAllPlayers()) {
+			auto spawnerID = player->GetObjectID();
+			DespawnEntitiesSpawnedByID(sysAddr, spawnerID);
+		}
+	}
+
+	void SaveAllPlayerSpawns(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		// This one requires a custom implementation to put everything into a single list.
+		std::vector<Entity*> fullEntityList;
+		for (auto* player : PlayerManager::GetAllPlayers()) {
+			auto spawnerID = player->GetObjectID();
+			std::vector<Entity*> entityList = Game::entityManager->GetEntitiesBySpawnerID(spawnerID);
+			fullEntityList.insert(fullEntityList.end(), entityList.begin(), entityList.end());
+		}
+		SaveEntityList(entity, sysAddr, fullEntityList);
+	}
+
+	void Despawn(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+		if (args == "") return;
+
+		auto objectId = GeneralUtils::TryParse<LWOOBJID>(splitArgs[0]);
+
+		if (!objectId) {
+			ChatPackets::SendSystemMessage(sysAddr, u"Invalid object ID.");
+			return;
+		}
+
+		Entity* targetEntity = Game::entityManager->GetEntity(objectId.value());
+
+		if (targetEntity == nullptr) {
+			ChatPackets::SendSystemMessage(sysAddr, u"Object ID not found.");
+			return;
+		}
+
+		Game::entityManager->DestroyEntity(targetEntity);
 	}
 
 	void SpawnGroup(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
@@ -824,7 +1199,7 @@ namespace DEVGMCommands {
 
 	void GiveUScore(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		const auto uscoreOptional = GeneralUtils::TryParse<int32_t>(splitArgs[0]);
 		if (!uscoreOptional) {
@@ -849,7 +1224,7 @@ namespace DEVGMCommands {
 
 	void SetLevel(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		// We may be trying to set a specific players level to a level.  If so override the entity with the requested players.
 		std::string requestedPlayerToSetLevelOf = "";
@@ -951,7 +1326,7 @@ namespace DEVGMCommands {
 
 	void FreeMoney(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		const auto money = GeneralUtils::TryParse<int64_t>(splitArgs[0]);
 
@@ -966,7 +1341,7 @@ namespace DEVGMCommands {
 
 	void SetCurrency(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		const auto money = GeneralUtils::TryParse<int64_t>(splitArgs[0]);
 
@@ -1002,7 +1377,7 @@ namespace DEVGMCommands {
 
 	void TestMap(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		ChatPackets::SendSystemMessage(sysAddr, u"Requesting map change...");
 		LWOCLONEID cloneId = 0;
@@ -1143,7 +1518,7 @@ namespace DEVGMCommands {
 
 	void ActivateSpawner(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		auto spawners = Game::zoneManager->GetSpawnersByName(splitArgs[0]);
 
@@ -1191,7 +1566,7 @@ namespace DEVGMCommands {
 
 	void TriggerSpawner(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		auto spawners = Game::zoneManager->GetSpawnersByName(splitArgs[0]);
 
@@ -1326,7 +1701,7 @@ namespace DEVGMCommands {
 
 	void DeleteInven(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		eInventoryType inventoryType = eInventoryType::INVALID;
 
@@ -1360,7 +1735,7 @@ namespace DEVGMCommands {
 
 	void CastSkill(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		auto* skillComponent = entity->GetComponent<SkillComponent>();
 		if (skillComponent) {
@@ -1401,7 +1776,7 @@ namespace DEVGMCommands {
 
 	void SetFaction(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		auto* destroyableComponent = entity->GetComponent<DestroyableComponent>();
 		if (destroyableComponent) {
@@ -1419,7 +1794,7 @@ namespace DEVGMCommands {
 
 	void AddFaction(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		auto* destroyableComponent = entity->GetComponent<DestroyableComponent>();
 		if (destroyableComponent) {
@@ -1455,37 +1830,20 @@ namespace DEVGMCommands {
 		if (!character) return;
 		auto* user = character->GetParentUser();
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 		auto* cdrewardCodes = CDClientManager::GetTable<CDRewardCodesTable>();
 
 		auto id = cdrewardCodes->GetCodeID(splitArgs[0]);
 		if (id != -1) Database::Get()->InsertRewardCode(user->GetAccountID(), id);
 	}
 
-	void Inspect(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
-		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
-
+	static std::tuple<Entity*, float> ClosestToEntity(const NiPoint3 reference, const eReplicaComponentType component,
+											   const std::u16string ldf, const bool isLDF) {
 		Entity* closest = nullptr;
-
-		std::u16string ldf;
-
-		bool isLDF = false;
-
-		auto component = GeneralUtils::TryParse<eReplicaComponentType>(splitArgs[0]);
-		if (!component) {
-			component = eReplicaComponentType::INVALID;
-
-			ldf = GeneralUtils::UTF8ToUTF16(splitArgs[0]);
-
-			isLDF = true;
-		}
-
-		auto reference = entity->GetPosition();
 
 		auto closestDistance = 0.0f;
 
-		const auto candidates = Game::entityManager->GetEntitiesByComponent(component.value());
+		const auto candidates = Game::entityManager->GetEntitiesByComponent(component);
 
 		for (auto* candidate : candidates) {
 			if (candidate->GetLOT() == 1 || candidate->GetLOT() == 8092) {
@@ -1512,6 +1870,61 @@ namespace DEVGMCommands {
 				closestDistance = distance;
 			}
 		}
+		return {closest, closestDistance};
+	}
+
+	void InspectDespawn(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+		if (args == "") return;
+
+		ControllablePhysicsComponent* comp = static_cast<ControllablePhysicsComponent*>(entity->GetComponent(eReplicaComponentType::CONTROLLABLE_PHYSICS));
+		if (!comp) return;
+
+		std::u16string ldf;
+
+		bool isLDF = false;
+
+		auto component = GeneralUtils::TryParse<eReplicaComponentType>(splitArgs[0]);
+		if (!component) {
+			component = eReplicaComponentType::INVALID;
+
+			ldf = GeneralUtils::UTF8ToUTF16(splitArgs[0]);
+
+			isLDF = true;
+		}
+
+		auto reference = entity->GetPosition();
+
+		auto [closest, closestDistance] = ClosestToEntity(reference, component.value(), ldf, isLDF);
+
+		if (!closest) {
+			ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16("No entities found with that component."));
+			return;
+		}
+
+		Game::entityManager->DestroyEntity(closest);
+	}
+
+	void Inspect(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
+		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
+		if (args == "") return;
+
+		std::u16string ldf;
+
+		bool isLDF = false;
+
+		auto component = GeneralUtils::TryParse<eReplicaComponentType>(splitArgs[0]);
+		if (!component) {
+			component = eReplicaComponentType::INVALID;
+
+			ldf = GeneralUtils::UTF8ToUTF16(splitArgs[0]);
+
+			isLDF = true;
+		}
+
+		auto reference = entity->GetPosition();
+
+		auto [closest, closestDistance] = ClosestToEntity(reference, component.value(), ldf, isLDF);
 
 		if (!closest) return;
 
@@ -1526,6 +1939,12 @@ namespace DEVGMCommands {
 		header << info.name << " [" << std::to_string(info.id) << "]" << " " << std::to_string(closestDistance) << " " << std::to_string(closest->IsSleeping());
 
 		ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16(header.str()));
+
+		std::stringstream idMessage;
+
+		idMessage << "Object ID: " << std::to_string(closest->GetObjectID());
+
+		ChatPackets::SendSystemMessage(sysAddr, GeneralUtils::ASCIIToUTF16(idMessage.str()));
 
 		for (const auto& pair : closest->GetComponents()) {
 			auto id = pair.first;

--- a/dGame/dUtilities/SlashCommands/DEVGMCommands.h
+++ b/dGame/dUtilities/SlashCommands/DEVGMCommands.h
@@ -27,15 +27,18 @@ namespace DEVGMCommands {
 	void CompleteMission(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void CreatePrivate(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void DebugUi(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void Despawn(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void Dismount(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void ReloadConfig(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void ForceSave(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void Freecam(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void FreeMoney(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void GetNavmeshHeight(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void GetPlayerID(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void GiveUScore(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void GmAddItem(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void Inspect(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void InspectDespawn(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void ListSpawns(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void LocRow(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void Lookup(Entity* entity, const SystemAddress& sysAddr, const std::string args);
@@ -74,6 +77,22 @@ namespace DEVGMCommands {
 	void CastSkill(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void DeleteInven(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 	void Shutdown(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+
+	void DespawnGroup(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void DespawnSpawnedByPlayer(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void DespawnSpawnedBySender(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void DespawnSpawnedBySpawnerID(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void DespawnAllPlayerSpawns(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void ListGroup(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void ListSpawnedByPlayer(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void ListSpawnedBySender(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void ListSpawnedBySpawnerID(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void ListAllPlayerSpawns(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void SaveGroup(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void SaveSpawnedByPlayer(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void SaveSpawnedBySender(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void SaveSpawnedBySpawnerID(Entity* entity, const SystemAddress& sysAddr, const std::string args);
+	void SaveAllPlayerSpawns(Entity* entity, const SystemAddress& sysAddr, const std::string args);
 }
 
 #endif  //!DEVGMCOMMANDS_H

--- a/dGame/dUtilities/SlashCommands/GMGreaterThanZeroCommands.cpp
+++ b/dGame/dUtilities/SlashCommands/GMGreaterThanZeroCommands.cpp
@@ -228,7 +228,7 @@ namespace GMGreaterThanZeroCommands {
 					if (tempScaleStore) {
 						speedScale = tempScaleStore.value();
 					} else {
-						ChatPackets::SendSystemMessage(sysAddr, u"Failed to parse speed scale argument.");
+						if (splitArgs.at(0) != "") ChatPackets::SendSystemMessage(sysAddr, u"Failed to parse speed scale argument.");
 					}
 				}
 
@@ -245,7 +245,7 @@ namespace GMGreaterThanZeroCommands {
 
 	void AttackImmune(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		auto* destroyableComponent = entity->GetComponent<DestroyableComponent>();
 
@@ -261,7 +261,7 @@ namespace GMGreaterThanZeroCommands {
 
 	void GmImmune(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		const auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		auto* destroyableComponent = entity->GetComponent<DestroyableComponent>();
 

--- a/dGame/dUtilities/SlashCommands/GMZeroCommands.cpp
+++ b/dGame/dUtilities/SlashCommands/GMZeroCommands.cpp
@@ -185,7 +185,7 @@ namespace GMZeroCommands {
 
 	void Join(Entity* entity, const SystemAddress& sysAddr, const std::string args) {
 		auto splitArgs = GeneralUtils::SplitString(args, ' ');
-		if (splitArgs.empty()) return;
+		if (args == "") return;
 
 		ChatPackets::SendSystemMessage(sysAddr, u"Requesting private map...");
 		const auto& password = splitArgs[0];

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -72,6 +72,12 @@ These commands are primarily for development and testing. The usage of many of t
 |completemission|`/completemission <mission id>`|Completes the mission, removing it from your journal.|8|
 |createprivate|`/createprivate <zone id> <clone id> <password>`|Creates a private zone with password.|8|
 |debugui|`/debugui`|Toggle Debug UI.|8|
+|despawn|`/despawn <object id>`|Despawns an object based on its object id, such as that found by `/inspect`.|8|
+|despawn-group|`/despawn-group <groupname>`|Despawns all entities in a given group. Group name should not contain spaces. Alias: `/despawngroup`.|8|
+|despawn-player-spawns|`/despawn-player-spawns <player name>`|Despawns all entities spawned by a given player. Alias: `/despawnplayerspawns`.|8|
+|despawn-my-spawns|`/despawn-my-spawns`|Despawns all entities spawned by you. Aliases: `/despawnmyspawns`.|8|
+|despawn-by-spawner-id|`/despawn-by-spawner-id <spawner id>`|Despawns all entities with a given spawner id. Alias: `/despawnbyspawnerid`.|8|
+|despawn-all-player-spawns|`/despawn-all-player-spawns`|Despawns all entities spawned by online players. Alias: `/despawnallplayerspawns`.|8|
 |dismount|`/dismount`|Dismounts you from the vehicle or mount.|8|
 |reloadconfig|`/reloadconfig`|Reloads the server with the new config values.|8|
 |force-save|`/force-save`|While saving to database usually happens on regular intervals and when you disconnect from the server, this command saves your player's data to the database.|8|
@@ -81,11 +87,18 @@ These commands are primarily for development and testing. The usage of many of t
 |giveuscore|`/giveuscore <uscore>`|Gives uscore.|8|
 |gmadditem|`/gmadditem <id> (count)`|Adds the given item to your inventory by id.|8|
 |inspect|`/inspect <component> (-m <waypoint> \| -a <animation> \| -s \| -p \| -f (faction) \| -t)`|Finds the closest entity with the given component or LDF variable (ignoring players and racing cars), printing its ID, distance from the player, and whether it is sleeping, as well as the the IDs of all components the entity has. See [Detailed `/inspect` Usage](#detailed-inspect-usage) below.|8|
+|inspect-despawn|`/inspect-despawn <component>`|Finds the closest entity with the given component or LDF variable (ignoring players and racing cars) and despawns it. Alias: `/inspect-destroy`|8|
 |list-spawns|`/list-spawns`|Lists all the character spawn points in the zone. Additionally, this command will display the current scene that plays when the character lands in the next zone, if there is one.|8|
+|list-group|`/list-group <groupname>`|Lists all entities in a given group. Group name should not contain spaces. Alias: `/listgroup`.|8|
+|list-spawned-by-player|`/list-spawned-by-player <player name>`|Lists all entities spawned by a given player. Alias: `/listspawnedbyplayer`.|8|
+|list-my-spawns|`/list-my-spawns`|Lists all entities spawned by you. Aliases: `/listmyspawns`, `/my-spawns`, `/myspawns`.|8|
+|list-spawned-by-id|`/list-spawned-by-id <spawner id>`|Lists all entities with a given spawner id. Alias: `/listspawnedbyid`.|8|
+|list-all-player-spawns|`/list-all-player-spawns`|Lists all entities spawned by online players. Alias: `/listallplayerspawns`.|8|
 |locrow|`/locrow`|Prints the your current position and rotation information to the console.|8|
 |lookup|`/lookup <query>`|Searches through the Objects table in the client SQLite database for items whose display name, name, or description contains the query.  Query can be multiple words delimited by spaces.|8|
 |playanimation|`/playanimation <id>`|Plays animation with given ID. Alias: `/playanim`.|8|
 |playeffect|`/playeffect <effect id> <effect type> <effect name>`|Plays an effect.|8|
+|playerid|`/playerid (player name)`|Gets your player's object id, or that of another character by name, if provided. Alias: `/getplayerid`.|8|
 |playlvlfx|`/playlvlfx`|Plays the level up animation on your character.|8|
 |playrebuildfx|`/playrebuildfx`|Plays the quickbuild animation on your character.|8|
 |pos|`/pos`|Displays your current position in chat and in the console.|8|
@@ -94,12 +107,17 @@ These commands are primarily for development and testing. The usage of many of t
 |resetmission|`/resetmission <mission id>`|Sets the state of the mission to accepted but not yet started.|8|
 |rot|`/rot`|Displays your current rotation in chat and in the console.|8|
 |runmacro|`/runmacro <macro>`|Runs any command macro found in `./res/macros/`|8|
+|save-group|`/save-group <groupname>`|Saves all entities in a given group. Group name should not contain spaces. Alias: `/savegroup`.|8|
+|save-player-spawns|`/save-player-spawns <player name>`|Saves all entities spawned by a given player. Alias: `/saveplayerspawns`.|8|
+|save-my-spawns|`/save-my-spawns`|Saves all entities spawned by you. Aliases: `/savemyspawns`.|8|
+|save-by-spawner-id|`/save-by-spawner-id <spawner id>`|Saves all entities with a given spawner id. Alias: `/savebyspawnerid`.|8|
+|save-all-player-spawns|`/save-all-player-spawns`|Saves all entities spawned by online players. Alias: `/saveallplayerspawns`.|8|
 |setcontrolscheme|`/setcontrolscheme <scheme number>`|Sets the character control scheme to the specified number.|8|
 |setcurrency|`/setcurrency <coins>`|Sets your coins.|8|
 |setflag|`/setflag (value) <flag id>`|Sets the given inventory or health flag to the given value, where value can be one of "on" or "off". If no value is given, by default this adds the flag to your character (equivalent of calling `/setflag on <flag id>`).|8|
 |setinventorysize|`/setinventorysize <size> (inventory)` or <br> `/setinvsize <size> (inventory)`|Sets your inventory size to the given size. If `inventory` is provided, the number or string will be used to set that inventory to the requested size. Alias: `/setinvsize`|8|
 |setuistate|`/setuistate <ui state>`|Changes UI state.|8|
-|spawn|`/spawn <id>`|Spawns an object at your location by id.|8|
+|spawn|`/spawn <id> (<x> <y> <z> (<rotw> <rotx> <roty> <rotz>)) (<groupname>)`|Spawns an object by id, defaulting to your position and rotation, or with a manual position, or manual position and rotation, provided. Additionally, a group name can be provided, to make working with large groups of spawns easier. Note, groupname should not include spaces.|8|
 |spawngroup|`/spawngroup <id> <amount> <radius>`|Spawns `<amount>` of object `<id>` within the given `<radius>` from your location|8|
 |speedboost|`/speedboost <amount>`|Sets the speed multiplier to the given amount. `/speedboost 1.5` will set the speed multiplier to 1.5x the normal speed.|8|
 |startcelebration|`/startcelebration <id>`|Starts a celebration effect on your character.|8|


### PR DESCRIPTION
Added commands to print to chat, despawn, and save to a bug reports entry, lists of entities, based on entity groups, or who/what spawned them.

Added a command to despawn an object by object id, and one to despawn based on the 'nearest to player' check done by the inspect command.

Added a command to print a player's object id to chat.

Also replaced (splitArgs.empty()) checks with (args == ""), because the argument parser never returns an empty vector, only a vector containing an empty string.

Updated Commands.md to reflect the added commands.