### PR TITLE
Revert uint8_t in game message tests

### DIFF
--- a/tests/dGameTests/dGameMessagesTests/GameMessageTests.cpp
+++ b/tests/dGameTests/dGameMessagesTests/GameMessageTests.cpp
@@ -57,13 +57,12 @@ TEST_F(GameMessageTests, SendBlueprintLoadItemResponse) {
 	ASSERT_EQ(bitStream->GetNumberOfUnreadBits(), 200);
 	// First read in the packets' header
 	uint8_t rakNetPacketId{};
-	uint8_t remoteServiceType{};
+	uint16_t remoteServiceType{};
 	uint32_t packetId{};
 	uint8_t always0{};
 
 	bitStream->Read(rakNetPacketId);
 	bitStream->Read(remoteServiceType);
-    bitStream->IgnoreBytes(1);
 	bitStream->Read(packetId);
 	bitStream->Read(always0);
 	ASSERT_EQ(rakNetPacketId, 0x53);


### PR DESCRIPTION
This is a remnant of a reverted change that slipped into a previous PR and no longer makes sense since ServiceType is a uint16_t, not a uint8_t