### PR TITLE
fix: Extend saved ugc id to 64 bits

### DIFF
--- a/dDatabase/GameDatabase/ITables/IPropertyContents.h
+++ b/dDatabase/GameDatabase/ITables/IPropertyContents.h
@@ -23,7 +23,7 @@ public:
 	// Inserts a new UGC model into the database.
 	virtual void InsertNewUgcModel(
 		std::stringstream& sd0Data,
-		const uint32_t blueprintId,
+		const uint64_t blueprintId,
 		const uint32_t accountId,
 		const LWOOBJID characterId) = 0;
 

--- a/dDatabase/GameDatabase/MySQL/MySQLDatabase.h
+++ b/dDatabase/GameDatabase/MySQL/MySQLDatabase.h
@@ -83,7 +83,7 @@ public:
 	void InsertNewMail(const MailInfo& mail) override;
 	void InsertNewUgcModel(
 		std::stringstream& sd0Data,
-		const uint32_t blueprintId,
+		const uint64_t blueprintId,
 		const uint32_t accountId,
 		const LWOOBJID characterId) override;
 	std::vector<MailInfo> GetMailForPlayer(const LWOOBJID characterId, const uint32_t numberOfMail) override;

--- a/dDatabase/GameDatabase/MySQL/Tables/Ugc.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/Ugc.cpp
@@ -46,7 +46,7 @@ void MySQLDatabase::RemoveUnreferencedUgcModels() {
 
 void MySQLDatabase::InsertNewUgcModel(
 	std:: stringstream& sd0Data, // cant be const sad
-	const uint32_t blueprintId,
+	const uint64_t blueprintId,
 	const uint32_t accountId,
 	const LWOOBJID characterId) {
 	const std::istream stream(sd0Data.rdbuf());

--- a/dDatabase/GameDatabase/SQLite/SQLiteDatabase.h
+++ b/dDatabase/GameDatabase/SQLite/SQLiteDatabase.h
@@ -81,7 +81,7 @@ public:
 	void InsertNewMail(const MailInfo& mail) override;
 	void InsertNewUgcModel(
 		std::stringstream& sd0Data,
-		const uint32_t blueprintId,
+		const uint64_t blueprintId,
 		const uint32_t accountId,
 		const LWOOBJID characterId) override;
 	std::vector<MailInfo> GetMailForPlayer(const LWOOBJID characterId, const uint32_t numberOfMail) override;

--- a/dDatabase/GameDatabase/SQLite/Tables/Ugc.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/Ugc.cpp
@@ -47,7 +47,7 @@ void SQLiteDatabase::RemoveUnreferencedUgcModels() {
 
 void SQLiteDatabase::InsertNewUgcModel(
 	std::stringstream& sd0Data, // cant be const sad
-	const uint32_t blueprintId,
+	const uint64_t blueprintId,
 	const uint32_t accountId,
 	const LWOOBJID characterId) {
 	const std::istream stream(sd0Data.rdbuf());

--- a/dDatabase/GameDatabase/TestSQL/TestSQLDatabase.cpp
+++ b/dDatabase/GameDatabase/TestSQL/TestSQLDatabase.cpp
@@ -192,7 +192,7 @@ void TestSQLDatabase::InsertNewMail(const MailInfo& mail) {
 
 }
 
-void TestSQLDatabase::InsertNewUgcModel(std::stringstream& sd0Data, const uint32_t blueprintId, const uint32_t accountId, const LWOOBJID characterId) {
+void TestSQLDatabase::InsertNewUgcModel(std::stringstream& sd0Data, const uint64_t blueprintId, const uint32_t accountId, const LWOOBJID characterId) {
 
 }
 

--- a/dDatabase/GameDatabase/TestSQL/TestSQLDatabase.h
+++ b/dDatabase/GameDatabase/TestSQL/TestSQLDatabase.h
@@ -60,7 +60,7 @@ class TestSQLDatabase : public GameDatabase {
 	void InsertNewMail(const MailInfo& mail) override;
 	void InsertNewUgcModel(
 		std::stringstream& sd0Data,
-		const uint32_t blueprintId,
+		const uint64_t blueprintId,
 		const uint32_t accountId,
 		const LWOOBJID characterId) override;
 	std::vector<MailInfo> GetMailForPlayer(const LWOOBJID characterId, const uint32_t numberOfMail) override;

--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -621,7 +621,6 @@ void PropertyManagementComponent::Load() {
 		//BBB property models need to have extra stuff set for them:
 		if (databaseModel.lot == 14) {
 			LWOOBJID blueprintID = databaseModel.ugcId;
-			GeneralUtils::SetBit(blueprintID, eObjectBits::CHARACTER);
 
 			settings.push_back(new LDFData<LWOOBJID>(u"blueprintid", blueprintID));
 			settings.push_back(new LDFData<int>(u"componentWhitelist", 1));

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -2588,8 +2588,7 @@ void GameMessages::HandleBBBSaveRequest(RakNet::BitStream& inStream, Entity* ent
 		LWOOBJID newIDL = newID;
 		GeneralUtils::SetBit(newIDL, eObjectBits::CHARACTER);
 
-		uint32_t blueprintIDSmall = ObjectIDManager::GenerateRandomObjectID();
-		LWOOBJID blueprintID = blueprintIDSmall;
+		LWOOBJID blueprintID = ObjectIDManager::GenerateRandomObjectID();
 		GeneralUtils::SetBit(blueprintID, eObjectBits::CHARACTER);
 
 		//We need to get the propertyID: (stolen from Wincent's propertyManagementComp)
@@ -2614,12 +2613,12 @@ void GameMessages::HandleBBBSaveRequest(RakNet::BitStream& inStream, Entity* ent
 		// Recompress the data and save to the database
 		sd0.FromData(reinterpret_cast<const uint8_t*>(newLxfml.data()), newLxfml.size());
 		auto sd0AsStream = sd0.GetAsStream();
-		Database::Get()->InsertNewUgcModel(sd0AsStream, blueprintIDSmall, entity->GetCharacter()->GetParentUser()->GetAccountID(), entity->GetCharacter()->GetID());
+		Database::Get()->InsertNewUgcModel(sd0AsStream, blueprintID, entity->GetCharacter()->GetParentUser()->GetAccountID(), entity->GetCharacter()->GetID());
 
 		//Insert into the db as a BBB model:
 		IPropertyContents::Model model;
 		model.id = newIDL;
-		model.ugcId = blueprintIDSmall;
+		model.ugcId = blueprintID;
 		model.position = newCenter;
 		model.rotation = NiQuaternion(0.0f, 0.0f, 0.0f, 0.0f);
 		model.lot = 14;


### PR DESCRIPTION
Tetsed that ugc models are saved and loaded with the correct bits (they showed up correctly in the first place just with weird ids)