### PR TITLE
fix: don't construct zone control twice on player loadin

### DIFF
--- a/dGame/EntityManager.cpp
+++ b/dGame/EntityManager.cpp
@@ -394,7 +394,7 @@ void EntityManager::ConstructAllEntities(const SystemAddress& sysAddr) {
 		}
 	}
 
-	UpdateGhosting(PlayerManager::GetPlayer(sysAddr));
+	UpdateGhosting(PlayerManager::GetPlayer(sysAddr), true);
 }
 
 void EntityManager::DestructEntity(Entity* entity, const SystemAddress& sysAddr) {
@@ -417,7 +417,7 @@ void EntityManager::DestructEntity(Entity* entity, const SystemAddress& sysAddr)
 
 void EntityManager::SerializeEntity(Entity* entity) {
 	if (!entity) return;
-	
+
 	EntityManager::SerializeEntity(*entity);
 }
 
@@ -463,7 +463,7 @@ void EntityManager::UpdateGhosting() {
 	m_PlayersToUpdateGhosting.clear();
 }
 
-void EntityManager::UpdateGhosting(Entity* player) {
+void EntityManager::UpdateGhosting(Entity* player, const bool constructAll) {
 	if (!player) return;
 
 	auto* missionComponent = player->GetComponent<MissionComponent>();
@@ -511,9 +511,12 @@ void EntityManager::UpdateGhosting(Entity* player) {
 
 			ghostComponent->ObserveEntity(id);
 
-			ConstructEntity(entity, player->GetSystemAddress());
-
 			entity->SetObservers(entity->GetObservers() + 1);
+
+			// TODO: figure out if zone control should be ghosted at all
+			if (constructAll && entity->GetObjectID() == GetZoneControlEntity()->GetObjectID()) continue;
+
+			ConstructEntity(entity, player->GetSystemAddress());
 		}
 	}
 }

--- a/dGame/EntityManager.h
+++ b/dGame/EntityManager.h
@@ -9,7 +9,7 @@
 #include "dCommonVars.h"
 
 class Entity;
-class EntityInfo;
+struct EntityInfo;
 class Player;
 class User;
 enum class eReplicaComponentType : uint32_t;
@@ -54,7 +54,7 @@ public:
 	void SetGhostDistanceMin(float value);
 	void QueueGhostUpdate(LWOOBJID playerID);
 	void UpdateGhosting();
-	void UpdateGhosting(Entity* player);
+	void UpdateGhosting(Entity* player, const bool constructAll = false);
 	void CheckGhosting(Entity* entity);
 	Entity* GetGhostCandidate(LWOOBJID id) const;
 	bool GetGhostingEnabled() const;


### PR DESCRIPTION
checked that the logs no longer have an error about zone control mismatched pointers

not sure yet if we should be ghosting zone control at all in the first place