### PR TITLE
feat: debug features and implement ObjectDebugger

### DIFF
--- a/dGame/Entity.h
+++ b/dGame/Entity.h
@@ -175,6 +175,8 @@ public:
 
 	void AddComponent(eReplicaComponentType componentId, Component* component);
 
+	bool MsgRequestServerObjectInfo(GameMessages::GameMsg& msg);
+
 	// This is expceted to never return nullptr, an assert checks this.
 	CppScripts::Script* const GetScript() const;
 
@@ -335,6 +337,10 @@ public:
 	void RegisterMsg(const MessageType::Game msgId, std::function<bool(GameMessages::GameMsg&)> handler);
 
 	bool HandleMsg(GameMessages::GameMsg& msg) const;
+
+	void RegisterMsg(const MessageType::Game msgId, auto* self, const auto handler) {
+		RegisterMsg(msgId, std::bind(handler, self, std::placeholders::_1));
+	}
 
 	/**
 	 * @brief The observable for player entity position updates.

--- a/dGame/dComponents/CharacterComponent.h
+++ b/dGame/dComponents/CharacterComponent.h
@@ -331,7 +331,7 @@ public:
 	void LoadVisitedLevelsXml(const tinyxml2::XMLElement& doc);
 private:
 
-	bool OnRequestServerObjectInfo(GameMessages::GameMsg& msg);
+	bool OnGetObjectReportInfo(GameMessages::GameMsg& msg);
 
 	/**
 	 * The map of active venture vision effects

--- a/dGame/dGameMessages/GameMessages.h
+++ b/dGame/dGameMessages/GameMessages.h
@@ -15,6 +15,7 @@
 #include "eGameMasterLevel.h"
 
 class AMFBaseValue;
+class AMFArrayValue;
 class Entity;
 class Item;
 class NiQuaternion;
@@ -786,6 +787,13 @@ namespace GameMessages {
 		RequestServerObjectInfo() : GameMsg(MessageType::Game::REQUEST_SERVER_OBJECT_INFO, eGameMasterLevel::DEVELOPER) {}
 		bool Deserialize(RakNet::BitStream& bitStream) override;
 		void Handle(Entity& entity, const SystemAddress& sysAddr) override;
+	};
+
+	struct GetObjectReportInfo : public GameMsg {
+		AMFArrayValue* info{};
+		bool bVerbose{};
+
+		GetObjectReportInfo() : GameMsg(MessageType::Game::GET_OBJECT_REPORT_INFO, eGameMasterLevel::DEVELOPER) {}
 	};
 
 	struct RequestUse : public GameMsg {

--- a/dNet/WorldPackets.h
+++ b/dNet/WorldPackets.h
@@ -31,7 +31,7 @@ namespace WorldPackets {
 	void SendCharacterDeleteResponse(const SystemAddress& sysAddr, bool response);
 	void SendTransferToWorld(const SystemAddress& sysAddr, const std::string& serverIP, uint32_t serverPort, bool mythranShift);
 	void SendServerState(const SystemAddress& sysAddr);
-	void SendCreateCharacter(const SystemAddress& sysAddr, int64_t reputation, LWOOBJID player, const std::string& xmlData, const std::u16string& username, eGameMasterLevel gm);
+	void SendCreateCharacter(const SystemAddress& sysAddr, int64_t reputation, LWOOBJID player, const std::string& xmlData, const std::u16string& username, eGameMasterLevel gm, const LWOCLONEID cloneID);
 	void SendChatModerationResponse(const SystemAddress& sysAddr, bool requestAccepted, uint32_t requestID, const std::string& receiver, std::set<std::pair<uint8_t, uint8_t>> unacceptedItems);
 	void SendGMLevelChange(const SystemAddress& sysAddr, bool success, eGameMasterLevel highestLevel, eGameMasterLevel prevLevel, eGameMasterLevel newLevel);
 	void SendHTTPMonitorInfo(const SystemAddress& sysAddr, const HTTPMonitorInfo& info);

--- a/dWorldServer/WorldServer.cpp
+++ b/dWorldServer/WorldServer.cpp
@@ -1040,7 +1040,7 @@ void HandlePacket(Packet* packet) {
 				auto* characterComponent = player->GetComponent<CharacterComponent>();
 				if (!characterComponent) return;
 
-				WorldPackets::SendCreateCharacter(packet->systemAddress, player->GetComponent<CharacterComponent>()->GetReputation(), player->GetObjectID(), c->GetXMLData(), username, c->GetGMLevel());
+				WorldPackets::SendCreateCharacter(packet->systemAddress, player->GetComponent<CharacterComponent>()->GetReputation(), player->GetObjectID(), c->GetXMLData(), username, c->GetGMLevel(), c->GetPropertyCloneID());
 				WorldPackets::SendServerState(packet->systemAddress);
 
 				const auto respawnPoint = player->GetCharacter()->GetRespawnPoint(Game::zoneManager->GetZone()->GetWorldID());

--- a/docs/Commands.md
+++ b/docs/Commands.md
@@ -121,15 +121,15 @@ These commands are primarily for development and testing. The usage of many of t
 
 ## Detailed `/inspect` Usage
 
-`/inspect <component> (-m <waypoint> | -a <animation> | -s | -p | -f (faction) | -t)`
+`/inspect <component> (-m <waypoint> | -a <animation> | -p | -f (faction) | -t)`
 
 Finds the closest entity with the given component or LDF variable (ignoring players and racing cars), printing its ID, distance from the player, and whether it is sleeping, as well as the the IDs of all components the entity has.
+This info is then shown in a window on the client which the user can navigate
 
 ### `/inspect` Options
 
 * `-m`: If the entity has a moving platform component, sends it to the given waypoint, or stops the platform if `waypoint` is `-1`.
 * `-a`: Plays the given animation on the entity.
-* `-s`: Prints the entity's settings and spawner ID.
 * `-p`: Prints the entity's position
 * `-f`: If the entity has a destroyable component, prints whether the entity is smashable and its friendly and enemy faction IDs; if `faction` is specified, adds that faction to the entity.
 * `-cf`: check if the entity is enemy or friend


### PR DESCRIPTION
Move the -s and base features of inspect to the object debugger (this file is present in an unmodified, live client and works as-is)

Updates the components to use StringifiedEnum::ToString instead of printing the raw ID
An example of the window in usage is below. This window can be re-sized, moved around and closed when not in use. 

<img width="1105" height="902" alt="image" src="https://github.com/user-attachments/assets/bcc5293f-15ae-4dbc-9fdf-151b6fc4c29a" />
