### PR TITLE
feat: OnAttack behavior

### DIFF
--- a/dGame/dComponents/DestroyableComponent.h
+++ b/dGame/dComponents/DestroyableComponent.h
@@ -469,6 +469,7 @@ public:
 	void DoHardcoreModeDrops(const LWOOBJID source);
 
 	bool OnGetObjectReportInfo(GameMessages::GameMsg& msg);
+	bool OnSetFaction(GameMessages::GameMsg& msg);
 
 	static Implementation<bool, const Entity*> IsEnemyImplentation;
 	static Implementation<bool, const Entity*> IsFriendImplentation;

--- a/dGame/dComponents/ModelComponent.h
+++ b/dGame/dComponents/ModelComponent.h
@@ -146,11 +146,21 @@ public:
 
 	void OnChatMessageReceived(const std::string& sMessage);
 
+	void OnHit();
+
 	// Sets the speed of the model
 	void SetSpeed(const float newSpeed) { m_Speed = newSpeed; }
 
 	// Whether or not to restart at the end of the frame
 	void RestartAtEndOfFrame() { m_RestartAtEndOfFrame = true; }
+
+	// Increments the number of strips listening for an attack.
+	// If this is the first strip adding an attack, it will set the factions to the correct values.
+	void AddAttack();
+
+	// Decrements the number of strips listening for an attack.
+	// If this is the last strip removing an attack, it will reset the factions to the default of -1.
+	void RemoveAttack();
 private:
 
 	// Loads a behavior from the database.
@@ -167,6 +177,9 @@ private:
 
 	// The number of strips listening for a RequestUse GM to come in.
 	uint32_t m_NumListeningInteract{};
+
+	// The number of strips listening for an attack.
+	uint32_t m_NumActiveAttack{};
 
 	// Whether or not the model is paused and should reject all interactions regarding behaviors.
 	bool m_IsPaused{};

--- a/dGame/dGameMessages/GameMessages.h
+++ b/dGame/dGameMessages/GameMessages.h
@@ -863,5 +863,13 @@ namespace GameMessages {
 
 		NiPoint3 pos{};
 	};
+
+	struct SetFaction : public GameMsg {
+		SetFaction() : GameMsg(MessageType::Game::SET_FACTION) {}
+
+		int32_t factionID{};
+
+		bool bIgnoreChecks{ false };
+	};
 };
 #endif // GAMEMESSAGES_H

--- a/dGame/dPropertyBehaviors/PropertyBehavior.cpp
+++ b/dGame/dPropertyBehaviors/PropertyBehavior.cpp
@@ -184,3 +184,7 @@ void PropertyBehavior::Update(float deltaTime, ModelComponent& modelComponent) {
 void PropertyBehavior::OnChatMessageReceived(const std::string& sMessage) {
 	for (auto& state : m_States | std::views::values) state.OnChatMessageReceived(sMessage);
 }
+
+void PropertyBehavior::OnHit() {
+	for (auto& state : m_States | std::views::values) state.OnHit();
+}

--- a/dGame/dPropertyBehaviors/PropertyBehavior.h
+++ b/dGame/dPropertyBehaviors/PropertyBehavior.h
@@ -42,6 +42,7 @@ public:
 
 	void Update(float deltaTime, ModelComponent& modelComponent);
 	void OnChatMessageReceived(const std::string& sMessage);
+	void OnHit();
 
 private:
 	// The current active behavior state. Behaviors can only be in ONE state at a time.

--- a/dGame/dPropertyBehaviors/State.cpp
+++ b/dGame/dPropertyBehaviors/State.cpp
@@ -170,3 +170,7 @@ void State::Update(float deltaTime, ModelComponent& modelComponent) {
 void State::OnChatMessageReceived(const std::string& sMessage) {
 	for (auto& strip : m_Strips) strip.OnChatMessageReceived(sMessage);
 }
+
+void State::OnHit() {
+	for (auto& strip : m_Strips) strip.OnHit();
+}

--- a/dGame/dPropertyBehaviors/State.h
+++ b/dGame/dPropertyBehaviors/State.h
@@ -24,6 +24,7 @@ public:
 	void Update(float deltaTime, ModelComponent& modelComponent);
 
 	void OnChatMessageReceived(const std::string& sMessage);
+	void OnHit();
 private:
 
 	// The strips contained within this state.

--- a/dGame/dPropertyBehaviors/Strip.cpp
+++ b/dGame/dPropertyBehaviors/Strip.cpp
@@ -118,6 +118,16 @@ void Strip::OnChatMessageReceived(const std::string& sMessage) {
 	}
 }
 
+void Strip::OnHit() {
+	if (m_PausedTime > 0.0f || !HasMinimumActions()) return;
+
+	const auto& nextAction = GetNextAction();
+	if (nextAction.GetType() == "OnAttack") {
+		IncrementAction();
+		m_WaitingForAction = false;
+	}
+}
+
 void Strip::IncrementAction() {
 	if (m_Actions.empty()) return;
 	m_NextActionIndex++;
@@ -259,6 +269,8 @@ void Strip::RemoveStates(ModelComponent& modelComponent) const {
 	if (prevActionType == "OnInteract") {
 		modelComponent.RemoveInteract();
 		Game::entityManager->SerializeEntity(modelComponent.GetParent());
+	} else if (prevActionType == "OnAttack") {
+		modelComponent.RemoveAttack();
 	} else if (prevActionType == "UnSmash") {
 		modelComponent.RemoveUnSmash();
 	}
@@ -336,13 +348,14 @@ void Strip::Update(float deltaTime, ModelComponent& modelComponent) {
 	if (m_NextActionIndex == 0) {
 		if (nextAction.GetType() == "OnInteract") {
 			modelComponent.AddInteract();
-			Game::entityManager->SerializeEntity(entity);
-			m_WaitingForAction = true;
 
 		} else if (nextAction.GetType() == "OnChat") {
-			Game::entityManager->SerializeEntity(entity);
-			m_WaitingForAction = true;
+			// logic here if needed
+		} else if (nextAction.GetType() == "OnAttack") {
+			modelComponent.AddAttack();
 		}
+		Game::entityManager->SerializeEntity(entity);
+		m_WaitingForAction = true;
 	} else { // should be a normal block
 		ProcNormalAction(deltaTime, modelComponent);
 	}

--- a/dGame/dPropertyBehaviors/Strip.h
+++ b/dGame/dPropertyBehaviors/Strip.h
@@ -42,6 +42,7 @@ public:
 	bool HasMinimumActions() const { return m_Actions.size() >= 2; }
 	
 	void OnChatMessageReceived(const std::string& sMessage);
+	void OnHit();
 private:
 	// Indicates this Strip is waiting for an action to be taken upon it to progress to its actions
 	bool m_WaitingForAction{ false };


### PR DESCRIPTION
Adds the `OnAttack` property behavior starting node. Tested that having the node allows the model to be attacked to trigger the start of behaviors