### PR TITLE
fix: property behavior crashes

### DIFF
--- a/dCommon/DluAssert.h
+++ b/dCommon/DluAssert.h
@@ -4,7 +4,7 @@
 #include <assert.h>
 
 #ifdef _DEBUG
-#	define DluAssert(expression) do { assert(expression) } while(0)
+#	define DluAssert(expression) do { assert(expression); } while(0)
 #else
 #	define DluAssert(expression)
 #endif

--- a/dGame/dPropertyBehaviors/Strip.cpp
+++ b/dGame/dPropertyBehaviors/Strip.cpp
@@ -84,9 +84,11 @@ void Strip::HandleMsg(MigrateActionsMessage& msg) {
 
 template<>
 void Strip::HandleMsg(GameMessages::RequestUse& msg) {
-	if (m_PausedTime > 0.0f) return;
+	if (m_PausedTime > 0.0f || !HasMinimumActions()) return;
 
-	if (m_Actions[m_NextActionIndex].GetType() == "OnInteract") {
+	auto& nextAction = GetNextAction();
+
+	if (nextAction.GetType() == "OnInteract") {
 		IncrementAction();
 		m_WaitingForAction = false;
 	}
@@ -168,7 +170,6 @@ void Strip::ProcNormalAction(float deltaTime, ModelComponent& modelComponent) {
 			LOG("Tried to play action (%s) which is not supported.", nextActionType.data());
 			g_WarnedActions.insert(nextActionType.data());
 		}
-		return;
 	}
 
 	IncrementAction();
@@ -188,11 +189,17 @@ void Strip::RemoveStates(ModelComponent& modelComponent) const {
 }
 
 void Strip::Update(float deltaTime, ModelComponent& modelComponent) {
+	// No point in running a strip with only one action.
+	// Strips are also designed to have 2 actions or more to run.
+	if (!HasMinimumActions()) return;
+
+	// Don't run this strip if we're paused.
 	m_PausedTime -= deltaTime;
 	if (m_PausedTime > 0.0f) return;
 
 	m_PausedTime = 0.0f;
 
+	// Return here if we're waiting for external interactions to continue.
 	if (m_WaitingForAction) return;
 
 	auto& entity = *modelComponent.GetParent();

--- a/dGame/dPropertyBehaviors/Strip.h
+++ b/dGame/dPropertyBehaviors/Strip.h
@@ -33,6 +33,9 @@ public:
 	void SpawnDrop(LOT dropLOT, Entity& entity);
 	void ProcNormalAction(float deltaTime, ModelComponent& modelComponent);
 	void RemoveStates(ModelComponent& modelComponent) const;
+
+	// 2 actions are required for strips to work
+	bool HasMinimumActions() const { return m_Actions.size() >= 2; }
 private:
 	// Indicates this Strip is waiting for an action to be taken upon it to progress to its actions
 	bool m_WaitingForAction{ false };

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -713,12 +713,12 @@ void HandleMasterPacket(Packet* packet) {
 			//Create our user and send them in:
 			UserManager::Instance()->CreateUser(it->second.sysAddr, username.GetAsString(), userHash);
 
-			auto zone = Game::zoneManager->GetZone();
-			if (zone) {
+			if (Game::zoneManager->HasZone()) {
 				float x = 0.0f;
 				float y = 0.0f;
 				float z = 0.0f;
 
+				auto zone = Game::zoneManager->GetZone();
 				if (zone->GetZoneID().GetMapID() == 1100) {
 					auto pos = zone->GetSpawnPos();
 					x = pos.x;

--- a/dZoneManager/dZoneManager.h
+++ b/dZoneManager/dZoneManager.h
@@ -29,6 +29,7 @@ public:
 	/* Gets a pointer to the currently loaded zone. */
 	Zone* GetZoneMut() const;
 	const Zone* GetZone() const { return GetZoneMut(); };
+	bool HasZone() const { return m_pZone != nullptr; };
 	void LoadZone(const LWOZONEID& zoneID); //Discard the current zone (if any) and loads a new zone.
 
 	/* Adds a spawner to the zone with the specified ID. */


### PR DESCRIPTION
Tested that behaviors with 1 start node and nothing else no longer crash
Tested that behaviors with 1 starting node and an unimplemented behavior no longer crash
Tested that placing 2 strips of actions followed by merging the first placed strip into the second no longer crashes