### PR TITLE
feat: Add Restart Behavior

### DIFF
--- a/dGame/dComponents/ModelComponent.cpp
+++ b/dGame/dComponents/ModelComponent.cpp
@@ -63,6 +63,12 @@ void ModelComponent::Update(float deltaTime) {
 	for (auto& behavior : m_Behaviors) {
 		behavior.Update(deltaTime, *this);
 	}
+
+	if (!m_RestartAtEndOfFrame) return;
+
+	GameMessages::ResetModelToDefaults reset{};
+	OnResetModelToDefaults(reset);
+	m_RestartAtEndOfFrame = false;
 }
 
 void ModelComponent::LoadBehaviors() {

--- a/dGame/dComponents/ModelComponent.h
+++ b/dGame/dComponents/ModelComponent.h
@@ -146,7 +146,11 @@ public:
 
 	void OnChatMessageReceived(const std::string& sMessage);
 
+	// Sets the speed of the model
 	void SetSpeed(const float newSpeed) { m_Speed = newSpeed; }
+
+	// Whether or not to restart at the end of the frame
+	void RestartAtEndOfFrame() { m_RestartAtEndOfFrame = true; }
 private:
 
 	// Loads a behavior from the database.
@@ -190,4 +194,7 @@ private:
 
 	// The speed at which this model moves
 	float m_Speed{ 3.0f };
+
+	// Whether or not to restart at the end of the frame.
+	bool m_RestartAtEndOfFrame{ false };
 };

--- a/dGame/dPropertyBehaviors/Strip.cpp
+++ b/dGame/dPropertyBehaviors/Strip.cpp
@@ -221,6 +221,8 @@ void Strip::ProcNormalAction(float deltaTime, ModelComponent& modelComponent) {
 		sound.target = modelComponent.GetParent()->GetObjectID();
 		sound.soundID = numberAsInt;
 		sound.Send(UNASSIGNED_SYSTEM_ADDRESS);
+	} else if (nextActionType == "Restart") {
+		modelComponent.RestartAtEndOfFrame();
 	}
 	/* END Action */
 	/* BEGIN Gameplay */

--- a/dGame/dPropertyBehaviors/Strip.h
+++ b/dGame/dPropertyBehaviors/Strip.h
@@ -65,6 +65,8 @@ private:
 
 	// The position of the parent model on the previous frame
 	NiPoint3 m_PreviousFramePosition{};
+
+	NiPoint3 m_SavedVelocity{};
 };
 
 #endif  //!__STRIP__H__


### PR DESCRIPTION
Resets the model to the default state at the end of the models frame.  Will see if in the future designers want this to be more strict on the resetting timing.