### PR TITLE
fix: large inventories and inspect not printing objectID

### DIFF
--- a/dGame/dGameMessages/GameMessageHandler.cpp
+++ b/dGame/dGameMessages/GameMessageHandler.cpp
@@ -158,6 +158,10 @@ void GameMessageHandler::HandleMessage(RakNet::BitStream& inStream, const System
 
 				inv->AddItemSkills(item.lot);
 			}
+
+			// Fixes a bug where testmapping too fast causes large item inventories to become invisible.
+			// Only affects item inventory
+			GameMessages::SendSetInventorySize(entity, eInventoryType::ITEMS, inv->GetInventory(eInventoryType::ITEMS)->GetSize());
 		}
 
 		GameMessages::SendRestoreToPostLoadStats(entity, sysAddr);

--- a/dGame/dUtilities/SlashCommands/DEVGMCommands.cpp
+++ b/dGame/dUtilities/SlashCommands/DEVGMCommands.cpp
@@ -1514,6 +1514,7 @@ namespace DEVGMCommands {
 		}
 
 		if (!closest) return;
+		LOG("%llu", closest->GetObjectID());
 
 		Game::entityManager->SerializeEntity(closest);
 


### PR DESCRIPTION
Tested that inspect now logs the object ID and that large inventories no longer have the chance of showing up with less items then there are.