### PR TITLE
fix: FetchContent_Declare speed

### DIFF
--- a/cmake/FindGoogleTest.cmake
+++ b/cmake/FindGoogleTest.cmake
@@ -7,6 +7,7 @@ FetchContent_Declare(
 	GIT_REPOSITORY https://github.com/google/googletest.git
 	GIT_TAG release-1.12.1
 	GIT_PROGRESS TRUE
+	GIT_SHALLOW 1
 )
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings

--- a/dCommon/CMakeLists.txt
+++ b/dCommon/CMakeLists.txt
@@ -55,6 +55,7 @@ elseif (WIN32)
 		URL https://github.com/madler/zlib/archive/refs/tags/v1.2.11.zip
 		URL_HASH MD5=9d6a627693163bbbf3f26403a3a0b0b1
 		GIT_PROGRESS TRUE
+		GIT_SHALLOW 1
 	)
 
 	# Disable warning about no project version.

--- a/thirdparty/CMakeLists.txt
+++ b/thirdparty/CMakeLists.txt
@@ -49,6 +49,7 @@ if(UNIX AND NOT APPLE)
 			backtrace
 			GIT_REPOSITORY https://github.com/ianlancetaylor/libbacktrace.git
 			GIT_PROGRESS TRUE
+			GIT_SHALLOW 1
 		)
 
 		FetchContent_MakeAvailable(backtrace)
@@ -71,6 +72,7 @@ FetchContent_Declare(
 	GIT_REPOSITORY	https://github.com/g-truc/glm.git
 	GIT_TAG 	bf71a834948186f4097caa076cd2663c69a10e1e #refs/tags/1.0.1
 	GIT_PROGRESS TRUE
+	GIT_SHALLOW 1
 )
 
 FetchContent_MakeAvailable(glm)


### PR DESCRIPTION
Only clones the specified commit instead of the entire commit tree to save time on build.  Given we only want a specific commit anyways, this should be the standard way to do this and improve speed in ci and all builds