### PR TITLE
feat: convert character ids to 64 bits

### DIFF
--- a/dChatServer/ChatIgnoreList.cpp
+++ b/dChatServer/ChatIgnoreList.cpp
@@ -34,7 +34,7 @@ void ChatIgnoreList::GetIgnoreList(Packet* packet) {
 	if (!receiver.ignoredPlayers.empty()) {
 		LOG_DEBUG("Player %llu already has an ignore list, but is requesting it again.", playerId);
 	} else {
-		auto ignoreList = Database::Get()->GetIgnoreList(static_cast<uint32_t>(playerId));
+		auto ignoreList = Database::Get()->GetIgnoreList(playerId);
 		if (ignoreList.empty()) {
 			LOG_DEBUG("Player %llu has no ignores", playerId);
 			return;
@@ -43,7 +43,6 @@ void ChatIgnoreList::GetIgnoreList(Packet* packet) {
 		for (auto& ignoredPlayer : ignoreList) {
 			receiver.ignoredPlayers.emplace_back(ignoredPlayer.name, ignoredPlayer.id);
 			GeneralUtils::SetBit(receiver.ignoredPlayers.back().playerId, eObjectBits::CHARACTER);
-			GeneralUtils::SetBit(receiver.ignoredPlayers.back().playerId, eObjectBits::PERSISTENT);
 		}
 	}
 
@@ -114,9 +113,8 @@ void ChatIgnoreList::AddIgnore(Packet* packet) {
 		}
 
 		if (ignoredPlayerId != LWOOBJID_EMPTY) {
-			Database::Get()->AddIgnore(static_cast<uint32_t>(playerId), static_cast<uint32_t>(ignoredPlayerId));
+			Database::Get()->AddIgnore(playerId, ignoredPlayerId);
 			GeneralUtils::SetBit(ignoredPlayerId, eObjectBits::CHARACTER);
-			GeneralUtils::SetBit(ignoredPlayerId, eObjectBits::PERSISTENT);
 
 			receiver.ignoredPlayers.emplace_back(toIgnoreStr, ignoredPlayerId);
 			LOG_DEBUG("Player %llu is ignoring %s", playerId, toIgnoreStr.c_str());
@@ -157,7 +155,7 @@ void ChatIgnoreList::RemoveIgnore(Packet* packet) {
 		return;
 	}
 
-	Database::Get()->RemoveIgnore(static_cast<uint32_t>(playerId), static_cast<uint32_t>(toRemove->playerId));
+	Database::Get()->RemoveIgnore(playerId, toRemove->playerId);
 	receiver.ignoredPlayers.erase(toRemove, receiver.ignoredPlayers.end());
 
 	CBITSTREAM;

--- a/dChatServer/ChatPacketHandler.cpp
+++ b/dChatServer/ChatPacketHandler.cpp
@@ -35,7 +35,6 @@ void ChatPacketHandler::HandleFriendlistRequest(Packet* packet) {
 		FriendData fd;
 		fd.isFTP = false; // not a thing in DLU
 		fd.friendID = friendData.friendID;
-		GeneralUtils::SetBit(fd.friendID, eObjectBits::PERSISTENT);
 		GeneralUtils::SetBit(fd.friendID, eObjectBits::CHARACTER);
 
 		fd.isBestFriend = friendData.isBestFriend; //0 = friends, 1 = left_requested, 2 = right_requested, 3 = both_accepted - are now bffs
@@ -161,9 +160,7 @@ void ChatPacketHandler::HandleFriendRequest(Packet* packet) {
 
 			// Set the bits
 			GeneralUtils::SetBit(queryPlayerID, eObjectBits::CHARACTER);
-			GeneralUtils::SetBit(queryPlayerID, eObjectBits::PERSISTENT);
 			GeneralUtils::SetBit(queryFriendID, eObjectBits::CHARACTER);
-			GeneralUtils::SetBit(queryFriendID, eObjectBits::PERSISTENT);
 
 			// Since this player can either be the friend of someone else or be friends with someone else
 			// their column in the database determines what bit gets set.  When the value hits 3, they
@@ -318,7 +315,6 @@ void ChatPacketHandler::HandleRemoveFriend(Packet* packet) {
 	}
 
 	// Convert friendID to LWOOBJID
-	GeneralUtils::SetBit(friendID, eObjectBits::PERSISTENT);
 	GeneralUtils::SetBit(friendID, eObjectBits::CHARACTER);
 
 	Database::Get()->RemoveFriend(playerID, friendID);

--- a/dDatabase/GameDatabase/GameDatabase.h
+++ b/dDatabase/GameDatabase/GameDatabase.h
@@ -48,7 +48,7 @@ public:
 	virtual void Commit() = 0;
 	virtual bool GetAutoCommit() = 0;
 	virtual void SetAutoCommit(bool value) = 0;
-	virtual void DeleteCharacter(const uint32_t characterId) = 0;
+	virtual void DeleteCharacter(const LWOOBJID characterId) = 0;
 };
 
 #endif  //!__GAMEDATABASE__H__

--- a/dDatabase/GameDatabase/ITables/IActivityLog.h
+++ b/dDatabase/GameDatabase/ITables/IActivityLog.h
@@ -14,7 +14,7 @@ enum class eActivityType : uint32_t {
 class IActivityLog {
 public:
 	// Update the activity log for the given account.
-	virtual void UpdateActivityLog(const uint32_t characterId, const eActivityType activityType, const LWOMAPID mapId) = 0;
+	virtual void UpdateActivityLog(const LWOOBJID characterId, const eActivityType activityType, const LWOMAPID mapId) = 0;
 };
 
 #endif  //!__IACTIVITYLOG__H__

--- a/dDatabase/GameDatabase/ITables/IBehaviors.h
+++ b/dDatabase/GameDatabase/ITables/IBehaviors.h
@@ -9,7 +9,7 @@ class IBehaviors {
 public:
 	struct Info {
 		LWOOBJID behaviorId{};
-		uint32_t characterId{};
+		LWOOBJID characterId{};
 		std::string behaviorInfo;
 	};
 

--- a/dDatabase/GameDatabase/ITables/IBugReports.h
+++ b/dDatabase/GameDatabase/ITables/IBugReports.h
@@ -11,7 +11,7 @@ public:
 		std::string clientVersion;
 		std::string otherPlayer;
 		std::string selection;
-		uint32_t characterId{};
+		LWOOBJID characterId{};
 	};
 
 	// Add a new bug report to the database.

--- a/dDatabase/GameDatabase/ITables/ICharInfo.h
+++ b/dDatabase/GameDatabase/ITables/ICharInfo.h
@@ -14,7 +14,7 @@ public:
 	struct Info {
 		std::string name;
 		std::string pendingName;
-		uint32_t id{};
+		LWOOBJID id{};
 		uint32_t accountId{};
 		bool needsRename{};
 		LWOCLONEID cloneId{};
@@ -25,25 +25,25 @@ public:
 	virtual std::vector<std::string> GetApprovedCharacterNames() = 0;
 
 	// Get the character info for the given character id.
-	virtual std::optional<ICharInfo::Info> GetCharacterInfo(const uint32_t charId) = 0;
+	virtual std::optional<ICharInfo::Info> GetCharacterInfo(const LWOOBJID charId) = 0;
 
 	// Get the character info for the given character name.
 	virtual std::optional<ICharInfo::Info> GetCharacterInfo(const std::string_view name) = 0;
 	
 	// Get the character ids for the given account.
-	virtual std::vector<uint32_t> GetAccountCharacterIds(const uint32_t accountId) = 0;
+	virtual std::vector<LWOOBJID> GetAccountCharacterIds(const LWOOBJID accountId) = 0;
 
 	// Insert a new character into the database.
 	virtual void InsertNewCharacter(const ICharInfo::Info info) = 0;
 
 	// Set the name of the given character.
-	virtual void SetCharacterName(const uint32_t characterId, const std::string_view name) = 0;
+	virtual void SetCharacterName(const LWOOBJID characterId, const std::string_view name) = 0;
 
 	// Set the pending name of the given character.
-	virtual void SetPendingCharacterName(const uint32_t characterId, const std::string_view name) = 0;
+	virtual void SetPendingCharacterName(const LWOOBJID characterId, const std::string_view name) = 0;
 
 	// Updates the given character ids last login to be right now.
-	virtual void UpdateLastLoggedInCharacter(const uint32_t characterId) = 0;
+	virtual void UpdateLastLoggedInCharacter(const LWOOBJID characterId) = 0;
 
 	virtual bool IsNameInUse(const std::string_view name) = 0;
 };

--- a/dDatabase/GameDatabase/ITables/ICharXml.h
+++ b/dDatabase/GameDatabase/ITables/ICharXml.h
@@ -8,13 +8,13 @@
 class ICharXml {
 public:
 	// Get the character xml for the given character id.
-	virtual std::string GetCharacterXml(const uint32_t charId) = 0;
+	virtual std::string GetCharacterXml(const LWOOBJID charId) = 0;
 
 	// Update the character xml for the given character id.
-	virtual void UpdateCharacterXml(const uint32_t charId, const std::string_view lxfml) = 0;
+	virtual void UpdateCharacterXml(const LWOOBJID charId, const std::string_view lxfml) = 0;
 
 	// Insert the character xml for the given character id.
-	virtual void InsertCharacterXml(const uint32_t characterId, const std::string_view lxfml) = 0;
+	virtual void InsertCharacterXml(const LWOOBJID characterId, const std::string_view lxfml) = 0;
 };
 
 #endif  //!__ICHARXML__H__

--- a/dDatabase/GameDatabase/ITables/ICommandLog.h
+++ b/dDatabase/GameDatabase/ITables/ICommandLog.h
@@ -8,7 +8,7 @@ class ICommandLog {
 public:	
 
 	// Insert a new slash command log entry.
-	virtual void InsertSlashCommandUsage(const uint32_t characterId, const std::string_view command) = 0;
+	virtual void InsertSlashCommandUsage(const LWOOBJID characterId, const std::string_view command) = 0;
 };
 
 #endif  //!__ICOMMANDLOG__H__

--- a/dDatabase/GameDatabase/ITables/IFriends.h
+++ b/dDatabase/GameDatabase/ITables/IFriends.h
@@ -8,25 +8,25 @@
 class IFriends {
 public:
 	struct BestFriendStatus {
-		uint32_t playerCharacterId{};
-		uint32_t friendCharacterId{};
+		LWOOBJID playerCharacterId{};
+		LWOOBJID friendCharacterId{};
 		uint32_t bestFriendStatus{};
 	};
 
 	// Get the friends list for the given character id.
-	virtual std::vector<FriendData> GetFriendsList(const uint32_t charId) = 0;
+	virtual std::vector<FriendData> GetFriendsList(const LWOOBJID charId) = 0;
 
 	// Get the best friend status for the given player and friend character ids.
-	virtual std::optional<IFriends::BestFriendStatus> GetBestFriendStatus(const uint32_t playerCharacterId, const uint32_t friendCharacterId) = 0;
+	virtual std::optional<IFriends::BestFriendStatus> GetBestFriendStatus(const LWOOBJID playerCharacterId, const LWOOBJID friendCharacterId) = 0;
 
 	// Set the best friend status for the given player and friend character ids.
-	virtual void SetBestFriendStatus(const uint32_t playerCharacterId, const uint32_t friendCharacterId, const uint32_t bestFriendStatus) = 0;
+	virtual void SetBestFriendStatus(const LWOOBJID playerCharacterId, const LWOOBJID friendCharacterId, const uint32_t bestFriendStatus) = 0;
 
 	// Add a friend to the given character id.
-	virtual void AddFriend(const uint32_t playerCharacterId, const uint32_t friendCharacterId) = 0;
+	virtual void AddFriend(const LWOOBJID playerCharacterId, const LWOOBJID friendCharacterId) = 0;
 
 	// Remove a friend from the given character id.
-	virtual void RemoveFriend(const uint32_t playerCharacterId, const uint32_t friendCharacterId) = 0;
+	virtual void RemoveFriend(const LWOOBJID playerCharacterId, const LWOOBJID friendCharacterId) = 0;
 };
 
 #endif  //!__IFRIENDS__H__

--- a/dDatabase/GameDatabase/ITables/IIgnoreList.h
+++ b/dDatabase/GameDatabase/ITables/IIgnoreList.h
@@ -9,12 +9,12 @@ class IIgnoreList {
 public:
 	struct Info {
 		std::string name;
-		uint32_t id;
+		LWOOBJID id;
 	};
 
-	virtual std::vector<Info> GetIgnoreList(const uint32_t playerId) = 0;
-	virtual void AddIgnore(const uint32_t playerId, const uint32_t ignoredPlayerId) = 0;
-	virtual void RemoveIgnore(const uint32_t playerId, const uint32_t ignoredPlayerId) = 0;
+	virtual std::vector<Info> GetIgnoreList(const LWOOBJID playerId) = 0;
+	virtual void AddIgnore(const LWOOBJID playerId, const LWOOBJID ignoredPlayerId) = 0;
+	virtual void RemoveIgnore(const LWOOBJID playerId, const LWOOBJID ignoredPlayerId) = 0;
 };
 
 #endif  //!__IIGNORELIST__H__

--- a/dDatabase/GameDatabase/ITables/ILeaderboard.h
+++ b/dDatabase/GameDatabase/ITables/ILeaderboard.h
@@ -5,12 +5,13 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include "dCommonVars.h"
 
 class ILeaderboard {
 public:
 
 	struct Entry {
-		uint32_t charId{};
+		LWOOBJID charId{};
 		uint32_t lastPlayedTimestamp{};
 		float primaryScore{};
 		float secondaryScore{};
@@ -36,12 +37,12 @@ public:
 	virtual std::vector<ILeaderboard::Entry> GetAscendingLeaderboard(const uint32_t activityId) = 0;
 	virtual std::vector<ILeaderboard::Entry> GetNsLeaderboard(const uint32_t activityId) = 0;
 	virtual std::vector<ILeaderboard::Entry> GetAgsLeaderboard(const uint32_t activityId) = 0;
-	virtual std::optional<Score> GetPlayerScore(const uint32_t playerId, const uint32_t gameId) = 0;
+	virtual std::optional<Score> GetPlayerScore(const LWOOBJID playerId, const uint32_t gameId) = 0;
 
-	virtual void SaveScore(const uint32_t playerId, const uint32_t gameId, const Score& score) = 0;
-	virtual void UpdateScore(const uint32_t playerId, const uint32_t gameId, const Score& score) = 0;
-	virtual void IncrementNumWins(const uint32_t playerId, const uint32_t gameId) = 0;
-	virtual void IncrementTimesPlayed(const uint32_t playerId, const uint32_t gameId) = 0;
+	virtual void SaveScore(const LWOOBJID playerId, const uint32_t gameId, const Score& score) = 0;
+	virtual void UpdateScore(const LWOOBJID playerId, const uint32_t gameId, const Score& score) = 0;
+	virtual void IncrementNumWins(const LWOOBJID playerId, const uint32_t gameId) = 0;
+	virtual void IncrementTimesPlayed(const LWOOBJID playerId, const uint32_t gameId) = 0;
 };
 
 #endif  //!__ILEADERBOARD__H__

--- a/dDatabase/GameDatabase/ITables/IMail.h
+++ b/dDatabase/GameDatabase/ITables/IMail.h
@@ -16,13 +16,13 @@ public:
 	virtual void InsertNewMail(const MailInfo& mail) = 0;
 
 	// Get the mail for the given character id.
-	virtual std::vector<MailInfo> GetMailForPlayer(const uint32_t characterId, const uint32_t numberOfMail) = 0;
+	virtual std::vector<MailInfo> GetMailForPlayer(const LWOOBJID characterId, const uint32_t numberOfMail) = 0;
 
 	// Get the mail for the given mail id.
 	virtual std::optional<MailInfo> GetMail(const uint64_t mailId) = 0;
 
 	// Get the number of unread mail for the given character id.
-	virtual uint32_t GetUnreadMailCount(const uint32_t characterId) = 0;
+	virtual uint32_t GetUnreadMailCount(const LWOOBJID characterId) = 0;
 
 	// Mark the given mail as read.
 	virtual void MarkMailRead(const uint64_t mailId) = 0;

--- a/dDatabase/GameDatabase/ITables/IProperty.h
+++ b/dDatabase/GameDatabase/ITables/IProperty.h
@@ -13,7 +13,7 @@ public:
 		std::string description;
 		std::string rejectionReason;
 		LWOOBJID id{};
-		uint32_t ownerId{};
+		LWOOBJID ownerId{};
 		LWOCLONEID cloneId{};
 		int32_t privacyOption{};
 		uint32_t modApproved{};
@@ -27,7 +27,7 @@ public:
 		uint32_t mapId{};
 		std::string searchString;
 		ePropertySortType sortChoice{};
-		uint32_t playerId{};
+		LWOOBJID playerId{};
 		uint32_t numResults{};
 		uint32_t startIndex{};
 		uint32_t playerSort{};

--- a/dDatabase/GameDatabase/ITables/IPropertyContents.h
+++ b/dDatabase/GameDatabase/ITables/IPropertyContents.h
@@ -25,7 +25,7 @@ public:
 		std::stringstream& sd0Data,
 		const uint32_t blueprintId,
 		const uint32_t accountId,
-		const uint32_t characterId) = 0;
+		const LWOOBJID characterId) = 0;
 
 	// Get the property models for the given property id.
 	virtual std::vector<IPropertyContents::Model> GetPropertyModels(const LWOOBJID& propertyId) = 0;

--- a/dDatabase/GameDatabase/ITables/IUgcModularBuild.h
+++ b/dDatabase/GameDatabase/ITables/IUgcModularBuild.h
@@ -7,7 +7,7 @@
 
 class IUgcModularBuild {
 public:
-	virtual void InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<uint32_t> characterId) = 0;
+	virtual void InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<LWOOBJID> characterId) = 0;
 	virtual void DeleteUgcBuild(const LWOOBJID bigId) = 0;
 };
 

--- a/dDatabase/GameDatabase/MySQL/MySQLDatabase.cpp
+++ b/dDatabase/GameDatabase/MySQL/MySQLDatabase.cpp
@@ -100,7 +100,7 @@ void MySQLDatabase::SetAutoCommit(bool value) {
 	con->setAutoCommit(value);
 }
 
-void MySQLDatabase::DeleteCharacter(const uint32_t characterId) {
+void MySQLDatabase::DeleteCharacter(const LWOOBJID characterId) {
 	ExecuteDelete("DELETE FROM charxml WHERE id=? LIMIT 1;", characterId);
 	ExecuteDelete("DELETE FROM command_log WHERE character_id=?;", characterId);
 	ExecuteDelete("DELETE FROM friends WHERE player_id=? OR friend_id=?;", characterId, characterId);

--- a/dDatabase/GameDatabase/MySQL/MySQLDatabase.h
+++ b/dDatabase/GameDatabase/MySQL/MySQLDatabase.h
@@ -40,31 +40,31 @@ public:
 
 	std::vector<std::string> GetApprovedCharacterNames() override;
 
-	std::vector<FriendData> GetFriendsList(uint32_t charID) override;
+	std::vector<FriendData> GetFriendsList(LWOOBJID charID) override;
 
-	std::optional<IFriends::BestFriendStatus> GetBestFriendStatus(const uint32_t playerCharacterId, const uint32_t friendCharacterId) override;
-	void SetBestFriendStatus(const uint32_t playerAccountId, const uint32_t friendAccountId, const uint32_t bestFriendStatus) override;
-	void AddFriend(const uint32_t playerAccountId, const uint32_t friendAccountId) override;
-	void RemoveFriend(const uint32_t playerAccountId, const uint32_t friendAccountId) override;
-	void UpdateActivityLog(const uint32_t characterId, const eActivityType activityType, const LWOMAPID mapId) override;
+	std::optional<IFriends::BestFriendStatus> GetBestFriendStatus(const LWOOBJID playerCharacterId, const LWOOBJID friendCharacterId) override;
+	void SetBestFriendStatus(const LWOOBJID playerAccountId, const LWOOBJID friendAccountId, const uint32_t bestFriendStatus) override;
+	void AddFriend(const LWOOBJID playerAccountId, const LWOOBJID friendAccountId) override;
+	void RemoveFriend(const LWOOBJID playerAccountId, const LWOOBJID friendAccountId) override;
+	void UpdateActivityLog(const LWOOBJID characterId, const eActivityType activityType, const LWOMAPID mapId) override;
 	void DeleteUgcModelData(const LWOOBJID& modelId) override;
 	void UpdateUgcModelData(const LWOOBJID& modelId, std::stringstream& lxfml) override;
 	std::vector<IUgc::Model> GetAllUgcModels() override;
 	void CreateMigrationHistoryTable() override;
 	bool IsMigrationRun(const std::string_view str) override;
 	void InsertMigration(const std::string_view str) override;
-	std::optional<ICharInfo::Info> GetCharacterInfo(const uint32_t charId) override;
+	std::optional<ICharInfo::Info> GetCharacterInfo(const LWOOBJID charId) override;
 	std::optional<ICharInfo::Info> GetCharacterInfo(const std::string_view charId) override;
-	std::string GetCharacterXml(const uint32_t accountId) override;
-	void UpdateCharacterXml(const uint32_t characterId, const std::string_view lxfml) override;
+	std::string GetCharacterXml(const LWOOBJID accountId) override;
+	void UpdateCharacterXml(const LWOOBJID characterId, const std::string_view lxfml) override;
 	std::optional<IAccounts::Info> GetAccountInfo(const std::string_view username) override;
 	void InsertNewCharacter(const ICharInfo::Info info) override;
-	void InsertCharacterXml(const uint32_t accountId, const std::string_view lxfml) override;
-	std::vector<uint32_t> GetAccountCharacterIds(uint32_t accountId) override;
-	void DeleteCharacter(const uint32_t characterId) override;
-	void SetCharacterName(const uint32_t characterId, const std::string_view name) override;
-	void SetPendingCharacterName(const uint32_t characterId, const std::string_view name) override;
-	void UpdateLastLoggedInCharacter(const uint32_t characterId) override;
+	void InsertCharacterXml(const LWOOBJID accountId, const std::string_view lxfml) override;
+	std::vector<LWOOBJID> GetAccountCharacterIds(LWOOBJID accountId) override;
+	void DeleteCharacter(const LWOOBJID characterId) override;
+	void SetCharacterName(const LWOOBJID characterId, const std::string_view name) override;
+	void SetPendingCharacterName(const LWOOBJID characterId, const std::string_view name) override;
+	void UpdateLastLoggedInCharacter(const LWOOBJID characterId) override;
 	void SetPetNameModerationStatus(const LWOOBJID& petId, const IPetNames::Info& info) override;
 	std::optional<IPetNames::Info> GetPetNameInfo(const LWOOBJID& petId) override;
 	std::optional<IProperty::Info> GetPropertyInfo(const LWOMAPID mapId, const LWOCLONEID cloneId) override;
@@ -85,14 +85,14 @@ public:
 		std::stringstream& sd0Data,
 		const uint32_t blueprintId,
 		const uint32_t accountId,
-		const uint32_t characterId) override;
-	std::vector<MailInfo> GetMailForPlayer(const uint32_t characterId, const uint32_t numberOfMail) override;
+		const LWOOBJID characterId) override;
+	std::vector<MailInfo> GetMailForPlayer(const LWOOBJID characterId, const uint32_t numberOfMail) override;
 	std::optional<MailInfo> GetMail(const uint64_t mailId) override;
-	uint32_t GetUnreadMailCount(const uint32_t characterId) override;
+	uint32_t GetUnreadMailCount(const LWOOBJID characterId) override;
 	void MarkMailRead(const uint64_t mailId) override;
 	void DeleteMail(const uint64_t mailId) override;
 	void ClaimMailItem(const uint64_t mailId) override;
-	void InsertSlashCommandUsage(const uint32_t characterId, const std::string_view command) override;
+	void InsertSlashCommandUsage(const LWOOBJID characterId, const std::string_view command) override;
 	void UpdateAccountUnmuteTime(const uint32_t accountId, const uint64_t timeToUnmute) override;
 	void UpdateAccountBan(const uint32_t accountId, const bool banned) override;
 	void UpdateAccountPassword(const uint32_t accountId, const std::string_view bcryptpassword) override;
@@ -104,9 +104,9 @@ public:
 	std::optional<uint32_t> GetDonationTotal(const uint32_t activityId) override;
 	std::optional<bool> IsPlaykeyActive(const int32_t playkeyId) override;
 	std::vector<IUgc::Model> GetUgcModels(const LWOOBJID& propertyId) override;
-	void AddIgnore(const uint32_t playerId, const uint32_t ignoredPlayerId) override;
-	void RemoveIgnore(const uint32_t playerId, const uint32_t ignoredPlayerId) override;
-	std::vector<IIgnoreList::Info> GetIgnoreList(const uint32_t playerId) override;
+	void AddIgnore(const LWOOBJID playerId, const LWOOBJID ignoredPlayerId) override;
+	void RemoveIgnore(const LWOOBJID playerId, const LWOOBJID ignoredPlayerId) override;
+	std::vector<IIgnoreList::Info> GetIgnoreList(const LWOOBJID playerId) override;
 	void InsertRewardCode(const uint32_t account_id, const uint32_t reward_code) override;
 	std::vector<uint32_t> GetRewardCodesByAccountID(const uint32_t account_id) override;
 	void AddBehavior(const IBehaviors::Info& info) override;
@@ -118,12 +118,12 @@ public:
 	std::vector<ILeaderboard::Entry> GetAscendingLeaderboard(const uint32_t activityId) override;
 	std::vector<ILeaderboard::Entry> GetNsLeaderboard(const uint32_t activityId) override;
 	std::vector<ILeaderboard::Entry> GetAgsLeaderboard(const uint32_t activityId) override;
-	void SaveScore(const uint32_t playerId, const uint32_t gameId, const Score& score) override;
-	void UpdateScore(const uint32_t playerId, const uint32_t gameId, const Score& score) override;
-	std::optional<ILeaderboard::Score> GetPlayerScore(const uint32_t playerId, const uint32_t gameId) override;
-	void IncrementNumWins(const uint32_t playerId, const uint32_t gameId) override;
-	void IncrementTimesPlayed(const uint32_t playerId, const uint32_t gameId) override;
-	void InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<uint32_t> characterId) override;
+	void SaveScore(const LWOOBJID playerId, const uint32_t gameId, const Score& score) override;
+	void UpdateScore(const LWOOBJID playerId, const uint32_t gameId, const Score& score) override;
+	std::optional<ILeaderboard::Score> GetPlayerScore(const LWOOBJID playerId, const uint32_t gameId) override;
+	void IncrementNumWins(const LWOOBJID playerId, const uint32_t gameId) override;
+	void IncrementTimesPlayed(const LWOOBJID playerId, const uint32_t gameId) override;
+	void InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<LWOOBJID> characterId) override;
 	void DeleteUgcBuild(const LWOOBJID bigId) override;
 	uint32_t GetAccountCount() override;
 	bool IsNameInUse(const std::string_view name) override;
@@ -262,6 +262,17 @@ inline void SetParam(UniquePreppedStmtRef stmt, const int index, const std::opti
 	if (param) {
 		// LOG("%d", param.value());
 		stmt->setInt(index, param.value());
+	} else {
+		// LOG("Null");
+		stmt->setNull(index, sql::DataType::SQLNULL);
+	}
+}
+
+template<>
+inline void SetParam(UniquePreppedStmtRef stmt, const int index, const std::optional<LWOOBJID> param) {
+	if (param) {
+		// LOG("%d", param.value());
+		stmt->setInt64(index, param.value());
 	} else {
 		// LOG("Null");
 		stmt->setNull(index, sql::DataType::SQLNULL);

--- a/dDatabase/GameDatabase/MySQL/Tables/ActivityLog.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/ActivityLog.cpp
@@ -1,6 +1,6 @@
 #include "MySQLDatabase.h"
 
-void MySQLDatabase::UpdateActivityLog(const uint32_t characterId, const eActivityType activityType, const LWOMAPID mapId) {
+void MySQLDatabase::UpdateActivityLog(const LWOOBJID characterId, const eActivityType activityType, const LWOMAPID mapId) {
 	ExecuteInsert("INSERT INTO activity_log (character_id, activity, time, map_id) VALUES (?, ?, ?, ?);",
 		characterId, static_cast<uint32_t>(activityType), static_cast<uint32_t>(time(NULL)), mapId);
 }

--- a/dDatabase/GameDatabase/MySQL/Tables/CharInfo.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/CharInfo.cpp
@@ -19,7 +19,7 @@ std::optional<ICharInfo::Info> CharInfoFromQueryResult(std::unique_ptr<sql::Resu
 
 	ICharInfo::Info toReturn;
 
-	toReturn.id = stmt->getUInt("id");
+	toReturn.id = stmt->getInt64("id");
 	toReturn.name = stmt->getString("name").c_str();
 	toReturn.pendingName = stmt->getString("pending_name").c_str();
 	toReturn.needsRename = stmt->getBoolean("needs_rename");
@@ -30,7 +30,7 @@ std::optional<ICharInfo::Info> CharInfoFromQueryResult(std::unique_ptr<sql::Resu
 	return toReturn;
 }
 
-std::optional<ICharInfo::Info> MySQLDatabase::GetCharacterInfo(const uint32_t charId) {
+std::optional<ICharInfo::Info> MySQLDatabase::GetCharacterInfo(const LWOOBJID charId) {
 	return CharInfoFromQueryResult(
 		ExecuteSelect("SELECT name, pending_name, needs_rename, prop_clone_id, permission_map, id, account_id FROM charinfo WHERE id = ? LIMIT 1;", charId)
 	);
@@ -42,13 +42,13 @@ std::optional<ICharInfo::Info> MySQLDatabase::GetCharacterInfo(const std::string
 	);
 }
 
-std::vector<uint32_t> MySQLDatabase::GetAccountCharacterIds(const uint32_t accountId) {
+std::vector<LWOOBJID> MySQLDatabase::GetAccountCharacterIds(const LWOOBJID accountId) {
 	auto result = ExecuteSelect("SELECT id FROM charinfo WHERE account_id = ? ORDER BY last_login DESC LIMIT 4;", accountId);
 
-	std::vector<uint32_t> toReturn;
+	std::vector<LWOOBJID> toReturn;
 	toReturn.reserve(result->rowsCount());
 	while (result->next()) {
-		toReturn.push_back(result->getUInt("id"));
+		toReturn.push_back(result->getInt64("id"));
 	}
 
 	return toReturn;
@@ -65,15 +65,15 @@ void MySQLDatabase::InsertNewCharacter(const ICharInfo::Info info) {
 		static_cast<uint32_t>(time(NULL)));
 }
 
-void MySQLDatabase::SetCharacterName(const uint32_t characterId, const std::string_view name) {
+void MySQLDatabase::SetCharacterName(const LWOOBJID characterId, const std::string_view name) {
 	ExecuteUpdate("UPDATE charinfo SET name = ?, pending_name = '', needs_rename = 0, last_login = ? WHERE id = ? LIMIT 1;", name, static_cast<uint32_t>(time(NULL)), characterId);
 }
 
-void MySQLDatabase::SetPendingCharacterName(const uint32_t characterId, const std::string_view name) {
+void MySQLDatabase::SetPendingCharacterName(const LWOOBJID characterId, const std::string_view name) {
 	ExecuteUpdate("UPDATE charinfo SET pending_name = ?, needs_rename = 0, last_login = ? WHERE id = ? LIMIT 1", name, static_cast<uint32_t>(time(NULL)), characterId);
 }
 
-void MySQLDatabase::UpdateLastLoggedInCharacter(const uint32_t characterId) {
+void MySQLDatabase::UpdateLastLoggedInCharacter(const LWOOBJID characterId) {
 	ExecuteUpdate("UPDATE charinfo SET last_login = ? WHERE id = ? LIMIT 1", static_cast<uint32_t>(time(NULL)), characterId);
 }
 

--- a/dDatabase/GameDatabase/MySQL/Tables/CharXml.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/CharXml.cpp
@@ -1,6 +1,6 @@
 #include "MySQLDatabase.h"
 
-std::string MySQLDatabase::GetCharacterXml(const uint32_t charId) {
+std::string MySQLDatabase::GetCharacterXml(const LWOOBJID charId) {
 	auto result = ExecuteSelect("SELECT xml_data FROM charxml WHERE id = ? LIMIT 1;", charId);
 
 	if (!result->next()) {
@@ -10,10 +10,10 @@ std::string MySQLDatabase::GetCharacterXml(const uint32_t charId) {
 	return result->getString("xml_data").c_str();
 }
 
-void MySQLDatabase::UpdateCharacterXml(const uint32_t charId, const std::string_view lxfml) {
+void MySQLDatabase::UpdateCharacterXml(const LWOOBJID charId, const std::string_view lxfml) {
 	ExecuteUpdate("UPDATE charxml SET xml_data = ? WHERE id = ?;", lxfml, charId);
 }
 
-void MySQLDatabase::InsertCharacterXml(const uint32_t characterId, const std::string_view lxfml) {
+void MySQLDatabase::InsertCharacterXml(const LWOOBJID characterId, const std::string_view lxfml) {
 	ExecuteInsert("INSERT INTO `charxml` (`id`, `xml_data`) VALUES (?,?)", characterId, lxfml);
 }

--- a/dDatabase/GameDatabase/MySQL/Tables/CommandLog.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/CommandLog.cpp
@@ -1,5 +1,5 @@
 #include "MySQLDatabase.h"
 
-void MySQLDatabase::InsertSlashCommandUsage(const uint32_t characterId, const std::string_view command) {
+void MySQLDatabase::InsertSlashCommandUsage(const LWOOBJID characterId, const std::string_view command) {
 	ExecuteInsert("INSERT INTO command_log (character_id, command) VALUES (?, ?);", characterId, command);
 }

--- a/dDatabase/GameDatabase/MySQL/Tables/IgnoreList.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/IgnoreList.cpp
@@ -1,22 +1,22 @@
 #include "MySQLDatabase.h"
 
-std::vector<IIgnoreList::Info> MySQLDatabase::GetIgnoreList(const uint32_t playerId) {
+std::vector<IIgnoreList::Info> MySQLDatabase::GetIgnoreList(const LWOOBJID playerId) {
 	auto result = ExecuteSelect("SELECT ci.name AS name, il.ignored_player_id AS ignore_id FROM ignore_list AS il JOIN charinfo AS ci ON il.ignored_player_id = ci.id WHERE il.player_id = ?", playerId);
 
 	std::vector<IIgnoreList::Info> ignoreList;
 
 	ignoreList.reserve(result->rowsCount());
 	while (result->next()) {
-		ignoreList.push_back(IIgnoreList::Info{ result->getString("name").c_str(), result->getUInt("ignore_id") });
+		ignoreList.push_back(IIgnoreList::Info{ result->getString("name").c_str(), result->getInt64("ignore_id") });
 	}
 
 	return ignoreList;
 }
 
-void MySQLDatabase::AddIgnore(const uint32_t playerId, const uint32_t ignoredPlayerId) {
+void MySQLDatabase::AddIgnore(const LWOOBJID playerId, const LWOOBJID ignoredPlayerId) {
 	ExecuteInsert("INSERT IGNORE INTO ignore_list (player_id, ignored_player_id) VALUES (?, ?)", playerId, ignoredPlayerId);
 }
 
-void MySQLDatabase::RemoveIgnore(const uint32_t playerId, const uint32_t ignoredPlayerId) {
+void MySQLDatabase::RemoveIgnore(const LWOOBJID playerId, const LWOOBJID ignoredPlayerId) {
 	ExecuteDelete("DELETE FROM ignore_list WHERE player_id = ? AND ignored_player_id = ?", playerId, ignoredPlayerId);
 }

--- a/dDatabase/GameDatabase/MySQL/Tables/Leaderboard.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/Leaderboard.cpp
@@ -21,7 +21,7 @@ std::vector<ILeaderboard::Entry> ProcessQuery(UniqueResultSet& rows) {
 	while (rows->next()) {
 		auto& entry = entries.emplace_back();
 
-		entry.charId = rows->getUInt("character_id");
+		entry.charId = rows->getUInt64("character_id");
 		entry.lastPlayedTimestamp = rows->getUInt("lp_unix");
 		entry.primaryScore = rows->getFloat("primaryScore");
 		entry.secondaryScore = rows->getFloat("secondaryScore");
@@ -58,21 +58,21 @@ std::vector<ILeaderboard::Entry> MySQLDatabase::GetNsLeaderboard(const uint32_t 
 	return ProcessQuery(leaderboard);
 }
 
-void MySQLDatabase::SaveScore(const uint32_t playerId, const uint32_t gameId, const Score& score) {
+void MySQLDatabase::SaveScore(const LWOOBJID playerId, const uint32_t gameId, const Score& score) {
 	ExecuteInsert("INSERT leaderboard SET primaryScore = ?, secondaryScore = ?, tertiaryScore = ?, character_id = ?, game_id = ?;",
 		score.primaryScore, score.secondaryScore, score.tertiaryScore, playerId, gameId);
 }
 
-void MySQLDatabase::UpdateScore(const uint32_t playerId, const uint32_t gameId, const Score& score) {
+void MySQLDatabase::UpdateScore(const LWOOBJID playerId, const uint32_t gameId, const Score& score) {
 	ExecuteInsert("UPDATE leaderboard SET primaryScore = ?, secondaryScore = ?, tertiaryScore = ?, timesPlayed = timesPlayed + 1 WHERE character_id = ? AND game_id = ?;",
 		score.primaryScore, score.secondaryScore, score.tertiaryScore, playerId, gameId);
 }
 
-void MySQLDatabase::IncrementTimesPlayed(const uint32_t playerId, const uint32_t gameId) {
+void MySQLDatabase::IncrementTimesPlayed(const LWOOBJID playerId, const uint32_t gameId) {
 	ExecuteUpdate("UPDATE leaderboard SET timesPlayed = timesPlayed + 1 WHERE character_id = ? AND game_id = ?;", playerId, gameId);
 }
 
-std::optional<ILeaderboard::Score> MySQLDatabase::GetPlayerScore(const uint32_t playerId, const uint32_t gameId) {
+std::optional<ILeaderboard::Score> MySQLDatabase::GetPlayerScore(const LWOOBJID playerId, const uint32_t gameId) {
 	std::optional<ILeaderboard::Score> toReturn = std::nullopt;
 	auto res = ExecuteSelect("SELECT * FROM leaderboard WHERE character_id = ? AND game_id = ?;", playerId, gameId);
 	if (res->next()) {
@@ -86,6 +86,6 @@ std::optional<ILeaderboard::Score> MySQLDatabase::GetPlayerScore(const uint32_t 
 	return toReturn;
 }
 
-void MySQLDatabase::IncrementNumWins(const uint32_t playerId, const uint32_t gameId) {
+void MySQLDatabase::IncrementNumWins(const LWOOBJID playerId, const uint32_t gameId) {
 	ExecuteUpdate("UPDATE leaderboard SET numWins = numWins + 1 WHERE character_id = ? AND game_id = ?;", playerId, gameId);
 }

--- a/dDatabase/GameDatabase/MySQL/Tables/Mail.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/Mail.cpp
@@ -19,7 +19,7 @@ void MySQLDatabase::InsertNewMail(const MailInfo& mail) {
 		mail.itemCount);
 }
 
-std::vector<MailInfo> MySQLDatabase::GetMailForPlayer(const uint32_t characterId, const uint32_t numberOfMail) {
+std::vector<MailInfo> MySQLDatabase::GetMailForPlayer(const LWOOBJID characterId, const uint32_t numberOfMail) {
 	auto res = ExecuteSelect(
 		"SELECT id, subject, body, sender_name, attachment_id, attachment_lot, attachment_subkey, attachment_count, was_read, time_sent"
 		" FROM mail WHERE receiver_id=? limit ?;",
@@ -61,7 +61,7 @@ std::optional<MailInfo> MySQLDatabase::GetMail(const uint64_t mailId) {
 	return toReturn;
 }
 
-uint32_t MySQLDatabase::GetUnreadMailCount(const uint32_t characterId) {
+uint32_t MySQLDatabase::GetUnreadMailCount(const LWOOBJID characterId) {
 	auto res = ExecuteSelect("SELECT COUNT(*) AS number_unread FROM mail WHERE receiver_id=? AND was_read=0;", characterId);
 
 	if (!res->next()) {

--- a/dDatabase/GameDatabase/MySQL/Tables/Property.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/Property.cpp
@@ -119,7 +119,7 @@ std::optional<IProperty::PropertyEntranceResult> MySQLDatabase::GetProperties(co
 		if (!result) result = IProperty::PropertyEntranceResult();
 		auto& entry = result->entries.emplace_back();
 		entry.id = properties->getUInt64("id");
-		entry.ownerId = properties->getUInt64("owner_id");
+		entry.ownerId = properties->getInt64("owner_id");
 		entry.cloneId = properties->getUInt64("clone_id");
 		entry.name = properties->getString("name").c_str();
 		entry.description = properties->getString("description").c_str();
@@ -146,7 +146,7 @@ std::optional<IProperty::Info> MySQLDatabase::GetPropertyInfo(const LWOMAPID map
 
 	IProperty::Info toReturn;
 	toReturn.id = propertyEntry->getUInt64("id");
-	toReturn.ownerId = propertyEntry->getUInt64("owner_id");
+	toReturn.ownerId = propertyEntry->getInt64("owner_id");
 	toReturn.cloneId = propertyEntry->getUInt64("clone_id");
 	toReturn.name = propertyEntry->getString("name").c_str();
 	toReturn.description = propertyEntry->getString("description").c_str();

--- a/dDatabase/GameDatabase/MySQL/Tables/Ugc.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/Ugc.cpp
@@ -48,7 +48,7 @@ void MySQLDatabase::InsertNewUgcModel(
 	std:: stringstream& sd0Data, // cant be const sad
 	const uint32_t blueprintId,
 	const uint32_t accountId,
-	const uint32_t characterId) {
+	const LWOOBJID characterId) {
 	const std::istream stream(sd0Data.rdbuf());
 	ExecuteInsert(
 		"INSERT INTO `ugc`(`id`, `account_id`, `character_id`, `is_optimized`, `lxfml`, `bake_ao`, `filename`) VALUES (?,?,?,?,?,?,?)",

--- a/dDatabase/GameDatabase/MySQL/Tables/UgcModularBuild.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/UgcModularBuild.cpp
@@ -1,6 +1,6 @@
 #include "MySQLDatabase.h"
 
-void MySQLDatabase::InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<uint32_t> characterId) {
+void MySQLDatabase::InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<LWOOBJID> characterId) {
 	ExecuteInsert("INSERT INTO ugc_modular_build (ugc_id, ldf_config, character_id) VALUES (?,?,?)", bigId, modules, characterId);
 }
 

--- a/dDatabase/GameDatabase/SQLite/SQLiteDatabase.cpp
+++ b/dDatabase/GameDatabase/SQLite/SQLiteDatabase.cpp
@@ -67,7 +67,7 @@ void SQLiteDatabase::SetAutoCommit(bool value) {
 	}
 }
 
-void SQLiteDatabase::DeleteCharacter(const uint32_t characterId) {
+void SQLiteDatabase::DeleteCharacter(const LWOOBJID characterId) {
 	ExecuteDelete("DELETE FROM charxml WHERE id=?;", characterId);
 	ExecuteDelete("DELETE FROM command_log WHERE character_id=?;", characterId);
 	ExecuteDelete("DELETE FROM friends WHERE player_id=? OR friend_id=?;", characterId, characterId);

--- a/dDatabase/GameDatabase/SQLite/SQLiteDatabase.h
+++ b/dDatabase/GameDatabase/SQLite/SQLiteDatabase.h
@@ -38,31 +38,31 @@ public:
 
 	std::vector<std::string> GetApprovedCharacterNames() override;
 
-	std::vector<FriendData> GetFriendsList(uint32_t charID) override;
+	std::vector<FriendData> GetFriendsList(LWOOBJID charID) override;
 
-	std::optional<IFriends::BestFriendStatus> GetBestFriendStatus(const uint32_t playerCharacterId, const uint32_t friendCharacterId) override;
-	void SetBestFriendStatus(const uint32_t playerAccountId, const uint32_t friendAccountId, const uint32_t bestFriendStatus) override;
-	void AddFriend(const uint32_t playerAccountId, const uint32_t friendAccountId) override;
-	void RemoveFriend(const uint32_t playerAccountId, const uint32_t friendAccountId) override;
-	void UpdateActivityLog(const uint32_t characterId, const eActivityType activityType, const LWOMAPID mapId) override;
+	std::optional<IFriends::BestFriendStatus> GetBestFriendStatus(const LWOOBJID playerCharacterId, const LWOOBJID friendCharacterId) override;
+	void SetBestFriendStatus(const LWOOBJID playerAccountId, const LWOOBJID friendAccountId, const uint32_t bestFriendStatus) override;
+	void AddFriend(const LWOOBJID playerAccountId, const LWOOBJID friendAccountId) override;
+	void RemoveFriend(const LWOOBJID playerAccountId, const LWOOBJID friendAccountId) override;
+	void UpdateActivityLog(const LWOOBJID characterId, const eActivityType activityType, const LWOMAPID mapId) override;
 	void DeleteUgcModelData(const LWOOBJID& modelId) override;
 	void UpdateUgcModelData(const LWOOBJID& modelId, std::stringstream& lxfml) override;
 	std::vector<IUgc::Model> GetAllUgcModels() override;
 	void CreateMigrationHistoryTable() override;
 	bool IsMigrationRun(const std::string_view str) override;
 	void InsertMigration(const std::string_view str) override;
-	std::optional<ICharInfo::Info> GetCharacterInfo(const uint32_t charId) override;
+	std::optional<ICharInfo::Info> GetCharacterInfo(const LWOOBJID charId) override;
 	std::optional<ICharInfo::Info> GetCharacterInfo(const std::string_view charId) override;
-	std::string GetCharacterXml(const uint32_t accountId) override;
-	void UpdateCharacterXml(const uint32_t characterId, const std::string_view lxfml) override;
+	std::string GetCharacterXml(const LWOOBJID accountId) override;
+	void UpdateCharacterXml(const LWOOBJID characterId, const std::string_view lxfml) override;
 	std::optional<IAccounts::Info> GetAccountInfo(const std::string_view username) override;
 	void InsertNewCharacter(const ICharInfo::Info info) override;
-	void InsertCharacterXml(const uint32_t accountId, const std::string_view lxfml) override;
-	std::vector<uint32_t> GetAccountCharacterIds(uint32_t accountId) override;
-	void DeleteCharacter(const uint32_t characterId) override;
-	void SetCharacterName(const uint32_t characterId, const std::string_view name) override;
-	void SetPendingCharacterName(const uint32_t characterId, const std::string_view name) override;
-	void UpdateLastLoggedInCharacter(const uint32_t characterId) override;
+	void InsertCharacterXml(const LWOOBJID accountId, const std::string_view lxfml) override;
+	std::vector<LWOOBJID> GetAccountCharacterIds(LWOOBJID accountId) override;
+	void DeleteCharacter(const LWOOBJID characterId) override;
+	void SetCharacterName(const LWOOBJID characterId, const std::string_view name) override;
+	void SetPendingCharacterName(const LWOOBJID characterId, const std::string_view name) override;
+	void UpdateLastLoggedInCharacter(const LWOOBJID characterId) override;
 	void SetPetNameModerationStatus(const LWOOBJID& petId, const IPetNames::Info& info) override;
 	std::optional<IPetNames::Info> GetPetNameInfo(const LWOOBJID& petId) override;
 	std::optional<IProperty::Info> GetPropertyInfo(const LWOMAPID mapId, const LWOCLONEID cloneId) override;
@@ -83,14 +83,14 @@ public:
 		std::stringstream& sd0Data,
 		const uint32_t blueprintId,
 		const uint32_t accountId,
-		const uint32_t characterId) override;
-	std::vector<MailInfo> GetMailForPlayer(const uint32_t characterId, const uint32_t numberOfMail) override;
+		const LWOOBJID characterId) override;
+	std::vector<MailInfo> GetMailForPlayer(const LWOOBJID characterId, const uint32_t numberOfMail) override;
 	std::optional<MailInfo> GetMail(const uint64_t mailId) override;
-	uint32_t GetUnreadMailCount(const uint32_t characterId) override;
+	uint32_t GetUnreadMailCount(const LWOOBJID characterId) override;
 	void MarkMailRead(const uint64_t mailId) override;
 	void DeleteMail(const uint64_t mailId) override;
 	void ClaimMailItem(const uint64_t mailId) override;
-	void InsertSlashCommandUsage(const uint32_t characterId, const std::string_view command) override;
+	void InsertSlashCommandUsage(const LWOOBJID characterId, const std::string_view command) override;
 	void UpdateAccountUnmuteTime(const uint32_t accountId, const uint64_t timeToUnmute) override;
 	void UpdateAccountBan(const uint32_t accountId, const bool banned) override;
 	void UpdateAccountPassword(const uint32_t accountId, const std::string_view bcryptpassword) override;
@@ -102,9 +102,9 @@ public:
 	std::optional<uint32_t> GetDonationTotal(const uint32_t activityId) override;
 	std::optional<bool> IsPlaykeyActive(const int32_t playkeyId) override;
 	std::vector<IUgc::Model> GetUgcModels(const LWOOBJID& propertyId) override;
-	void AddIgnore(const uint32_t playerId, const uint32_t ignoredPlayerId) override;
-	void RemoveIgnore(const uint32_t playerId, const uint32_t ignoredPlayerId) override;
-	std::vector<IIgnoreList::Info> GetIgnoreList(const uint32_t playerId) override;
+	void AddIgnore(const LWOOBJID playerId, const LWOOBJID ignoredPlayerId) override;
+	void RemoveIgnore(const LWOOBJID playerId, const LWOOBJID ignoredPlayerId) override;
+	std::vector<IIgnoreList::Info> GetIgnoreList(const LWOOBJID playerId) override;
 	void InsertRewardCode(const uint32_t account_id, const uint32_t reward_code) override;
 	std::vector<uint32_t> GetRewardCodesByAccountID(const uint32_t account_id) override;
 	void AddBehavior(const IBehaviors::Info& info) override;
@@ -116,12 +116,12 @@ public:
 	std::vector<ILeaderboard::Entry> GetAscendingLeaderboard(const uint32_t activityId) override;
 	std::vector<ILeaderboard::Entry> GetNsLeaderboard(const uint32_t activityId) override;
 	std::vector<ILeaderboard::Entry> GetAgsLeaderboard(const uint32_t activityId) override;
-	void SaveScore(const uint32_t playerId, const uint32_t gameId, const Score& score) override;
-	void UpdateScore(const uint32_t playerId, const uint32_t gameId, const Score& score) override;
-	std::optional<ILeaderboard::Score> GetPlayerScore(const uint32_t playerId, const uint32_t gameId) override;
-	void IncrementNumWins(const uint32_t playerId, const uint32_t gameId) override;
-	void IncrementTimesPlayed(const uint32_t playerId, const uint32_t gameId) override;
-	void InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<uint32_t> characterId) override;
+	void SaveScore(const LWOOBJID playerId, const uint32_t gameId, const Score& score) override;
+	void UpdateScore(const LWOOBJID playerId, const uint32_t gameId, const Score& score) override;
+	std::optional<ILeaderboard::Score> GetPlayerScore(const LWOOBJID playerId, const uint32_t gameId) override;
+	void IncrementNumWins(const LWOOBJID playerId, const uint32_t gameId) override;
+	void IncrementTimesPlayed(const LWOOBJID playerId, const uint32_t gameId) override;
+	void InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<LWOOBJID> characterId) override;
 	void DeleteUgcBuild(const LWOOBJID bigId) override;
 	uint32_t GetAccountCount() override;
 	bool IsNameInUse(const std::string_view name) override;
@@ -264,6 +264,17 @@ inline void SetParam(PreppedStmtRef stmt, const int index, const std::optional<u
 	if (param) {
 		LOG("%d", param.value());
 		stmt.bind(index, static_cast<int>(param.value()));
+	} else {
+		LOG("Null");
+		stmt.bindNull(index);
+	}
+}
+
+template<>
+inline void SetParam(PreppedStmtRef stmt, const int index, const std::optional<LWOOBJID> param) {
+	if (param) {
+		LOG("%d", param.value());
+		stmt.bind(index, static_cast<sqlite_int64>(param.value()));
 	} else {
 		LOG("Null");
 		stmt.bindNull(index);

--- a/dDatabase/GameDatabase/SQLite/Tables/ActivityLog.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/ActivityLog.cpp
@@ -1,6 +1,6 @@
 #include "SQLiteDatabase.h"
 
-void SQLiteDatabase::UpdateActivityLog(const uint32_t characterId, const eActivityType activityType, const LWOMAPID mapId) {
+void SQLiteDatabase::UpdateActivityLog(const LWOOBJID characterId, const eActivityType activityType, const LWOMAPID mapId) {
 	ExecuteInsert("INSERT INTO activity_log (character_id, activity, time, map_id) VALUES (?, ?, ?, ?);",
 		characterId, static_cast<uint32_t>(activityType), static_cast<uint32_t>(time(NULL)), mapId);
 }

--- a/dDatabase/GameDatabase/SQLite/Tables/CharInfo.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/CharInfo.cpp
@@ -20,7 +20,7 @@ std::optional<ICharInfo::Info> CharInfoFromQueryResult(CppSQLite3Query stmt) {
 
 	ICharInfo::Info toReturn;
 
-	toReturn.id = stmt.getIntField("id");
+	toReturn.id = stmt.getInt64Field("id");
 	toReturn.name = stmt.getStringField("name");
 	toReturn.pendingName = stmt.getStringField("pending_name");
 	toReturn.needsRename = stmt.getIntField("needs_rename");
@@ -31,7 +31,7 @@ std::optional<ICharInfo::Info> CharInfoFromQueryResult(CppSQLite3Query stmt) {
 	return toReturn;
 }
 
-std::optional<ICharInfo::Info> SQLiteDatabase::GetCharacterInfo(const uint32_t charId) {
+std::optional<ICharInfo::Info> SQLiteDatabase::GetCharacterInfo(const LWOOBJID charId) {
 	return CharInfoFromQueryResult(
 		ExecuteSelect("SELECT name, pending_name, needs_rename, prop_clone_id, permission_map, id, account_id FROM charinfo WHERE id = ? LIMIT 1;", charId).second
 	);
@@ -43,12 +43,12 @@ std::optional<ICharInfo::Info> SQLiteDatabase::GetCharacterInfo(const std::strin
 	);
 }
 
-std::vector<uint32_t> SQLiteDatabase::GetAccountCharacterIds(const uint32_t accountId) {
+std::vector<LWOOBJID> SQLiteDatabase::GetAccountCharacterIds(const LWOOBJID accountId) {
 	auto [_, result] = ExecuteSelect("SELECT id FROM charinfo WHERE account_id = ? ORDER BY last_login DESC LIMIT 4;", accountId);
 
-	std::vector<uint32_t> toReturn;
+	std::vector<LWOOBJID> toReturn;
 	while (!result.eof()) {
-		toReturn.push_back(result.getIntField("id"));
+		toReturn.push_back(result.getInt64Field("id"));
 		result.nextRow();
 	}
 
@@ -66,15 +66,15 @@ void SQLiteDatabase::InsertNewCharacter(const ICharInfo::Info info) {
 		static_cast<uint32_t>(time(NULL)));
 }
 
-void SQLiteDatabase::SetCharacterName(const uint32_t characterId, const std::string_view name) {
+void SQLiteDatabase::SetCharacterName(const LWOOBJID characterId, const std::string_view name) {
 	ExecuteUpdate("UPDATE charinfo SET name = ?, pending_name = '', needs_rename = 0, last_login = ? WHERE id = ?;", name, static_cast<uint32_t>(time(NULL)), characterId);
 }
 
-void SQLiteDatabase::SetPendingCharacterName(const uint32_t characterId, const std::string_view name) {
+void SQLiteDatabase::SetPendingCharacterName(const LWOOBJID characterId, const std::string_view name) {
 	ExecuteUpdate("UPDATE charinfo SET pending_name = ?, needs_rename = 0, last_login = ? WHERE id = ?;", name, static_cast<uint32_t>(time(NULL)), characterId);
 }
 
-void SQLiteDatabase::UpdateLastLoggedInCharacter(const uint32_t characterId) {
+void SQLiteDatabase::UpdateLastLoggedInCharacter(const LWOOBJID characterId) {
 	ExecuteUpdate("UPDATE charinfo SET last_login = ? WHERE id = ?;", static_cast<uint32_t>(time(NULL)), characterId);
 }
 

--- a/dDatabase/GameDatabase/SQLite/Tables/CharXml.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/CharXml.cpp
@@ -1,6 +1,6 @@
 #include "SQLiteDatabase.h"
 
-std::string SQLiteDatabase::GetCharacterXml(const uint32_t charId) {
+std::string SQLiteDatabase::GetCharacterXml(const LWOOBJID charId) {
 	auto [_, result] = ExecuteSelect("SELECT xml_data FROM charxml WHERE id = ? LIMIT 1;", charId);
 
 	if (result.eof()) {
@@ -10,10 +10,10 @@ std::string SQLiteDatabase::GetCharacterXml(const uint32_t charId) {
 	return result.getStringField("xml_data");
 }
 
-void SQLiteDatabase::UpdateCharacterXml(const uint32_t charId, const std::string_view lxfml) {
+void SQLiteDatabase::UpdateCharacterXml(const LWOOBJID charId, const std::string_view lxfml) {
 	ExecuteUpdate("UPDATE charxml SET xml_data = ? WHERE id = ?;", lxfml, charId);
 }
 
-void SQLiteDatabase::InsertCharacterXml(const uint32_t characterId, const std::string_view lxfml) {
+void SQLiteDatabase::InsertCharacterXml(const LWOOBJID characterId, const std::string_view lxfml) {
 	ExecuteInsert("INSERT INTO `charxml` (`id`, `xml_data`) VALUES (?,?)", characterId, lxfml);
 }

--- a/dDatabase/GameDatabase/SQLite/Tables/CommandLog.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/CommandLog.cpp
@@ -1,5 +1,5 @@
 #include "SQLiteDatabase.h"
 
-void SQLiteDatabase::InsertSlashCommandUsage(const uint32_t characterId, const std::string_view command) {
+void SQLiteDatabase::InsertSlashCommandUsage(const LWOOBJID characterId, const std::string_view command) {
 	ExecuteInsert("INSERT INTO command_log (character_id, command) VALUES (?, ?);", characterId, command);
 }

--- a/dDatabase/GameDatabase/SQLite/Tables/IgnoreList.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/IgnoreList.cpp
@@ -1,22 +1,22 @@
 #include "SQLiteDatabase.h"
 
-std::vector<IIgnoreList::Info> SQLiteDatabase::GetIgnoreList(const uint32_t playerId) {
+std::vector<IIgnoreList::Info> SQLiteDatabase::GetIgnoreList(const LWOOBJID playerId) {
 	auto [_, result] = ExecuteSelect("SELECT ci.name AS name, il.ignored_player_id AS ignore_id FROM ignore_list AS il JOIN charinfo AS ci ON il.ignored_player_id = ci.id WHERE il.player_id = ?", playerId);
 
 	std::vector<IIgnoreList::Info> ignoreList;
 
 	while (!result.eof()) {
-		ignoreList.push_back(IIgnoreList::Info{ result.getStringField("name"), static_cast<uint32_t>(result.getIntField("ignore_id")) });
+		ignoreList.push_back(IIgnoreList::Info{ result.getStringField("name"), result.getInt64Field("ignore_id") });
 		result.nextRow();
 	}
 
 	return ignoreList;
 }
 
-void SQLiteDatabase::AddIgnore(const uint32_t playerId, const uint32_t ignoredPlayerId) {
+void SQLiteDatabase::AddIgnore(const LWOOBJID playerId, const LWOOBJID ignoredPlayerId) {
 	ExecuteInsert("INSERT OR IGNORE INTO ignore_list (player_id, ignored_player_id) VALUES (?, ?)", playerId, ignoredPlayerId);
 }
 
-void SQLiteDatabase::RemoveIgnore(const uint32_t playerId, const uint32_t ignoredPlayerId) {
+void SQLiteDatabase::RemoveIgnore(const LWOOBJID playerId, const LWOOBJID ignoredPlayerId) {
 	ExecuteDelete("DELETE FROM ignore_list WHERE player_id = ? AND ignored_player_id = ?", playerId, ignoredPlayerId);
 }

--- a/dDatabase/GameDatabase/SQLite/Tables/Leaderboard.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/Leaderboard.cpp
@@ -20,7 +20,7 @@ std::vector<ILeaderboard::Entry> ProcessQuery(CppSQLite3Query& rows) {
 	while (!rows.eof()) {
 		auto& entry = entries.emplace_back();
 
-		entry.charId = rows.getIntField("character_id");
+		entry.charId = rows.getInt64Field("character_id");
 		entry.lastPlayedTimestamp = rows.getIntField("lp_unix");
 		entry.primaryScore = rows.getFloatField("primaryScore");
 		entry.secondaryScore = rows.getFloatField("secondaryScore");
@@ -58,17 +58,17 @@ std::vector<ILeaderboard::Entry> SQLiteDatabase::GetNsLeaderboard(const uint32_t
 	return ProcessQuery(result);
 }
 
-void SQLiteDatabase::SaveScore(const uint32_t playerId, const uint32_t gameId, const Score& score) {
+void SQLiteDatabase::SaveScore(const LWOOBJID playerId, const uint32_t gameId, const Score& score) {
 	ExecuteInsert("INSERT INTO leaderboard (primaryScore, secondaryScore, tertiaryScore, character_id, game_id, last_played) VALUES (?,?,?,?,?,CURRENT_TIMESTAMP) ;",
 		score.primaryScore, score.secondaryScore, score.tertiaryScore, playerId, gameId);
 }
 
-void SQLiteDatabase::UpdateScore(const uint32_t playerId, const uint32_t gameId, const Score& score) {
+void SQLiteDatabase::UpdateScore(const LWOOBJID playerId, const uint32_t gameId, const Score& score) {
 	ExecuteInsert("UPDATE leaderboard SET primaryScore = ?, secondaryScore = ?, tertiaryScore = ?, timesPlayed = timesPlayed + 1, last_played = CURRENT_TIMESTAMP WHERE character_id = ? AND game_id = ?;",
 		score.primaryScore, score.secondaryScore, score.tertiaryScore, playerId, gameId);
 }
 
-std::optional<ILeaderboard::Score> SQLiteDatabase::GetPlayerScore(const uint32_t playerId, const uint32_t gameId) {
+std::optional<ILeaderboard::Score> SQLiteDatabase::GetPlayerScore(const LWOOBJID playerId, const uint32_t gameId) {
 	std::optional<ILeaderboard::Score> toReturn = std::nullopt;
 	auto [_, res] = ExecuteSelect("SELECT * FROM leaderboard WHERE character_id = ? AND game_id = ?;", playerId, gameId);
 	if (!res.eof()) {
@@ -82,10 +82,10 @@ std::optional<ILeaderboard::Score> SQLiteDatabase::GetPlayerScore(const uint32_t
 	return toReturn;
 }
 
-void SQLiteDatabase::IncrementNumWins(const uint32_t playerId, const uint32_t gameId) {
+void SQLiteDatabase::IncrementNumWins(const LWOOBJID playerId, const uint32_t gameId) {
 	ExecuteUpdate("UPDATE leaderboard SET numWins = numWins + 1, last_played = CURRENT_TIMESTAMP WHERE character_id = ? AND game_id = ?;", playerId, gameId);
 }
 
-void SQLiteDatabase::IncrementTimesPlayed(const uint32_t playerId, const uint32_t gameId) {
+void SQLiteDatabase::IncrementTimesPlayed(const LWOOBJID playerId, const uint32_t gameId) {
 	ExecuteUpdate("UPDATE leaderboard SET timesPlayed = timesPlayed + 1, last_played = CURRENT_TIMESTAMP WHERE character_id = ? AND game_id = ?;", playerId, gameId);
 }

--- a/dDatabase/GameDatabase/SQLite/Tables/Mail.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/Mail.cpp
@@ -18,7 +18,7 @@ void SQLiteDatabase::InsertNewMail(const MailInfo& mail) {
 		mail.itemCount);
 }
 
-std::vector<MailInfo> SQLiteDatabase::GetMailForPlayer(const uint32_t characterId, const uint32_t numberOfMail) {
+std::vector<MailInfo> SQLiteDatabase::GetMailForPlayer(const LWOOBJID characterId, const uint32_t numberOfMail) {
 	auto [_, res] = ExecuteSelect(
 		"SELECT id, subject, body, sender_name, attachment_id, attachment_lot, attachment_subkey, attachment_count, was_read, time_sent"
 		" FROM mail WHERE receiver_id=? limit ?;",
@@ -60,7 +60,7 @@ std::optional<MailInfo> SQLiteDatabase::GetMail(const uint64_t mailId) {
 	return toReturn;
 }
 
-uint32_t SQLiteDatabase::GetUnreadMailCount(const uint32_t characterId) {
+uint32_t SQLiteDatabase::GetUnreadMailCount(const LWOOBJID characterId) {
 	auto [_, res] = ExecuteSelect("SELECT COUNT(*) AS number_unread FROM mail WHERE receiver_id=? AND was_read=0;", characterId);
 
 	if (res.eof()) {

--- a/dDatabase/GameDatabase/SQLite/Tables/Ugc.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/Ugc.cpp
@@ -49,7 +49,7 @@ void SQLiteDatabase::InsertNewUgcModel(
 	std::stringstream& sd0Data, // cant be const sad
 	const uint32_t blueprintId,
 	const uint32_t accountId,
-	const uint32_t characterId) {
+	const LWOOBJID characterId) {
 	const std::istream stream(sd0Data.rdbuf());
 	ExecuteInsert(
 		"INSERT INTO `ugc`(`id`, `account_id`, `character_id`, `is_optimized`, `lxfml`, `bake_ao`, `filename`) VALUES (?,?,?,?,?,?,?)",

--- a/dDatabase/GameDatabase/SQLite/Tables/UgcModularBuild.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/UgcModularBuild.cpp
@@ -1,6 +1,6 @@
 #include "SQLiteDatabase.h"
 
-void SQLiteDatabase::InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<uint32_t> characterId) {
+void SQLiteDatabase::InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<LWOOBJID> characterId) {
 	ExecuteInsert("INSERT INTO ugc_modular_build (ugc_id, ldf_config, character_id) VALUES (?,?,?)", bigId, modules, characterId);
 }
 

--- a/dDatabase/GameDatabase/TestSQL/TestSQLDatabase.cpp
+++ b/dDatabase/GameDatabase/TestSQL/TestSQLDatabase.cpp
@@ -32,27 +32,27 @@ std::vector<std::string> TestSQLDatabase::GetApprovedCharacterNames() {
 	return {};
 }
 
-std::vector<FriendData> TestSQLDatabase::GetFriendsList(uint32_t charID) {
+std::vector<FriendData> TestSQLDatabase::GetFriendsList(LWOOBJID charID) {
 	return {};
 }
 
-std::optional<IFriends::BestFriendStatus> TestSQLDatabase::GetBestFriendStatus(const uint32_t playerCharacterId, const uint32_t friendCharacterId) {
+std::optional<IFriends::BestFriendStatus> TestSQLDatabase::GetBestFriendStatus(const LWOOBJID playerCharacterId, const LWOOBJID friendCharacterId) {
 	return {};
 }
 
-void TestSQLDatabase::SetBestFriendStatus(const uint32_t playerAccountId, const uint32_t friendAccountId, const uint32_t bestFriendStatus) {
+void TestSQLDatabase::SetBestFriendStatus(const LWOOBJID playerAccountId, const LWOOBJID friendAccountId, const uint32_t bestFriendStatus) {
 
 }
 
-void TestSQLDatabase::AddFriend(const uint32_t playerAccountId, const uint32_t friendAccountId) {
+void TestSQLDatabase::AddFriend(const LWOOBJID playerAccountId, const LWOOBJID friendAccountId) {
 
 }
 
-void TestSQLDatabase::RemoveFriend(const uint32_t playerAccountId, const uint32_t friendAccountId) {
+void TestSQLDatabase::RemoveFriend(const LWOOBJID playerAccountId, const LWOOBJID friendAccountId) {
 
 }
 
-void TestSQLDatabase::UpdateActivityLog(const uint32_t characterId, const eActivityType activityType, const LWOMAPID mapId) {
+void TestSQLDatabase::UpdateActivityLog(const LWOOBJID characterId, const eActivityType activityType, const LWOMAPID mapId) {
 
 }
 
@@ -80,7 +80,7 @@ void TestSQLDatabase::InsertMigration(const std::string_view str) {
 
 }
 
-std::optional<ICharInfo::Info> TestSQLDatabase::GetCharacterInfo(const uint32_t charId) {
+std::optional<ICharInfo::Info> TestSQLDatabase::GetCharacterInfo(const LWOOBJID charId) {
 	return {};
 }
 
@@ -88,11 +88,11 @@ std::optional<ICharInfo::Info> TestSQLDatabase::GetCharacterInfo(const std::stri
 	return {};
 }
 
-std::string TestSQLDatabase::GetCharacterXml(const uint32_t accountId) {
+std::string TestSQLDatabase::GetCharacterXml(const LWOOBJID accountId) {
 	return {};
 }
 
-void TestSQLDatabase::UpdateCharacterXml(const uint32_t characterId, const std::string_view lxfml) {
+void TestSQLDatabase::UpdateCharacterXml(const LWOOBJID characterId, const std::string_view lxfml) {
 
 }
 
@@ -104,27 +104,27 @@ void TestSQLDatabase::InsertNewCharacter(const ICharInfo::Info info) {
 
 }
 
-void TestSQLDatabase::InsertCharacterXml(const uint32_t accountId, const std::string_view lxfml) {
+void TestSQLDatabase::InsertCharacterXml(const LWOOBJID accountId, const std::string_view lxfml) {
 
 }
 
-std::vector<uint32_t> TestSQLDatabase::GetAccountCharacterIds(uint32_t accountId) {
+std::vector<LWOOBJID> TestSQLDatabase::GetAccountCharacterIds(LWOOBJID accountId) {
 	return {};
 }
 
-void TestSQLDatabase::DeleteCharacter(const uint32_t characterId) {
+void TestSQLDatabase::DeleteCharacter(const LWOOBJID characterId) {
 
 }
 
-void TestSQLDatabase::SetCharacterName(const uint32_t characterId, const std::string_view name) {
+void TestSQLDatabase::SetCharacterName(const LWOOBJID characterId, const std::string_view name) {
 
 }
 
-void TestSQLDatabase::SetPendingCharacterName(const uint32_t characterId, const std::string_view name) {
+void TestSQLDatabase::SetPendingCharacterName(const LWOOBJID characterId, const std::string_view name) {
 
 }
 
-void TestSQLDatabase::UpdateLastLoggedInCharacter(const uint32_t characterId) {
+void TestSQLDatabase::UpdateLastLoggedInCharacter(const LWOOBJID characterId) {
 
 }
 
@@ -192,11 +192,11 @@ void TestSQLDatabase::InsertNewMail(const MailInfo& mail) {
 
 }
 
-void TestSQLDatabase::InsertNewUgcModel(std::stringstream& sd0Data, const uint32_t blueprintId, const uint32_t accountId, const uint32_t characterId) {
+void TestSQLDatabase::InsertNewUgcModel(std::stringstream& sd0Data, const uint32_t blueprintId, const uint32_t accountId, const LWOOBJID characterId) {
 
 }
 
-std::vector<MailInfo> TestSQLDatabase::GetMailForPlayer(const uint32_t characterId, const uint32_t numberOfMail) {
+std::vector<MailInfo> TestSQLDatabase::GetMailForPlayer(const LWOOBJID characterId, const uint32_t numberOfMail) {
 	return {};
 }
 
@@ -204,7 +204,7 @@ std::optional<MailInfo> TestSQLDatabase::GetMail(const uint64_t mailId) {
 	return {};
 }
 
-uint32_t TestSQLDatabase::GetUnreadMailCount(const uint32_t characterId) {
+uint32_t TestSQLDatabase::GetUnreadMailCount(const LWOOBJID characterId) {
 	return {};
 }
 
@@ -220,7 +220,7 @@ void TestSQLDatabase::ClaimMailItem(const uint64_t mailId) {
 
 }
 
-void TestSQLDatabase::InsertSlashCommandUsage(const uint32_t characterId, const std::string_view command) {
+void TestSQLDatabase::InsertSlashCommandUsage(const LWOOBJID characterId, const std::string_view command) {
 
 }
 
@@ -268,15 +268,15 @@ std::vector<IUgc::Model> TestSQLDatabase::GetUgcModels(const LWOOBJID& propertyI
 	return {};
 }
 
-void TestSQLDatabase::AddIgnore(const uint32_t playerId, const uint32_t ignoredPlayerId) {
+void TestSQLDatabase::AddIgnore(const LWOOBJID playerId, const LWOOBJID ignoredPlayerId) {
 
 }
 
-void TestSQLDatabase::RemoveIgnore(const uint32_t playerId, const uint32_t ignoredPlayerId) {
+void TestSQLDatabase::RemoveIgnore(const LWOOBJID playerId, const LWOOBJID ignoredPlayerId) {
 
 }
 
-std::vector<IIgnoreList::Info> TestSQLDatabase::GetIgnoreList(const uint32_t playerId) {
+std::vector<IIgnoreList::Info> TestSQLDatabase::GetIgnoreList(const LWOOBJID playerId) {
 	return {};
 }
 

--- a/dDatabase/GameDatabase/TestSQL/TestSQLDatabase.h
+++ b/dDatabase/GameDatabase/TestSQL/TestSQLDatabase.h
@@ -17,31 +17,31 @@ class TestSQLDatabase : public GameDatabase {
 
 	std::vector<std::string> GetApprovedCharacterNames() override;
 
-	std::vector<FriendData> GetFriendsList(uint32_t charID) override;
+	std::vector<FriendData> GetFriendsList(LWOOBJID charID) override;
 
-	std::optional<IFriends::BestFriendStatus> GetBestFriendStatus(const uint32_t playerCharacterId, const uint32_t friendCharacterId) override;
-	void SetBestFriendStatus(const uint32_t playerAccountId, const uint32_t friendAccountId, const uint32_t bestFriendStatus) override;
-	void AddFriend(const uint32_t playerAccountId, const uint32_t friendAccountId) override;
-	void RemoveFriend(const uint32_t playerAccountId, const uint32_t friendAccountId) override;
-	void UpdateActivityLog(const uint32_t characterId, const eActivityType activityType, const LWOMAPID mapId) override;
+	std::optional<IFriends::BestFriendStatus> GetBestFriendStatus(const LWOOBJID playerCharacterId, const LWOOBJID friendCharacterId) override;
+	void SetBestFriendStatus(const LWOOBJID playerAccountId, const LWOOBJID friendAccountId, const uint32_t bestFriendStatus) override;
+	void AddFriend(const LWOOBJID playerAccountId, const LWOOBJID friendAccountId) override;
+	void RemoveFriend(const LWOOBJID playerAccountId, const LWOOBJID friendAccountId) override;
+	void UpdateActivityLog(const LWOOBJID characterId, const eActivityType activityType, const LWOMAPID mapId) override;
 	void DeleteUgcModelData(const LWOOBJID& modelId) override;
 	void UpdateUgcModelData(const LWOOBJID& modelId, std::stringstream& lxfml) override;
 	std::vector<IUgc::Model> GetAllUgcModels() override;
 	void CreateMigrationHistoryTable() override;
 	bool IsMigrationRun(const std::string_view str) override;
 	void InsertMigration(const std::string_view str) override;
-	std::optional<ICharInfo::Info> GetCharacterInfo(const uint32_t charId) override;
+	std::optional<ICharInfo::Info> GetCharacterInfo(const LWOOBJID charId) override;
 	std::optional<ICharInfo::Info> GetCharacterInfo(const std::string_view charId) override;
-	std::string GetCharacterXml(const uint32_t accountId) override;
-	void UpdateCharacterXml(const uint32_t characterId, const std::string_view lxfml) override;
+	std::string GetCharacterXml(const LWOOBJID accountId) override;
+	void UpdateCharacterXml(const LWOOBJID characterId, const std::string_view lxfml) override;
 	std::optional<IAccounts::Info> GetAccountInfo(const std::string_view username) override;
 	void InsertNewCharacter(const ICharInfo::Info info) override;
-	void InsertCharacterXml(const uint32_t accountId, const std::string_view lxfml) override;
-	std::vector<uint32_t> GetAccountCharacterIds(uint32_t accountId) override;
-	void DeleteCharacter(const uint32_t characterId) override;
-	void SetCharacterName(const uint32_t characterId, const std::string_view name) override;
-	void SetPendingCharacterName(const uint32_t characterId, const std::string_view name) override;
-	void UpdateLastLoggedInCharacter(const uint32_t characterId) override;
+	void InsertCharacterXml(const LWOOBJID accountId, const std::string_view lxfml) override;
+	std::vector<LWOOBJID> GetAccountCharacterIds(LWOOBJID accountId) override;
+	void DeleteCharacter(const LWOOBJID characterId) override;
+	void SetCharacterName(const LWOOBJID characterId, const std::string_view name) override;
+	void SetPendingCharacterName(const LWOOBJID characterId, const std::string_view name) override;
+	void UpdateLastLoggedInCharacter(const LWOOBJID characterId) override;
 	void SetPetNameModerationStatus(const LWOOBJID& petId, const IPetNames::Info& info) override;
 	std::optional<IPetNames::Info> GetPetNameInfo(const LWOOBJID& petId) override;
 	std::optional<IProperty::Info> GetPropertyInfo(const LWOMAPID mapId, const LWOCLONEID cloneId) override;
@@ -62,14 +62,14 @@ class TestSQLDatabase : public GameDatabase {
 		std::stringstream& sd0Data,
 		const uint32_t blueprintId,
 		const uint32_t accountId,
-		const uint32_t characterId) override;
-	std::vector<MailInfo> GetMailForPlayer(const uint32_t characterId, const uint32_t numberOfMail) override;
+		const LWOOBJID characterId) override;
+	std::vector<MailInfo> GetMailForPlayer(const LWOOBJID characterId, const uint32_t numberOfMail) override;
 	std::optional<MailInfo> GetMail(const uint64_t mailId) override;
-	uint32_t GetUnreadMailCount(const uint32_t characterId) override;
+	uint32_t GetUnreadMailCount(const LWOOBJID characterId) override;
 	void MarkMailRead(const uint64_t mailId) override;
 	void DeleteMail(const uint64_t mailId) override;
 	void ClaimMailItem(const uint64_t mailId) override;
-	void InsertSlashCommandUsage(const uint32_t characterId, const std::string_view command) override;
+	void InsertSlashCommandUsage(const LWOOBJID characterId, const std::string_view command) override;
 	void UpdateAccountUnmuteTime(const uint32_t accountId, const uint64_t timeToUnmute) override;
 	void UpdateAccountBan(const uint32_t accountId, const bool banned) override;
 	void UpdateAccountPassword(const uint32_t accountId, const std::string_view bcryptpassword) override;
@@ -81,9 +81,9 @@ class TestSQLDatabase : public GameDatabase {
 	std::optional<uint32_t> GetDonationTotal(const uint32_t activityId) override;
 	std::optional<bool> IsPlaykeyActive(const int32_t playkeyId) override;
 	std::vector<IUgc::Model> GetUgcModels(const LWOOBJID& propertyId) override;
-	void AddIgnore(const uint32_t playerId, const uint32_t ignoredPlayerId) override;
-	void RemoveIgnore(const uint32_t playerId, const uint32_t ignoredPlayerId) override;
-	std::vector<IIgnoreList::Info> GetIgnoreList(const uint32_t playerId) override;
+	void AddIgnore(const LWOOBJID playerId, const LWOOBJID ignoredPlayerId) override;
+	void RemoveIgnore(const LWOOBJID playerId, const LWOOBJID ignoredPlayerId) override;
+	std::vector<IIgnoreList::Info> GetIgnoreList(const LWOOBJID playerId) override;
 	void InsertRewardCode(const uint32_t account_id, const uint32_t reward_code) override;
 	std::vector<uint32_t> GetRewardCodesByAccountID(const uint32_t account_id) override;
 	void AddBehavior(const IBehaviors::Info& info) override;
@@ -95,12 +95,12 @@ class TestSQLDatabase : public GameDatabase {
 	std::vector<ILeaderboard::Entry> GetAscendingLeaderboard(const uint32_t activityId) override { return {}; };
 	std::vector<ILeaderboard::Entry> GetNsLeaderboard(const uint32_t activityId) override { return {}; };
 	std::vector<ILeaderboard::Entry> GetAgsLeaderboard(const uint32_t activityId) override { return {}; };
-	void SaveScore(const uint32_t playerId, const uint32_t gameId, const Score& score) override {};
-	void UpdateScore(const uint32_t playerId, const uint32_t gameId, const Score& score) override {};
-	std::optional<ILeaderboard::Score> GetPlayerScore(const uint32_t playerId, const uint32_t gameId) override { return {}; };
-	void IncrementNumWins(const uint32_t playerId, const uint32_t gameId) override {};
-	void IncrementTimesPlayed(const uint32_t playerId, const uint32_t gameId) override {};
-	void InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<uint32_t> characterId) override {};
+	void SaveScore(const LWOOBJID playerId, const uint32_t gameId, const Score& score) override {};
+	void UpdateScore(const LWOOBJID playerId, const uint32_t gameId, const Score& score) override {};
+	std::optional<ILeaderboard::Score> GetPlayerScore(const LWOOBJID playerId, const uint32_t gameId) override { return {}; };
+	void IncrementNumWins(const LWOOBJID playerId, const uint32_t gameId) override {};
+	void IncrementTimesPlayed(const LWOOBJID playerId, const uint32_t gameId) override {};
+	void InsertUgcBuild(const std::string& modules, const LWOOBJID bigId, const std::optional<LWOOBJID> characterId) override {};
 	void DeleteUgcBuild(const LWOOBJID bigId) override {};
 	uint32_t GetAccountCount() override { return 0; };
 

--- a/dGame/Character.cpp
+++ b/dGame/Character.cpp
@@ -23,7 +23,7 @@
 #include "ePlayerFlag.h"
 #include "CDPlayerFlagsTable.h"
 
-Character::Character(uint32_t id, User* parentUser) {
+Character::Character(LWOOBJID id, User* parentUser) {
 	//First load the name, etc:
 	m_ID = id;
 	m_ParentUser = parentUser;
@@ -50,6 +50,10 @@ void Character::UpdateInfoFromDatabase() {
 
 	//Load the xmlData now:
 	m_XMLData = Database::Get()->GetCharacterXml(m_ID);
+	if (m_XMLData.empty()) {
+		LOG("Character %s (%llu) has no xml data!", m_Name.c_str(), m_ID);
+		return;
+	}
 
 	m_ZoneID = 0; //TEMP! Set back to 0 when done. This is so we can see loading screen progress for testing.
 	m_ZoneInstanceID = 0; //These values don't really matter, these are only used on the char select screen and seem unused.
@@ -61,7 +65,6 @@ void Character::UpdateInfoFromDatabase() {
 	//Set our objectID:
 	m_ObjectID = m_ID;
 	GeneralUtils::SetBit(m_ObjectID, eObjectBits::CHARACTER);
-	GeneralUtils::SetBit(m_ObjectID, eObjectBits::PERSISTENT);
 
 	m_OurEntity = nullptr;
 	m_BuildMode = false;
@@ -75,7 +78,7 @@ void Character::DoQuickXMLDataParse() {
 	if (m_XMLData.size() == 0) return;
 
 	if (m_Doc.Parse(m_XMLData.c_str(), m_XMLData.size()) == 0) {
-		LOG("Loaded xmlData for character %s (%i)!", m_Name.c_str(), m_ID);
+		LOG("Loaded xmlData for character %s (%llu)!", m_Name.c_str(), m_ID);
 	} else {
 		LOG("Failed to load xmlData (%i) (%s) (%s)!", m_Doc.ErrorID(), m_Doc.ErrorIDToName(m_Doc.ErrorID()), m_Doc.ErrorStr());
 		//Server::rakServer->CloseConnection(m_ParentUser->GetSystemAddress(), true);
@@ -238,7 +241,7 @@ void Character::SetBuildMode(bool buildMode) {
 void Character::SaveXMLToDatabase() {
 	// Check that we can actually _save_ before saving
 	if (!m_OurEntity) {
-		LOG("%i:%s didn't have an entity set while saving! CHARACTER WILL NOT BE SAVED!", this->GetID(), this->GetName().c_str());
+		LOG("%llu:%s didn't have an entity set while saving! CHARACTER WILL NOT BE SAVED!", this->GetID(), this->GetName().c_str());
 		return;
 	}
 
@@ -308,7 +311,7 @@ void Character::SaveXMLToDatabase() {
 	//For metrics, log the time it took to save:
 	auto end = std::chrono::system_clock::now();
 	std::chrono::duration<double> elapsed = end - start;
-	LOG("%i:%s Saved character to Database in: %fs", this->GetID(), this->GetName().c_str(), elapsed.count());
+	LOG("%llu:%s Saved character to Database in: %fs", this->GetID(), this->GetName().c_str(), elapsed.count());
 }
 
 void Character::SetIsNewLogin() {
@@ -320,7 +323,7 @@ void Character::SetIsNewLogin() {
 	while (currentChild) {
 		auto* nextChild = currentChild->NextSiblingElement();
 		if (currentChild->Attribute("si")) {
-			LOG("Removed session flag (%s) from character %i:%s, saving character to database", currentChild->Attribute("si"), GetID(), GetName().c_str());
+			LOG("Removed session flag (%s) from character %llu:%s, saving character to database", currentChild->Attribute("si"), GetID(), GetName().c_str());
 			flags->DeleteChild(currentChild);
 			WriteToDatabase();
 		}

--- a/dGame/Character.h
+++ b/dGame/Character.h
@@ -23,7 +23,7 @@ enum class eLootSourceType : uint32_t;
  */
 class Character {
 public:
-	Character(uint32_t id, User* parentUser);
+	Character(LWOOBJID id, User* parentUser);
 	~Character();
 
 	/**
@@ -53,7 +53,7 @@ public:
 	 * Gets the database ID of the character
 	 * @return the database ID of the character
 	 */
-	uint32_t GetID() const { return m_ID; }
+	LWOOBJID GetID() const { return m_ID; }
 
 	/**
 	 * Gets the (custom) name of the character
@@ -467,9 +467,9 @@ public:
 private:
 	void UpdateInfoFromDatabase();
 	/**
-	 * The ID of this character. First 32 bits of the ObjectID.
+	 * The ID of this character.
 	 */
-	uint32_t m_ID{};
+	LWOOBJID m_ID{};
 
 	/**
 	 * The 64-bit unique ID used in the game.

--- a/dGame/LeaderboardManager.cpp
+++ b/dGame/LeaderboardManager.cpp
@@ -145,7 +145,7 @@ void QueryToLdf(Leaderboard& leaderboard, const std::vector<ILeaderboard::Entry>
 	}
 }
 
-std::vector<ILeaderboard::Entry> FilterToNumResults(const std::vector<ILeaderboard::Entry>& leaderboard, const uint32_t relatedPlayer, const Leaderboard::InfoType infoType, const uint32_t numResults) {
+std::vector<ILeaderboard::Entry> FilterToNumResults(const std::vector<ILeaderboard::Entry>& leaderboard, const LWOOBJID relatedPlayer, const Leaderboard::InfoType infoType, const uint32_t numResults) {
 	std::vector<ILeaderboard::Entry> toReturn;
 
 	int32_t index = 0;
@@ -197,7 +197,7 @@ std::vector<ILeaderboard::Entry> FilterWeeklies(const std::vector<ILeaderboard::
 	return weeklyLeaderboard;
 }
 
-std::vector<ILeaderboard::Entry> FilterFriends(const std::vector<ILeaderboard::Entry>& leaderboard, const uint32_t relatedPlayer) {
+std::vector<ILeaderboard::Entry> FilterFriends(const std::vector<ILeaderboard::Entry>& leaderboard, const LWOOBJID relatedPlayer) {
 	// Filter the leaderboard to only include friends of the player
 	auto friendOfPlayer = Database::Get()->GetFriendsList(relatedPlayer);
 	std::vector<ILeaderboard::Entry> friendsLeaderboard;
@@ -217,7 +217,7 @@ std::vector<ILeaderboard::Entry> ProcessLeaderboard(
 	const std::vector<ILeaderboard::Entry>& leaderboard,
 	const bool weekly,
 	const Leaderboard::InfoType infoType,
-	const uint32_t relatedPlayer,
+	const LWOOBJID relatedPlayer,
 	const uint32_t numResults) {
 	std::vector<ILeaderboard::Entry> toReturn;
 

--- a/dGame/User.cpp
+++ b/dGame/User.cpp
@@ -39,11 +39,11 @@ User::User(const SystemAddress& sysAddr, const std::string& username, const std:
 	if (Game::server->GetZoneID() != 0) {
 		auto characterList = Database::Get()->GetAccountCharacterIds(m_AccountID);
 		if (!characterList.empty()) {
-			const uint32_t lastUsedCharacterId = characterList.front();
+			const auto lastUsedCharacterId = characterList.front();
 			Character* character = new Character(lastUsedCharacterId, this);
 			character->UpdateFromDatabase();
 			m_Characters.push_back(character);
-			LOG("Loaded %i as it is the last used char", lastUsedCharacterId);
+			LOG("Loaded %llu as it is the last used char", lastUsedCharacterId);
 		}
 	}
 }

--- a/dGame/UserManager.h
+++ b/dGame/UserManager.h
@@ -35,7 +35,7 @@ public:
 	void CreateCharacter(const SystemAddress& sysAddr, Packet* packet);
 	void DeleteCharacter(const SystemAddress& sysAddr, Packet* packet);
 	void RenameCharacter(const SystemAddress& sysAddr, Packet* packet);
-	void LoginCharacter(const SystemAddress& sysAddr, uint32_t playerID);
+	void LoginCharacter(const SystemAddress& sysAddr, LWOOBJID playerID);
 
 	void SaveAllActiveCharacters();
 

--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -64,7 +64,6 @@ PropertyManagementComponent::PropertyManagementComponent(Entity* parent) : Compo
 		this->propertyId = propertyInfo->id;
 		this->owner = propertyInfo->ownerId;
 		GeneralUtils::SetBit(this->owner, eObjectBits::CHARACTER);
-		GeneralUtils::SetBit(this->owner, eObjectBits::PERSISTENT);
 		this->clone_Id = propertyInfo->cloneId;
 		this->propertyName = propertyInfo->name;
 		this->propertyDescription = propertyInfo->description;

--- a/dGame/dUtilities/CheatDetection.cpp
+++ b/dGame/dUtilities/CheatDetection.cpp
@@ -76,8 +76,8 @@ void LogAndSaveFailedAntiCheatCheck(const LWOOBJID& id, const SystemAddress& sys
 		auto* user = UserManager::Instance()->GetUser(sysAddr);
 		
 		if (user) {
-			LOG("User at system address (%s) (%s) (%llu) sent a packet as (%i) which is not an id they own.",
-				sysAddr.ToString(), user->GetLastUsedChar()->GetName().c_str(), user->GetLastUsedChar()->GetObjectID(), static_cast<int32_t>(id));
+			LOG("User at system address (%s) (%s) (%llu) sent a packet as (%llu) which is not an id they own.",
+				sysAddr.ToString(), user->GetLastUsedChar()->GetName().c_str(), user->GetLastUsedChar()->GetObjectID(), id);
 		// Can't know sending player. Just log system address for IP banning.
 		} else {
 			LOG("No user found for system address (%s).", sysAddr.ToString());
@@ -117,7 +117,7 @@ bool CheatDetection::VerifyLwoobjidIsSender(const LWOOBJID& id, const SystemAddr
 			return false;
 		}
 		invalidPacket = true;
-		const uint32_t characterId = static_cast<uint32_t>(id);
+		const auto characterId = id;
 		// Check to make sure the ID provided is one of the user's characters.
 		for (const auto& character : sendingUser->GetCharacters()) {
 			if (character && character->GetID() == characterId) {

--- a/dGame/dUtilities/SlashCommands/GMGreaterThanZeroCommands.cpp
+++ b/dGame/dUtilities/SlashCommands/GMGreaterThanZeroCommands.cpp
@@ -141,7 +141,6 @@ namespace GMGreaterThanZeroCommands {
 					characterId = characterInfo->id;
 
 					GeneralUtils::SetBit(characterId, eObjectBits::CHARACTER);
-					GeneralUtils::SetBit(characterId, eObjectBits::PERSISTENT);
 				}
 
 				if (accountId == 0) {

--- a/dNet/MailInfo.h
+++ b/dNet/MailInfo.h
@@ -15,8 +15,8 @@ struct MailInfo {
 	std::string subject;
 	std::string body;
 	uint64_t id{};
-	uint32_t senderId{};
-	uint32_t receiverId{};
+	LWOOBJID senderId{};
+	LWOOBJID receiverId{};
 	uint64_t timeSent{};
 	bool wasRead{};
 	uint16_t languageCode{};

--- a/migrations/dlu/mysql/23_store_character_id_as_objectid.sql
+++ b/migrations/dlu/mysql/23_store_character_id_as_objectid.sql
@@ -14,7 +14,6 @@ UPDATE friends SET player_id = player_id | 0x1000000000000000, friend_id = frien
 UPDATE ignore_list SET player_id = player_id | 0x1000000000000000, ignored_player_id = ignored_player_id | 0x1000000000000000;
 UPDATE leaderboard SET character_id = character_id | 0x1000000000000000;
 UPDATE mail SET sender_id = sender_id | 0x1000000000000000, receiver_id = receiver_id | 0x1000000000000000;
-UPDATE pet_names SET owner_id = owner_id | 0x1000000000000000;
 UPDATE properties SET owner_id = owner_id | 0x1000000000000000;
 UPDATE ugc SET character_id = character_id | 0x1000000000000000;
 UPDATE ugc_modular_build SET character_id = character_id | 0x1000000000000000;

--- a/migrations/dlu/mysql/23_store_character_id_as_objectid.sql
+++ b/migrations/dlu/mysql/23_store_character_id_as_objectid.sql
@@ -1,0 +1,23 @@
+START TRANSACTION;
+ALTER TABLE mail MODIFY COLUMN sender_id BIGINT NOT NULL;
+ALTER TABLE bug_reports MODIFY COLUMN reporter_id BIGINT;
+/* This is done to prevent all entries on the leaderboard from updating */
+ALTER TABLE leaderboard CHANGE last_played last_played TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP();
+SET foreign_key_checks = 0;
+UPDATE activity_log SET character_id = character_id | 0x1000000000000000;
+UPDATE behaviors SET character_id = character_id | 0x1000000000000000;
+UPDATE bug_reports SET reporter_id = reporter_id | 0x1000000000000000;
+UPDATE charinfo SET id = id | 0x1000000000000000;
+UPDATE charxml SET id = id | 0x1000000000000000;
+UPDATE command_log SET character_id = character_id | 0x1000000000000000;
+UPDATE friends SET player_id = player_id | 0x1000000000000000, friend_id = friend_id | 0x1000000000000000;
+UPDATE ignore_list SET player_id = player_id | 0x1000000000000000, ignored_player_id = ignored_player_id | 0x1000000000000000;
+UPDATE leaderboard SET character_id = character_id | 0x1000000000000000;
+UPDATE mail SET sender_id = sender_id | 0x1000000000000000, receiver_id = receiver_id | 0x1000000000000000;
+UPDATE pet_names SET owner_id = owner_id | 0x1000000000000000;
+UPDATE properties SET owner_id = owner_id | 0x1000000000000000;
+UPDATE ugc SET character_id = character_id | 0x1000000000000000;
+UPDATE ugc_modular_build SET character_id = character_id | 0x1000000000000000;
+SET foreign_key_checks = 1;
+ALTER TABLE leaderboard CHANGE last_played last_played TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP() ON UPDATE CURRENT_TIMESTAMP();
+COMMIT;

--- a/migrations/dlu/sqlite/6_store_character_id_as_objectid.sql
+++ b/migrations/dlu/sqlite/6_store_character_id_as_objectid.sql
@@ -1,21 +1,23 @@
-START TRANSACTION;
-ALTER TABLE mail MODIFY COLUMN sender_id BIGINT NOT NULL;
-ALTER TABLE bug_reports MODIFY COLUMN reporter_id BIGINT;
+ALTER TABLE mail ADD COLUMN sender_id_1 BIGINT DEFAULT 0;
+ALTER TABLE bug_reports ADD COLUMN reporter_id_1 BIGINT DEFAULT 0;
 /* The leaderboard last_played change is not needed here since sqlite does not have ON UPDATE */
-SET foreign_key_checks = 0;
 UPDATE activity_log SET character_id = character_id | 0x1000000000000000;
 UPDATE behaviors SET character_id = character_id | 0x1000000000000000;
-UPDATE bug_reports SET reporter_id = reporter_id | 0x1000000000000000;
+UPDATE bug_reports SET reporter_id_1 = reporter_id | 0x1000000000000000;
 UPDATE charinfo SET id = id | 0x1000000000000000;
 UPDATE charxml SET id = id | 0x1000000000000000;
 UPDATE command_log SET character_id = character_id | 0x1000000000000000;
 UPDATE friends SET player_id = player_id | 0x1000000000000000, friend_id = friend_id | 0x1000000000000000;
 UPDATE ignore_list SET player_id = player_id | 0x1000000000000000, ignored_player_id = ignored_player_id | 0x1000000000000000;
 UPDATE leaderboard SET character_id = character_id | 0x1000000000000000;
-UPDATE mail SET sender_id = sender_id | 0x1000000000000000, receiver_id = receiver_id | 0x1000000000000000;
 UPDATE pet_names SET owner_id = owner_id | 0x1000000000000000;
+UPDATE mail SET sender_id_1 = sender_id | 0x1000000000000000, receiver_id = receiver_id | 0x1000000000000000;
 UPDATE properties SET owner_id = owner_id | 0x1000000000000000;
 UPDATE ugc SET character_id = character_id | 0x1000000000000000;
 UPDATE ugc_modular_build SET character_id = character_id | 0x1000000000000000;
-SET foreign_key_checks = 1;
-COMMIT;
+
+ALTER TABLE mail DROP COLUMN sender_id;
+ALTER TABLE mail RENAME COLUMN sender_id_1 TO sender_id;
+
+ALTER TABLE bug_reports DROP COLUMN reporter_id;
+ALTER TABLE bug_reports RENAME COLUMN reporter_id_1 TO reporter_id;

--- a/migrations/dlu/sqlite/6_store_character_id_as_objectid.sql
+++ b/migrations/dlu/sqlite/6_store_character_id_as_objectid.sql
@@ -10,7 +10,6 @@ UPDATE command_log SET character_id = character_id | 0x1000000000000000;
 UPDATE friends SET player_id = player_id | 0x1000000000000000, friend_id = friend_id | 0x1000000000000000;
 UPDATE ignore_list SET player_id = player_id | 0x1000000000000000, ignored_player_id = ignored_player_id | 0x1000000000000000;
 UPDATE leaderboard SET character_id = character_id | 0x1000000000000000;
-UPDATE pet_names SET owner_id = owner_id | 0x1000000000000000;
 UPDATE mail SET sender_id_1 = sender_id | 0x1000000000000000, receiver_id = receiver_id | 0x1000000000000000;
 UPDATE properties SET owner_id = owner_id | 0x1000000000000000;
 UPDATE ugc SET character_id = character_id | 0x1000000000000000;

--- a/migrations/dlu/sqlite/6_store_character_id_as_objectid.sql
+++ b/migrations/dlu/sqlite/6_store_character_id_as_objectid.sql
@@ -1,0 +1,21 @@
+START TRANSACTION;
+ALTER TABLE mail MODIFY COLUMN sender_id BIGINT NOT NULL;
+ALTER TABLE bug_reports MODIFY COLUMN reporter_id BIGINT;
+/* The leaderboard last_played change is not needed here since sqlite does not have ON UPDATE */
+SET foreign_key_checks = 0;
+UPDATE activity_log SET character_id = character_id | 0x1000000000000000;
+UPDATE behaviors SET character_id = character_id | 0x1000000000000000;
+UPDATE bug_reports SET reporter_id = reporter_id | 0x1000000000000000;
+UPDATE charinfo SET id = id | 0x1000000000000000;
+UPDATE charxml SET id = id | 0x1000000000000000;
+UPDATE command_log SET character_id = character_id | 0x1000000000000000;
+UPDATE friends SET player_id = player_id | 0x1000000000000000, friend_id = friend_id | 0x1000000000000000;
+UPDATE ignore_list SET player_id = player_id | 0x1000000000000000, ignored_player_id = ignored_player_id | 0x1000000000000000;
+UPDATE leaderboard SET character_id = character_id | 0x1000000000000000;
+UPDATE mail SET sender_id = sender_id | 0x1000000000000000, receiver_id = receiver_id | 0x1000000000000000;
+UPDATE pet_names SET owner_id = owner_id | 0x1000000000000000;
+UPDATE properties SET owner_id = owner_id | 0x1000000000000000;
+UPDATE ugc SET character_id = character_id | 0x1000000000000000;
+UPDATE ugc_modular_build SET character_id = character_id | 0x1000000000000000;
+SET foreign_key_checks = 1;
+COMMIT;


### PR DESCRIPTION
remove all usages of the PERSISTENT bit with regards to storing of playerIDs on the server.  the bit does not exist and was a phantom in the first place. Tested that a full playthrough of ag, ns and gf was still doable.  slash commands work, ugc works, friends works, ignore list works, properties work and have names, teaming works. migrating an old mysql database works . need to test an old sqlite database

some extra debug logging has been added to aid with debugging some issues.  It may get noisy but its worth it trust me