### PR TITLE
fix: uninitialized memory in activitycomponent 

### DIFF
--- a/dGame/dComponents/ActivityComponent.h
+++ b/dGame/dComponents/ActivityComponent.h
@@ -353,7 +353,7 @@ private:
 	/**
 	 * The database information for this activity
 	 */
-	CDActivities m_ActivityInfo;
+	CDActivities m_ActivityInfo{};
 
 	/**
 	 * All the active instances of this activity


### PR DESCRIPTION
rust would never