### PR TITLE
feat: Add GetComponents(Mut) functions to Entity

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -1662,10 +1662,8 @@ void Entity::PickupItem(const LWOOBJID& objectID) const {
 			auto* const skillsTable = CDClientManager::GetTable<CDObjectSkillsTable>();
 			const auto skills = skillsTable->Query([&info](CDObjectSkills entry) {return (entry.objectTemplate == info.lot); });
 			for (const auto& skill : skills) {
-				auto* skillComponent = GetComponent<SkillComponent>();
+				const auto [skillComponent, missionComponent] = GetComponentsMut<SkillComponent, MissionComponent>();
 				if (skillComponent) skillComponent->CastSkill(skill.skillID, GetObjectID(), GetObjectID(), skill.castOnType, NiQuaternion(0, 0, 0, 0));
-
-				auto* missionComponent = GetComponent<MissionComponent>();
 
 				if (missionComponent != nullptr) {
 					missionComponent->Progress(eMissionTaskType::POWERUP, skill.skillID);

--- a/dGame/Entity.h
+++ b/dGame/Entity.h
@@ -2,6 +2,7 @@
 
 #include <map>
 #include <functional>
+#include <tuple>
 #include <typeinfo>
 #include <type_traits>
 #include <unordered_map>
@@ -160,6 +161,12 @@ public:
 
 	template<typename T>
 	T* GetComponent() const;
+
+	template<typename... T>
+	auto GetComponents() const;
+
+	template<typename... T>
+	auto GetComponentsMut() const;
 
 	template<typename T>
 	bool TryGetComponent(eReplicaComponentType componentId, T*& component) const;
@@ -578,4 +585,14 @@ inline ComponentType* Entity::AddComponent(VaArgs... args) {
 	// Because of the assert above, this should always be a ComponentType* but I need a way to guarantee the map cannot be modifed outside this function
 	// To allow a static cast here instead of a dynamic one.
 	return dynamic_cast<ComponentType*>(componentToReturn);
+}
+
+template<typename... T>
+auto Entity::GetComponents() const {
+	return GetComponentsMut<const T...>();
+}
+
+template<typename... T>
+auto Entity::GetComponentsMut() const {
+	return std::tuple{GetComponent<T>()...};
 }

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -6165,12 +6165,9 @@ void GameMessages::HandleRemoveDonationItem(RakNet::BitStream& inStream, Entity*
 }
 
 void GameMessages::HandleConfirmDonationOnPlayer(RakNet::BitStream& inStream, Entity* entity) {
-	auto* inventoryComponent = entity->GetComponent<InventoryComponent>();
-	if (!inventoryComponent) return;
-	auto* missionComponent = entity->GetComponent<MissionComponent>();
-	if (!missionComponent) return;
-	auto* characterComponent = entity->GetComponent<CharacterComponent>();
-	if (!characterComponent || !characterComponent->GetCurrentInteracting()) return;
+	const auto [inventoryComponent, missionComponent, characterComponent] = entity->GetComponentsMut<InventoryComponent, MissionComponent, CharacterComponent>();
+	if (!inventoryComponent || !missionComponent || !characterComponent || !characterComponent->GetCurrentInteracting()) return;
+
 	auto* donationEntity = Game::entityManager->GetEntity(characterComponent->GetCurrentInteracting());
 	if (!donationEntity) return;
 	auto* donationVendorComponent = donationEntity->GetComponent<DonationVendorComponent>();


### PR DESCRIPTION
Allows for a really neat way of getting components using structured binding.  Tested that powerups still function.  Tested that jawbox also still works