### PR TITLE
fix: hardcore mode uscore dropping and other hardcore mode fixes

### DIFF
--- a/dCommon/dConfig.cpp
+++ b/dCommon/dConfig.cpp
@@ -47,6 +47,7 @@ void dConfig::LoadConfig() {
 void dConfig::ReloadConfig() {
 	this->m_ConfigValues.clear();
 	LoadConfig();
+	for (const auto& handler : m_ConfigHandlers) handler();
 }
 
 const std::string& dConfig::GetValue(std::string key) {
@@ -56,6 +57,10 @@ const std::string& dConfig::GetValue(std::string key) {
 		this->m_ConfigValues[key] = env_p;
 	}
 	return this->m_ConfigValues[key];
+}
+
+void dConfig::AddConfigHandler(std::function<void()> handler) {
+	m_ConfigHandlers.push_back(handler);
 }
 
 void dConfig::ProcessLine(const std::string& line) {

--- a/dCommon/dConfig.h
+++ b/dCommon/dConfig.h
@@ -1,5 +1,7 @@
 #pragma once
+
 #include <fstream>
+#include <functional>
 #include <map>
 #include <string>
 
@@ -29,10 +31,15 @@ public:
 	 * Reloads the config file to reset values
 	 */
 	void ReloadConfig();
+
+	// Adds a function to be called when the config is (re)loaded
+	void AddConfigHandler(std::function<void()> handler);
+
 private:
 	void ProcessLine(const std::string& line);
 
 private:
 	std::map<std::string, std::string> m_ConfigValues;
+	std::vector<std::function<void()>> m_ConfigHandlers;
 	std::string m_ConfigFilePath;
 };

--- a/dGame/EntityManager.h
+++ b/dGame/EntityManager.h
@@ -75,11 +75,13 @@ public:
 	const uint32_t GetHardcoreLoseUscoreOnDeathPercent() { return m_HardcoreLoseUscoreOnDeathPercent; };
 	const bool GetHardcoreDropinventoryOnDeath() { return m_HardcoreDropinventoryOnDeath; };
 	const uint32_t GetHardcoreUscoreEnemiesMultiplier() { return m_HardcoreUscoreEnemiesMultiplier; };
+	const std::set<LOT>& GetHardcoreExcludedItemDrops() { return m_HardcoreExcludedItemDrops; };
 
 	// Messaging
 	bool SendMessage(GameMessages::GameMsg& msg) const;
 
 private:
+	void ReloadConfig();
 	void SerializeEntities();
 	void KillEntities();
 	void DeleteEntities();
@@ -112,6 +114,7 @@ private:
 	uint32_t m_HardcoreLoseUscoreOnDeathPercent;
 	bool m_HardcoreDropinventoryOnDeath;
 	uint32_t m_HardcoreUscoreEnemiesMultiplier;
+	std::set<LOT> m_HardcoreExcludedItemDrops;
 };
 
 #endif // ENTITYMANAGER_H

--- a/resources/worldconfig.ini
+++ b/resources/worldconfig.ini
@@ -80,3 +80,6 @@ cdclient_mismatch_message=We detected that your client is out of date. Please up
 
 # Auto reject properties which contain no models | must be 1 in order to auto reject.
 auto_reject_empty_properties=0
+
+# comma delimited list of items to not drop in hardcore mode
+hardcore_excluded_item_drops=6086,7044


### PR DESCRIPTION
Tested that reloading config picks up on new items to be excluded from drops
tested that uscore is removed from the player now