### PR TITLE
fix: Add null check for character

### DIFF
--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -5207,7 +5207,7 @@ void GameMessages::HandlePickupCurrency(RakNet::BitStream& inStream, Entity* ent
 	if (currency == 0) return;
 
 	auto* ch = entity->GetCharacter();
-	if (entity->CanPickupCoins(currency)) {
+	if (ch && entity->CanPickupCoins(currency)) {
 		ch->SetCoins(ch->GetCoins() + currency, eLootSourceType::PICKUP);
 	}
 }


### PR DESCRIPTION
apparently if you switch characters while picking up currency itll crash lol.  check the ptr.