### PR TITLE
Update mute expiry from database

### DIFF
--- a/dDatabase/GameDatabase/ITables/IAccounts.h
+++ b/dDatabase/GameDatabase/ITables/IAccounts.h
@@ -14,6 +14,7 @@ public:
 		std::string bcryptPassword;
 		uint32_t id{};
 		uint32_t playKeyId{};
+		uint64_t muteExpire{};
 		bool banned{};
 		bool locked{};
 		eGameMasterLevel maxGmLevel{};

--- a/dDatabase/GameDatabase/MySQL/Tables/Accounts.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/Accounts.cpp
@@ -3,7 +3,7 @@
 #include "eGameMasterLevel.h"
 
 std::optional<IAccounts::Info> MySQLDatabase::GetAccountInfo(const std::string_view username) {
-	auto result = ExecuteSelect("SELECT id, password, banned, locked, play_key_id, gm_level FROM accounts WHERE name = ? LIMIT 1;", username);
+	auto result = ExecuteSelect("SELECT id, password, banned, locked, play_key_id, gm_level, mute_expire FROM accounts WHERE name = ? LIMIT 1;", username);
 
 	if (!result->next()) {
 		return std::nullopt;
@@ -16,6 +16,7 @@ std::optional<IAccounts::Info> MySQLDatabase::GetAccountInfo(const std::string_v
 	toReturn.banned = result->getBoolean("banned");
 	toReturn.locked = result->getBoolean("locked");
 	toReturn.playKeyId = result->getUInt("play_key_id");
+	toReturn.muteExpire = result->getUInt64("mute_expire");
 
 	return toReturn;
 }

--- a/dDatabase/GameDatabase/SQLite/Tables/Accounts.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/Accounts.cpp
@@ -17,6 +17,7 @@ std::optional<IAccounts::Info> SQLiteDatabase::GetAccountInfo(const std::string_
 	toReturn.banned = result.getIntField("banned");
 	toReturn.locked = result.getIntField("locked");
 	toReturn.playKeyId = result.getIntField("play_key_id");
+	toReturn.muteExpire = static_cast<uint64_t>(result.getInt64Field("mute_expire"));
 
 	return toReturn;
 }

--- a/dGame/User.cpp
+++ b/dGame/User.cpp
@@ -7,6 +7,10 @@
 #include "dZoneManager.h"
 #include "eServerDisconnectIdentifiers.h"
 #include "eGameMasterLevel.h"
+#include "BitStreamUtils.h"
+#include "MessageType/Chat.h"
+#include <chrono>
+#include <ctime>
 
 User::User(const SystemAddress& sysAddr, const std::string& username, const std::string& sessionKey) {
 	m_AccountID = 0;
@@ -28,7 +32,7 @@ User::User(const SystemAddress& sysAddr, const std::string& username, const std:
 	if (userInfo) {
 		m_AccountID = userInfo->id;
 		m_MaxGMLevel = userInfo->maxGmLevel;
-		m_MuteExpire = 0; //res->getUInt64(3);
+		m_MuteExpire = static_cast<time_t>(userInfo->muteExpire);
 	}
 
 	//If we're loading a zone, we'll load the last used (aka current) character:
@@ -92,7 +96,27 @@ Character* User::GetLastUsedChar() {
 }
 
 bool User::GetIsMuted() const {
-	return m_MuteExpire == 1 || m_MuteExpire > time(NULL);
+	using namespace std::chrono;
+	constexpr auto refreshInterval = seconds{ 60 };
+	const auto now = steady_clock::now();
+	if (now - m_LastMuteCheck >= refreshInterval) {
+		m_LastMuteCheck = now;
+		if (auto info = Database::Get()->GetAccountInfo(m_Username)) {
+			const auto expire = static_cast<time_t>(info->muteExpire);
+			if (expire != m_MuteExpire) {
+				m_MuteExpire = expire;
+
+				if (Game::chatServer && m_LoggedInCharID != 0) {
+					RakNet::BitStream bitStream;
+					BitStreamUtils::WriteHeader(bitStream, ServiceType::CHAT, MessageType::Chat::GM_MUTE);
+					bitStream.Write(m_LoggedInCharID);
+					bitStream.Write(m_MuteExpire);
+					Game::chatServer->Send(&bitStream, SYSTEM_PRIORITY, RELIABLE, 0, Game::chatSysAddr, false);
+				}
+			}
+		}
+	}
+	return m_MuteExpire == 1 || m_MuteExpire > std::time(nullptr);
 }
 
 time_t User::GetMuteExpire() const {

--- a/dGame/User.h
+++ b/dGame/User.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <chrono>
 #include "RakNetTypes.h"
 #include "dCommonVars.h"
 
@@ -72,7 +73,8 @@ private:
 	bool m_LastChatMessageApproved = false;
 	int m_AmountOfTimesOutOfSync = 0;
 	const int m_MaxDesyncAllowed = 12;
-	time_t m_MuteExpire;
+	mutable time_t m_MuteExpire;
+	mutable std::chrono::steady_clock::time_point m_LastMuteCheck{};
 };
 
 #endif // USER_H


### PR DESCRIPTION
Update "mute" to now be functional

- `mute_expire` is now retrieved on login
- player no longer needs to switch worlds for mute to be applied
    - `mute_expire` is pulled from the DB on a check if it has been more than 60 seconds from the last update

Tested the following
- Mute applies to account
   - Account characters are unable to send mail or chat while muted
- Un-muting account restores access for the affected characters
- Muting/un-muting account while target character is still in world
   - Mute applies and unapplies as expected
