### PR TITLE
fix: Show git download progress with FetchContent

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON) 	# Export the compile commands for debuggi
 set(CMAKE_POLICY_DEFAULT_CMP0063 NEW) 	# Set CMAKE visibility policy to NEW on project and subprojects
 set(CMAKE_VISIBILITY_INLINES_HIDDEN ON) # Set C and C++ symbol visibility to hide inlined functions
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(FETCHCONTENT_QUIET FALSE) # GLM takes a long time to clone, this will at least show _something_ while its downloading
 
 # Read variables from file
 FILE(READ "${CMAKE_SOURCE_DIR}/CMakeVariables.txt" variables)

--- a/cmake/FindGoogleTest.cmake
+++ b/cmake/FindGoogleTest.cmake
@@ -6,6 +6,7 @@ FetchContent_Declare(
 	googletest
 	GIT_REPOSITORY https://github.com/google/googletest.git
 	GIT_TAG release-1.12.1
+	GIT_PROGRESS TRUE
 )
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings

--- a/dCommon/CMakeLists.txt
+++ b/dCommon/CMakeLists.txt
@@ -54,6 +54,7 @@ elseif (WIN32)
 		zlib
 		URL https://github.com/madler/zlib/archive/refs/tags/v1.2.11.zip
 		URL_HASH MD5=9d6a627693163bbbf3f26403a3a0b0b1
+		GIT_PROGRESS TRUE
 	)
 
 	# Disable warning about no project version.

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -47,6 +47,7 @@ if(UNIX AND NOT APPLE)
 		FetchContent_Declare(
 			backtrace
 			GIT_REPOSITORY https://github.com/ianlancetaylor/libbacktrace.git
+			GIT_PROGRESS TRUE
 		)
 
 		FetchContent_MakeAvailable(backtrace)


### PR DESCRIPTION
Some downloads are slower and showing progress is better than sitting there doing nothing