### PR TITLE
feat: Add ComponentID to the root Component object

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -199,7 +199,7 @@ void Entity::Initialize() {
 
 	const auto triggerInfo = GetVarAsString(u"trigger_id");
 
-	if (!triggerInfo.empty()) AddComponent<TriggerComponent>(triggerInfo);
+	if (!triggerInfo.empty()) AddComponent<TriggerComponent>(-1, triggerInfo);
 
 	/**
 	 * Setup groups
@@ -234,11 +234,11 @@ void Entity::Initialize() {
 
 		AddComponent<SimplePhysicsComponent>(simplePhysicsComponentID);
 
-		AddComponent<ModelComponent>()->LoadBehaviors();
+		AddComponent<ModelComponent>(-1)->LoadBehaviors();
 
-		AddComponent<RenderComponent>();
+		AddComponent<RenderComponent>(-1);
 
-		auto* destroyableComponent = AddComponent<DestroyableComponent>();
+		auto* destroyableComponent = AddComponent<DestroyableComponent>(-1);
 		destroyableComponent->SetHealth(1);
 		destroyableComponent->SetMaxHealth(1.0f);
 		destroyableComponent->SetFaction(-1, true);
@@ -254,37 +254,42 @@ void Entity::Initialize() {
 	 */
 
 	if (m_Character && m_Character->GetParentUser()) {
-		AddComponent<MissionComponent>()->LoadFromXml(m_Character->GetXMLDoc());
+		AddComponent<MissionComponent>(-1)->LoadFromXml(m_Character->GetXMLDoc());
 	}
 
-	const uint32_t petComponentId = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::PET);
-	if (petComponentId > 0) {
-		AddComponent<PetComponent>(petComponentId);
+	const auto petComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::PET);
+	if (petComponentID > 0) {
+		AddComponent<PetComponent>(petComponentID);
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MINI_GAME_CONTROL) > 0) {
-		AddComponent<MiniGameControlComponent>();
+	const auto minigameControlID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MINI_GAME_CONTROL);
+	if (minigameControlID > 0) {
+		AddComponent<MiniGameControlComponent>(minigameControlID);
 	}
 
-	const uint32_t possessableComponentId = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::POSSESSABLE);
-	if (possessableComponentId > 0) {
-		AddComponent<PossessableComponent>(possessableComponentId);
+	const auto possessableComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::POSSESSABLE);
+	if (possessableComponentID > 0) {
+		AddComponent<PossessableComponent>(possessableComponentID);
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MODULE_ASSEMBLY) > 0) {
-		AddComponent<ModuleAssemblyComponent>();
+	const auto moduleAssemblyID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MODULE_ASSEMBLY);
+	if (moduleAssemblyID > 0) {
+		AddComponent<ModuleAssemblyComponent>(moduleAssemblyID);
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::RACING_STATS) > 0) {
-		AddComponent<RacingStatsComponent>();
+	const auto racingStatsID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::RACING_STATS);
+	if (racingStatsID > 0) {
+		AddComponent<RacingStatsComponent>(racingStatsID);
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::LUP_EXHIBIT, -1) >= 0) {
-		AddComponent<LUPExhibitComponent>();
+	const auto lupExhibitID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::LUP_EXHIBIT, -1);
+	if (lupExhibitID >= 0) {
+		AddComponent<LUPExhibitComponent>(lupExhibitID);
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::RACING_CONTROL) > 0) {
-		AddComponent<RacingControlComponent>();
+	const auto racingControlID =compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::RACING_CONTROL);
+	if (racingControlID > 0) {
+		AddComponent<RacingControlComponent>(racingControlID);
 	}
 
 	const auto propertyEntranceComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::PROPERTY_ENTRANCE);
@@ -292,7 +297,7 @@ void Entity::Initialize() {
 		AddComponent<PropertyEntranceComponent>(propertyEntranceComponentID);
 	}
 
-	const int32_t controllablePhysicsComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::CONTROLLABLE_PHYSICS);
+	const auto controllablePhysicsComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::CONTROLLABLE_PHYSICS);
 	if (controllablePhysicsComponentID > 0) {
 		auto* controllablePhysics = AddComponent<ControllablePhysicsComponent>(controllablePhysicsComponentID);
 
@@ -337,46 +342,48 @@ void Entity::Initialize() {
 		AddComponent<SimplePhysicsComponent>(simplePhysicsComponentID);
 	}
 
-	const int32_t rigidBodyPhantomPhysicsComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::RIGID_BODY_PHANTOM_PHYSICS);
+	const auto rigidBodyPhantomPhysicsComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::RIGID_BODY_PHANTOM_PHYSICS);
 	if (rigidBodyPhantomPhysicsComponentID > 0) {
 		AddComponent<RigidbodyPhantomPhysicsComponent>(rigidBodyPhantomPhysicsComponentID);
 	}
 
-	const int32_t phantomPhysicsComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::PHANTOM_PHYSICS);
+	const auto phantomPhysicsComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::PHANTOM_PHYSICS);
 	if (markedAsPhantom || phantomPhysicsComponentID > 0) {
 		AddComponent<PhantomPhysicsComponent>(phantomPhysicsComponentID)->SetPhysicsEffectActive(false);
 	}
 
-	const int32_t havokVehiclePhysicsComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::HAVOK_VEHICLE_PHYSICS);
+	const auto havokVehiclePhysicsComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::HAVOK_VEHICLE_PHYSICS);
 	if (havokVehiclePhysicsComponentID > 0) {
 		auto* havokVehiclePhysicsComponent = AddComponent<HavokVehiclePhysicsComponent>(havokVehiclePhysicsComponentID);
 		havokVehiclePhysicsComponent->SetPosition(m_DefaultPosition);
 		havokVehiclePhysicsComponent->SetRotation(m_DefaultRotation);
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::SOUND_TRIGGER, -1) != -1) {
-		AddComponent<SoundTriggerComponent>();
-	} else if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::RACING_SOUND_TRIGGER, -1) != -1) {
-		AddComponent<RacingSoundTriggerComponent>();
+	const auto soundTriggerID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::SOUND_TRIGGER, -1);
+	const auto racingSoundTriggerID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::RACING_SOUND_TRIGGER, -1);
+	if (soundTriggerID > -1) {
+		AddComponent<SoundTriggerComponent>(soundTriggerID);
+	} else if (racingSoundTriggerID > -1) {
+		AddComponent<RacingSoundTriggerComponent>(racingSoundTriggerID);
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::BUFF) > 0) {
-		AddComponent<BuffComponent>();
+	const auto buffComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::BUFF);
+	if (buffComponentID > 0) {
+		AddComponent<BuffComponent>(buffComponentID);
 	}
 
-	const int collectibleComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::COLLECTIBLE);
+	const auto collectibleComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::COLLECTIBLE);
 
 	if (collectibleComponentID > 0) {
-		AddComponent<CollectibleComponent>(GetVarAs<int32_t>(u"collectible_id"));
+		AddComponent<CollectibleComponent>(collectibleComponentID, GetVarAs<int32_t>(u"collectible_id"));
 	}
 
 	/**
 	 * Multiple components require the destructible component.
 	 */
-	const int buffComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::BUFF);
-	const int quickBuildComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::QUICK_BUILD);
+	const auto quickBuildComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::QUICK_BUILD);
 
-	int componentID = -1;
+	int32_t componentID = -1;
 	if (collectibleComponentID > 0) componentID = collectibleComponentID;
 	if (quickBuildComponentID > 0) componentID = quickBuildComponentID;
 	if (buffComponentID > 0) componentID = buffComponentID;
@@ -384,7 +391,7 @@ void Entity::Initialize() {
 
 	bool isSmashable = GetVarAs<int32_t>(u"is_smashable") != 0;
 	if (buffComponentID > 0 || collectibleComponentID > 0 || isSmashable) {
-		DestroyableComponent* comp = AddComponent<DestroyableComponent>();
+		DestroyableComponent* comp = AddComponent<DestroyableComponent>(componentID);
 		auto* const destCompTable = CDClientManager::GetTable<CDDestructibleComponentTable>();
 		std::vector<CDDestructibleComponent> destCompData = destCompTable->Query([componentID](const CDDestructibleComponent& entry) { return (entry.id == componentID); });
 
@@ -473,27 +480,30 @@ void Entity::Initialize() {
 		}
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::CHARACTER) > 0 || m_Character) {
+	const auto characterID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::CHARACTER);
+	if (characterID > 0 || m_Character) {
 		// Character Component always has a possessor, level, and forced movement components
-		AddComponent<PossessorComponent>();
+		AddComponent<PossessorComponent>(characterID);
 
 		// load in the xml for the level
-		AddComponent<LevelProgressionComponent>()->LoadFromXml(m_Character->GetXMLDoc());
+		AddComponent<LevelProgressionComponent>(characterID)->LoadFromXml(m_Character->GetXMLDoc());
 
-		AddComponent<PlayerForcedMovementComponent>();
+		AddComponent<PlayerForcedMovementComponent>(characterID);
 
 		auto& systemAddress = m_Character->GetParentUser() ? m_Character->GetParentUser()->GetSystemAddress() : UNASSIGNED_SYSTEM_ADDRESS;
-		AddComponent<CharacterComponent>(m_Character, systemAddress)->LoadFromXml(m_Character->GetXMLDoc());
+		AddComponent<CharacterComponent>(characterID, m_Character, systemAddress)->LoadFromXml(m_Character->GetXMLDoc());
 
-		AddComponent<GhostComponent>();
+		AddComponent<GhostComponent>(characterID);
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::INVENTORY) > 0 || m_Character) {
-		AddComponent<InventoryComponent>();
+	const auto inventoryID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::INVENTORY);
+	if (inventoryID > 0 || m_Character) {
+		AddComponent<InventoryComponent>(inventoryID);
 	}
 	// if this component exists, then we initialize it. it's value is always 0
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MULTI_ZONE_ENTRANCE, -1) != -1) {
-		AddComponent<MultiZoneEntranceComponent>();
+	const auto multiZoneEntranceID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MULTI_ZONE_ENTRANCE, -1);
+	if (multiZoneEntranceID > -1) {
+		AddComponent<MultiZoneEntranceComponent>(multiZoneEntranceID);
 	}
 
 	/**
@@ -545,7 +555,7 @@ void Entity::Initialize() {
 	}
 
 	if (!scriptName.empty() || client || m_Character || scriptComponentID >= 0) {
-		AddComponent<ScriptComponent>(scriptName, true, client && scriptName.empty());
+		AddComponent<ScriptComponent>(scriptComponentID, scriptName, true, client && scriptName.empty());
 	}
 
 	// ZoneControl script
@@ -554,26 +564,27 @@ void Entity::Initialize() {
 		const CDZoneTable* const zoneData = CDZoneTableTable::Query(zoneID.GetMapID());
 
 		if (zoneData != nullptr) {
-			int zoneScriptID = zoneData->scriptID;
+			const int32_t zoneScriptID = zoneData->scriptID;
 			CDScriptComponent zoneScriptData = scriptCompTable->GetByID(zoneScriptID);
-			AddComponent<ScriptComponent>(zoneScriptData.script_name, true);
+			AddComponent<ScriptComponent>(zoneScriptID, zoneScriptData.script_name, true, false);
 		}
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::SKILL, -1) != -1 || m_Character) {
-		AddComponent<SkillComponent>();
+	const auto skillID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::SKILL, -1);
+	if (skillID > -1 || m_Character) {
+		AddComponent<SkillComponent>(skillID);
 	}
 
-	const auto combatAiId = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::BASE_COMBAT_AI);
-	if (combatAiId > 0) {
-		AddComponent<BaseCombatAIComponent>(combatAiId);
+	const auto combatAiID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::BASE_COMBAT_AI);
+	if (combatAiID > 0) {
+		AddComponent<BaseCombatAIComponent>(combatAiID);
 	}
 
-	if (const int componentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::QUICK_BUILD) > 0) {
-		auto* const quickBuildComponent = AddComponent<QuickBuildComponent>();
+	if (quickBuildComponentID > 0) {
+		auto* const quickBuildComponent = AddComponent<QuickBuildComponent>(quickBuildComponentID);
 
 		CDRebuildComponentTable* const rebCompTable = CDClientManager::GetTable<CDRebuildComponentTable>();
-		const std::vector<CDRebuildComponent> rebCompData = rebCompTable->Query([=](CDRebuildComponent entry) { return (entry.id == quickBuildComponentID); });
+		const std::vector<CDRebuildComponent> rebCompData = rebCompTable->Query([quickBuildComponentID](CDRebuildComponent entry) { return (entry.id == quickBuildComponentID); });
 
 		if (!rebCompData.empty()) {
 			quickBuildComponent->SetResetTime(rebCompData[0].reset_time);
@@ -618,53 +629,63 @@ void Entity::Initialize() {
 		}
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::SWITCH, -1) != -1) {
-		AddComponent<SwitchComponent>();
+	const auto switchID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::SWITCH, -1);
+	if (switchID > -1) {
+		AddComponent<SwitchComponent>(switchID);
 	}
 
-	if ((compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::VENDOR) > 0)) {
-		AddComponent<VendorComponent>();
-	} else if ((compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::DONATION_VENDOR, -1) != -1)) {
-		AddComponent<DonationVendorComponent>();
-	} else if ((compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::ACHIEVEMENT_VENDOR, -1) != -1)) {
-		AddComponent<AchievementVendorComponent>();
+	const auto vendorID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::VENDOR);
+	const auto donationVendorID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::DONATION_VENDOR, -1);
+	const auto achievementVendorID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::ACHIEVEMENT_VENDOR, -1);
+	if (vendorID > 0) {
+		AddComponent<VendorComponent>(vendorID);
+	} else if (donationVendorID > -1) {
+		AddComponent<DonationVendorComponent>(donationVendorID);
+	} else if (achievementVendorID > -1) {
+		AddComponent<AchievementVendorComponent>(achievementVendorID);
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::PROPERTY_VENDOR, -1) != -1) {
-		AddComponent<PropertyVendorComponent>();
+	const auto propertyVendorID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::PROPERTY_VENDOR, -1);
+	if (propertyVendorID > -1) {
+		AddComponent<PropertyVendorComponent>(propertyVendorID);
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::PROPERTY_MANAGEMENT, -1) != -1) {
-		AddComponent<PropertyManagementComponent>();
+	const auto propertyManagementID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::PROPERTY_MANAGEMENT, -1);
+	if (propertyManagementID > -1) {
+		AddComponent<PropertyManagementComponent>(propertyManagementID);
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::BOUNCER, -1) != -1) { // you have to determine it like this because all bouncers have a componentID of 0
-		AddComponent<BouncerComponent>();
+	const auto bouncerID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::BOUNCER, -1);
+	if (bouncerID > -1) { // you have to determine it like this because all bouncers have a componentID of 0
+		AddComponent<BouncerComponent>(bouncerID);
 	}
 
-	const int32_t renderComponentId = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::RENDER);
-	if ((renderComponentId > 0 && m_TemplateID != 2365) || m_Character) {
-		AddComponent<RenderComponent>(renderComponentId);
+	const auto renderComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::RENDER);
+	if ((renderComponentID > 0 && m_TemplateID != 2365) || m_Character) {
+		AddComponent<RenderComponent>(renderComponentID);
 	}
 
-	if ((compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MISSION_OFFER) > 0) || m_Character) {
-		AddComponent<MissionOfferComponent>(m_TemplateID);
+	const auto missionOfferComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MISSION_OFFER, -1);
+	if (missionOfferComponentID > -1 || m_Character) {
+		AddComponent<MissionOfferComponent>(missionOfferComponentID);
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::BUILD_BORDER, -1) != -1) {
-		AddComponent<BuildBorderComponent>();
+	const auto buildBorderID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::BUILD_BORDER, -1);
+	if (buildBorderID > -1) {
+		AddComponent<BuildBorderComponent>(buildBorderID);
 	}
 
 	// Scripted activity component
-	const int32_t scriptedActivityID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::SCRIPTED_ACTIVITY, -1);
-	if (scriptedActivityID != -1) {
+	const auto scriptedActivityID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::SCRIPTED_ACTIVITY, -1);
+	if (scriptedActivityID > -1) {
 		AddComponent<ScriptedActivityComponent>(scriptedActivityID);
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MODEL, -1) != -1 && !GetComponent<PetComponent>()) {
-		AddComponent<ModelComponent>()->LoadBehaviors();
+	const auto modelID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MODEL, -1);
+	if (modelID > -1 && !GetComponent<PetComponent>()) {
+		AddComponent<ModelComponent>(modelID)->LoadBehaviors();
 		if (!HasComponent(eReplicaComponentType::DESTROYABLE)) {
-			auto* const destroyableComponent = AddComponent<DestroyableComponent>();
+			auto* const destroyableComponent = AddComponent<DestroyableComponent>(-1);
 			destroyableComponent->SetHealth(1);
 			destroyableComponent->SetMaxHealth(1.0f);
 			destroyableComponent->SetFaction(-1, true);
@@ -672,9 +693,10 @@ void Entity::Initialize() {
 		}
 	}
 
-	PetComponent* petComponent;
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::ITEM) > 0 && !TryGetComponent(eReplicaComponentType::PET, petComponent) && !HasComponent(eReplicaComponentType::MODEL)) {
-		AddComponent<ItemComponent>();
+	PetComponent* petComponent{};
+	const auto itemID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::ITEM);
+	if (itemID > 0 && !TryGetComponent(eReplicaComponentType::PET, petComponent) && !HasComponent(eReplicaComponentType::MODEL)) {
+		AddComponent<ItemComponent>(itemID);
 	}
 
 	// Shooting gallery component
@@ -683,16 +705,17 @@ void Entity::Initialize() {
 		AddComponent<ShootingGalleryComponent>(shootingGalleryComponentID);
 	}
 
-	if (compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::PROPERTY, -1) != -1) {
-		AddComponent<PropertyComponent>();
+	const auto propertyID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::PROPERTY, -1);
+	if (propertyID > -1) {
+		AddComponent<PropertyComponent>(propertyID);
 	}
 
-	const int rocketId = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::ROCKET_LAUNCH);
-	if ((rocketId > 0)) {
-		AddComponent<RocketLaunchpadControlComponent>(rocketId);
+	const auto rocketID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::ROCKET_LAUNCH);
+	if ((rocketID > 0)) {
+		AddComponent<RocketLaunchpadControlComponent>(rocketID);
 	}
 
-	const int32_t railComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::RAIL_ACTIVATOR);
+	const auto railComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::RAIL_ACTIVATOR);
 	if (railComponentID > 0) {
 		AddComponent<RailActivatorComponent>(railComponentID);
 	}
@@ -722,9 +745,9 @@ void Entity::Initialize() {
 				}
 			}
 
-			AddComponent<MovementAIComponent>(moveInfo);
+			AddComponent<MovementAIComponent>(movementAIID, moveInfo);
 		}
-	} else if (petComponentId > 0 || combatAiId > 0 && GetComponent<BaseCombatAIComponent>()->GetTetherSpeed() > 0) {
+	} else if (petComponentID > 0 || combatAiID > 0 && GetComponent<BaseCombatAIComponent>()->GetTetherSpeed() > 0) {
 		MovementAIInfo moveInfo{
 			.movementType = "",
 			.wanderRadius = 16,
@@ -734,7 +757,7 @@ void Entity::Initialize() {
 			.wanderDelayMax = 5,
 		};
 
-		AddComponent<MovementAIComponent>(moveInfo);
+		AddComponent<MovementAIComponent>(-1, moveInfo);
 	}
 
 	const std::string pathName = GetVarAsString(u"attached_path");
@@ -744,10 +767,10 @@ void Entity::Initialize() {
 	if (path) {
 		// if we have a moving platform path, then we need a moving platform component
 		if (path->pathType == PathType::MovingPlatform) {
-			AddComponent<MovingPlatformComponent>(pathName);
+			AddComponent<MovingPlatformComponent>(-1, pathName);
 		} else if (path->pathType == PathType::Movement) {
 			auto* const movementAIcomponent = GetComponent<MovementAIComponent>();
-			if (movementAIcomponent && combatAiId == 0) {
+			if (movementAIcomponent && combatAiID == 0) {
 				movementAIcomponent->SetPath(pathName);
 			} else {
 				MovementAIInfo moveInfo{
@@ -759,24 +782,24 @@ void Entity::Initialize() {
 					.wanderDelayMax = 5,
 				};
 
-				AddComponent<MovementAIComponent>(moveInfo);
+				AddComponent<MovementAIComponent>(-1, moveInfo);
 			}
 		}
 	} else {
 		// else we still need to setup moving platform if it has a moving platform comp but no path
-		const int32_t movingPlatformComponentId = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MOVING_PLATFORM, -1);
-		if (movingPlatformComponentId >= 0) {
-			AddComponent<MovingPlatformComponent>(pathName);
+		const auto movingPlatformComponentID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::MOVING_PLATFORM, -1);
+		if (movingPlatformComponentID >= 0) {
+			AddComponent<MovingPlatformComponent>(movingPlatformComponentID, pathName);
 		}
 	}
 
-	const int proximityMonitorID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::PROXIMITY_MONITOR);
+	const auto proximityMonitorID = compRegistryTable->GetByIDAndType(m_TemplateID, eReplicaComponentType::PROXIMITY_MONITOR);
 	if (proximityMonitorID > 0) {
 		auto* const proxCompTable = CDClientManager::GetTable<CDProximityMonitorComponentTable>();
 		const auto proxCompData = proxCompTable->Query([proximityMonitorID](const CDProximityMonitorComponent& entry) { return (entry.id == proximityMonitorID); });
 		if (proxCompData.size() > 0) {
 			std::vector<std::string> proximityStr = GeneralUtils::SplitString(proxCompData[0].Proximities, ',');
-			AddComponent<ProximityMonitorComponent>(std::stoi(proximityStr[0]), std::stoi(proximityStr[1]));
+			AddComponent<ProximityMonitorComponent>(proximityMonitorID, std::stoi(proximityStr[0]), std::stoi(proximityStr[1]));
 		}
 	}
 
@@ -882,12 +905,13 @@ void Entity::Unsubscribe(LWOOBJID scriptObjId, const std::string& notificationNa
 
 void Entity::SetProximityRadius(float proxRadius, std::string name) {
 	auto* proxMon = GetComponent<ProximityMonitorComponent>();
-	if (!proxMon) proxMon = AddComponent<ProximityMonitorComponent>();
+	if (!proxMon) proxMon = AddComponent<ProximityMonitorComponent>(-1);
 	proxMon->SetProximityRadius(proxRadius, name);
 }
 
 void Entity::SetProximityRadius(dpEntity* entity, std::string name) {
-	ProximityMonitorComponent* proxMon = AddComponent<ProximityMonitorComponent>();
+	auto* proxMon = GetComponent<ProximityMonitorComponent>();
+	if (!proxMon) proxMon = AddComponent<ProximityMonitorComponent>(-1);
 	proxMon->SetProximityRadius(entity, name);
 }
 

--- a/dGame/dComponents/AchievementVendorComponent.cpp
+++ b/dGame/dComponents/AchievementVendorComponent.cpp
@@ -9,7 +9,7 @@
 #include "UserManager.h"
 #include "CDMissionsTable.h"
 
-AchievementVendorComponent::AchievementVendorComponent(Entity* parent) : VendorComponent(parent) {
+AchievementVendorComponent::AchievementVendorComponent(Entity* parent, const int32_t componentID) : VendorComponent(parent, componentID) {
 	RefreshInventory(true);
 };
 

--- a/dGame/dComponents/AchievementVendorComponent.h
+++ b/dGame/dComponents/AchievementVendorComponent.h
@@ -11,7 +11,7 @@ class Entity;
 class AchievementVendorComponent final : public VendorComponent {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::ACHIEVEMENT_VENDOR;
-	AchievementVendorComponent(Entity* parent);
+	AchievementVendorComponent(Entity* parent, const int32_t componentID);
 	
 	void RefreshInventory(bool isCreation = false) override;
 	bool SellsItem(Entity* buyer, const LOT lot);

--- a/dGame/dComponents/ActivityComponent.cpp
+++ b/dGame/dComponents/ActivityComponent.cpp
@@ -30,7 +30,7 @@
 #include "CharacterComponent.h"
 #include "Amf3.h"
 
-ActivityComponent::ActivityComponent(Entity* parent, int32_t activityID) : Component(parent) {
+ActivityComponent::ActivityComponent(Entity* parent, int32_t componentID) : Component(parent, componentID) {
 	using namespace GameMessages;
 	RegisterMsg<GetObjectReportInfo>(this, &ActivityComponent::OnGetObjectReportInfo);
 	/*
@@ -39,8 +39,8 @@ ActivityComponent::ActivityComponent(Entity* parent, int32_t activityID) : Compo
 	* if activityID is specified and if that column exists in the activities table, update the activity info with that data.
 	*/
 
-	m_ActivityID = activityID;
-	LoadActivityData(activityID);
+	m_ActivityID = componentID;
+	LoadActivityData(componentID);
 	if (m_Parent->HasVar(u"activityID")) {
 		m_ActivityID = parent->GetVar<int32_t>(u"activityID");
 		LoadActivityData(m_ActivityID);

--- a/dGame/dComponents/BaseCombatAIComponent.cpp
+++ b/dGame/dComponents/BaseCombatAIComponent.cpp
@@ -28,7 +28,7 @@
 #include "CDPhysicsComponentTable.h"
 #include "dNavMesh.h"
 
-BaseCombatAIComponent::BaseCombatAIComponent(Entity* parent, const uint32_t id) : Component(parent) {
+BaseCombatAIComponent::BaseCombatAIComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	m_Target = LWOOBJID_EMPTY;
 	m_DirtyStateOrTarget = true;
 	m_State = AiState::spawn;
@@ -43,7 +43,7 @@ BaseCombatAIComponent::BaseCombatAIComponent(Entity* parent, const uint32_t id) 
 	//Grab the aggro information from BaseCombatAI:
 	auto componentQuery = CDClientDatabase::CreatePreppedStmt(
 		"SELECT aggroRadius, tetherSpeed, pursuitSpeed, softTetherRadius, hardTetherRadius FROM BaseCombatAIComponent WHERE id = ?;");
-	componentQuery.bind(1, static_cast<int>(id));
+	componentQuery.bind(1, static_cast<int>(componentID));
 
 	auto componentResult = componentQuery.execQuery();
 
@@ -111,12 +111,12 @@ BaseCombatAIComponent::BaseCombatAIComponent(Entity* parent, const uint32_t id) 
 	int32_t collisionGroup = (COLLISION_GROUP_DYNAMIC | COLLISION_GROUP_ENEMY);
 
 	CDComponentsRegistryTable* componentRegistryTable = CDClientManager::GetTable<CDComponentsRegistryTable>();
-	auto componentID = componentRegistryTable->GetByIDAndType(parent->GetLOT(), eReplicaComponentType::CONTROLLABLE_PHYSICS);
+	const auto controllablePhysicsID = componentRegistryTable->GetByIDAndType(parent->GetLOT(), eReplicaComponentType::CONTROLLABLE_PHYSICS);
 
 	CDPhysicsComponentTable* physicsComponentTable = CDClientManager::GetTable<CDPhysicsComponentTable>();
 
 	if (physicsComponentTable != nullptr) {
-		auto* info = physicsComponentTable->GetByID(componentID);
+		auto* info = physicsComponentTable->GetByID(controllablePhysicsID);
 		if (info != nullptr) {
 			collisionGroup = info->bStatic ? COLLISION_GROUP_NEUTRAL : info->collisionGroup;
 		}

--- a/dGame/dComponents/BaseCombatAIComponent.h
+++ b/dGame/dComponents/BaseCombatAIComponent.h
@@ -49,7 +49,7 @@ class BaseCombatAIComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::BASE_COMBAT_AI;
 
-	BaseCombatAIComponent(Entity* parentEntity, uint32_t id);
+	BaseCombatAIComponent(Entity* parentEntity, int32_t componentID);
 	~BaseCombatAIComponent() override;
 
 	void Update(float deltaTime) override;

--- a/dGame/dComponents/BouncerComponent.cpp
+++ b/dGame/dComponents/BouncerComponent.cpp
@@ -9,7 +9,7 @@
 #include "BitStream.h"
 #include "eTriggerEventType.h"
 
-BouncerComponent::BouncerComponent(Entity* parent) : Component(parent) {
+BouncerComponent::BouncerComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	m_PetEnabled = false;
 	m_PetBouncerEnabled = false;
 	m_PetSwitchLoaded = false;

--- a/dGame/dComponents/BouncerComponent.h
+++ b/dGame/dComponents/BouncerComponent.h
@@ -14,7 +14,7 @@ class BouncerComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::BOUNCER;
 
-	BouncerComponent(Entity* parentEntity);
+	BouncerComponent(Entity* parentEntity, const int32_t componentID);
 	~BouncerComponent() override;
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;

--- a/dGame/dComponents/BuffComponent.cpp
+++ b/dGame/dComponents/BuffComponent.cpp
@@ -26,7 +26,7 @@ namespace {
 	};
 }
 
-BuffComponent::BuffComponent(Entity* parent) : Component(parent) {
+BuffComponent::BuffComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 }
 
 BuffComponent::~BuffComponent() {

--- a/dGame/dComponents/BuffComponent.h
+++ b/dGame/dComponents/BuffComponent.h
@@ -51,7 +51,7 @@ class BuffComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::BUFF;
 
-	explicit BuffComponent(Entity* parent);
+	explicit BuffComponent(Entity* parent, const int32_t componentID);
 
 	~BuffComponent();
 

--- a/dGame/dComponents/BuildBorderComponent.cpp
+++ b/dGame/dComponents/BuildBorderComponent.cpp
@@ -9,7 +9,7 @@
 #include "Item.h"
 #include "PropertyManagementComponent.h"
 
-BuildBorderComponent::BuildBorderComponent(Entity* parent) : Component(parent) {
+BuildBorderComponent::BuildBorderComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 }
 
 BuildBorderComponent::~BuildBorderComponent() {

--- a/dGame/dComponents/BuildBorderComponent.h
+++ b/dGame/dComponents/BuildBorderComponent.h
@@ -18,7 +18,7 @@ class BuildBorderComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::BUILD_BORDER;
 
-	BuildBorderComponent(Entity* parent);
+	BuildBorderComponent(Entity* parent, const int32_t componentID);
 	~BuildBorderComponent() override;
 
 	/**

--- a/dGame/dComponents/CharacterComponent.cpp
+++ b/dGame/dComponents/CharacterComponent.cpp
@@ -25,7 +25,7 @@
 #include "MessageType/Game.h"
 #include <ctime>
 
-CharacterComponent::CharacterComponent(Entity* parent, Character* character, const SystemAddress& systemAddress) : Component(parent) {
+CharacterComponent::CharacterComponent(Entity* parent, const int32_t componentID, Character* character, const SystemAddress& systemAddress) : Component(parent, componentID) {
 	m_Character = character;
 
 	m_IsRacing = false;

--- a/dGame/dComponents/CharacterComponent.h
+++ b/dGame/dComponents/CharacterComponent.h
@@ -70,7 +70,7 @@ class CharacterComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::CHARACTER;
 
-	CharacterComponent(Entity* parent, Character* character, const SystemAddress& systemAddress);
+	CharacterComponent(Entity* parent, const int32_t componentID, Character* character, const SystemAddress& systemAddress);
 	~CharacterComponent() override;
 
 	void LoadFromXml(const tinyxml2::XMLDocument& doc) override;

--- a/dGame/dComponents/CollectibleComponent.h
+++ b/dGame/dComponents/CollectibleComponent.h
@@ -7,7 +7,7 @@
 class CollectibleComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::COLLECTIBLE;
-	CollectibleComponent(Entity* parentEntity, int32_t collectibleId) : Component(parentEntity), m_CollectibleId(collectibleId) {}
+	CollectibleComponent(Entity* parentEntity, const int32_t componentID, const int32_t collectibleId) : Component(parentEntity, componentID), m_CollectibleId(collectibleId) {}
 
 	int16_t GetCollectibleId() const { return m_CollectibleId; }
 	void Serialize(RakNet::BitStream& outBitStream, bool isConstruction) override;

--- a/dGame/dComponents/Component.h
+++ b/dGame/dComponents/Component.h
@@ -19,7 +19,7 @@ class Entity;
  */
 class Component {
 public:
-	Component(Entity* parent) : m_Parent{ parent } {}
+	Component(Entity* parent, const int32_t componentID) : m_Parent{ parent }, m_ComponentID{componentID} {}
 	virtual ~Component() = default;
 
 	/**
@@ -27,6 +27,8 @@ public:
 	 * @return the owner of this component
 	 */
 	Entity* GetParent() const { return m_Parent; }
+
+	[[nodiscard]] int32_t GetComponentID() const noexcept { return m_ComponentID; }
 
 	/**
 	 * Updates the component in the game loop
@@ -70,4 +72,11 @@ protected:
 	 * The entity that owns this component
 	 */
 	Entity* m_Parent;
+
+	// The component ID, this should never be changed after initialization
+	// This is used in various different ways
+	// 1. To identify which entry this component is in its corresponding table
+	// 2. To mark that an Entity should have the component with no database entry (it will be 0 in this case)
+	// 3. The component exists implicitly due to design (CollectibleComponent always has a DestructibleComponent accompanying it). In this case the ID will be -1.
+	const int32_t m_ComponentID;
 };

--- a/dGame/dComponents/ControllablePhysicsComponent.cpp
+++ b/dGame/dComponents/ControllablePhysicsComponent.cpp
@@ -17,7 +17,7 @@
 #include "StringifiedEnum.h"
 #include "Amf3.h"
 
-ControllablePhysicsComponent::ControllablePhysicsComponent(Entity* entity, int32_t componentId) : PhysicsComponent(entity, componentId) {
+ControllablePhysicsComponent::ControllablePhysicsComponent(Entity* entity, const int32_t componentID) : PhysicsComponent(entity, componentID) {
 	RegisterMsg(MessageType::Game::GET_OBJECT_REPORT_INFO, this, &ControllablePhysicsComponent::OnGetObjectReportInfo);
 
 	m_Velocity = {};

--- a/dGame/dComponents/ControllablePhysicsComponent.h
+++ b/dGame/dComponents/ControllablePhysicsComponent.h
@@ -25,7 +25,7 @@ class ControllablePhysicsComponent : public PhysicsComponent {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::CONTROLLABLE_PHYSICS;
 
-	ControllablePhysicsComponent(Entity* entity, int32_t componentId);
+	ControllablePhysicsComponent(Entity* entity, const int32_t componentID);
 	~ControllablePhysicsComponent() override;
 
 	void Update(float deltaTime) override;

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -44,7 +44,7 @@
 Implementation<bool, const Entity*> DestroyableComponent::IsEnemyImplentation;
 Implementation<bool, const Entity*> DestroyableComponent::IsFriendImplentation;
 
-DestroyableComponent::DestroyableComponent(Entity* parent) : Component(parent) {
+DestroyableComponent::DestroyableComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	using namespace GameMessages;
 	m_iArmor = 0;
 	m_fMaxArmor = 0.0f;

--- a/dGame/dComponents/DestroyableComponent.h
+++ b/dGame/dComponents/DestroyableComponent.h
@@ -26,7 +26,7 @@ class DestroyableComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::DESTROYABLE;
 
-	DestroyableComponent(Entity* parentEntity);
+	DestroyableComponent(Entity* parentEntity, const int32_t componentID);
 	~DestroyableComponent() override;
 
 	void Update(float deltaTime) override;

--- a/dGame/dComponents/DonationVendorComponent.cpp
+++ b/dGame/dComponents/DonationVendorComponent.cpp
@@ -1,7 +1,7 @@
 #include "DonationVendorComponent.h"
 #include "Database.h"
 
-DonationVendorComponent::DonationVendorComponent(Entity* parent) : VendorComponent(parent) {
+DonationVendorComponent::DonationVendorComponent(Entity* parent, const int32_t componentID) : VendorComponent(parent, componentID) {
 	//LoadConfigData
 	m_PercentComplete = 0.0;
 	m_TotalDonated = 0;

--- a/dGame/dComponents/DonationVendorComponent.h
+++ b/dGame/dComponents/DonationVendorComponent.h
@@ -9,7 +9,7 @@ class Entity;
 class DonationVendorComponent final : public VendorComponent {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::DONATION_VENDOR;
-	DonationVendorComponent(Entity* parent);
+	DonationVendorComponent(Entity* parent, const int32_t componentID);
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
 	uint32_t GetActivityID() {return m_ActivityId;};
 	void SubmitDonation(uint32_t count);

--- a/dGame/dComponents/GhostComponent.cpp
+++ b/dGame/dComponents/GhostComponent.cpp
@@ -1,6 +1,6 @@
 #include "GhostComponent.h"
 
-GhostComponent::GhostComponent(Entity* parent) : Component(parent) {
+GhostComponent::GhostComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	m_GhostReferencePoint = NiPoint3Constant::ZERO;
 	m_GhostOverridePoint = NiPoint3Constant::ZERO;
 	m_GhostOverride = false;

--- a/dGame/dComponents/GhostComponent.h
+++ b/dGame/dComponents/GhostComponent.h
@@ -10,7 +10,7 @@ class NiPoint3;
 class GhostComponent final : public Component {
 public:
 	static inline const eReplicaComponentType ComponentType = eReplicaComponentType::GHOST;
-	GhostComponent(Entity* parent);
+	GhostComponent(Entity* parent, const int32_t componentID);
 	~GhostComponent() override;
 
 	void SetGhostOverride(bool value) { m_GhostOverride = value; };

--- a/dGame/dComponents/HavokVehiclePhysicsComponent.cpp
+++ b/dGame/dComponents/HavokVehiclePhysicsComponent.cpp
@@ -2,7 +2,7 @@
 #include "EntityManager.h"
 #include "Amf3.h"
 
-HavokVehiclePhysicsComponent::HavokVehiclePhysicsComponent(Entity* parent, int32_t componentId) : PhysicsComponent(parent, componentId) {
+HavokVehiclePhysicsComponent::HavokVehiclePhysicsComponent(Entity* parent, const int32_t componentID) : PhysicsComponent(parent, componentID) {
 	RegisterMsg(MessageType::Game::GET_OBJECT_REPORT_INFO, this, &HavokVehiclePhysicsComponent::OnGetObjectReportInfo);
 
 	m_Velocity = NiPoint3Constant::ZERO;

--- a/dGame/dComponents/HavokVehiclePhysicsComponent.h
+++ b/dGame/dComponents/HavokVehiclePhysicsComponent.h
@@ -13,7 +13,7 @@ class HavokVehiclePhysicsComponent : public PhysicsComponent {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::HAVOK_VEHICLE_PHYSICS;
 
-	HavokVehiclePhysicsComponent(Entity* parentEntity, int32_t componentId);
+	HavokVehiclePhysicsComponent(Entity* parentEntity, const int32_t componentID);
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
 

--- a/dGame/dComponents/InventoryComponent.cpp
+++ b/dGame/dComponents/InventoryComponent.cpp
@@ -42,7 +42,7 @@
 
 #include <ranges>
 
-InventoryComponent::InventoryComponent(Entity* parent) : Component(parent) {
+InventoryComponent::InventoryComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	this->m_Dirty = true;
 	this->m_Equipped = {};
 	this->m_Pushed = {};

--- a/dGame/dComponents/InventoryComponent.h
+++ b/dGame/dComponents/InventoryComponent.h
@@ -67,7 +67,7 @@ public:
 	static constexpr uint32_t MaximumGroupCount = 50;
 
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::INVENTORY;
-	InventoryComponent(Entity* parent);
+	InventoryComponent(Entity* parent, const int32_t componentID);
 
 	void Update(float deltaTime) override;
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;

--- a/dGame/dComponents/ItemComponent.h
+++ b/dGame/dComponents/ItemComponent.h
@@ -8,7 +8,7 @@ class ItemComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::ITEM;
 
-	ItemComponent(Entity* entity) : Component(entity) {}
+	ItemComponent(Entity* entity, const int32_t componentID) : Component(entity, componentID) {}
 
 	void Serialize(RakNet::BitStream& bitStream, bool isConstruction) override;
 };

--- a/dGame/dComponents/LUPExhibitComponent.h
+++ b/dGame/dComponents/LUPExhibitComponent.h
@@ -16,7 +16,7 @@ class LUPExhibitComponent final : public Component
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::LUP_EXHIBIT;
 
-	LUPExhibitComponent(Entity* parent) : Component(parent) {};
+	LUPExhibitComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {};
 	void Update(float deltaTime) override;
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
 	void NextLUPExhibit();

--- a/dGame/dComponents/LevelProgressionComponent.cpp
+++ b/dGame/dComponents/LevelProgressionComponent.cpp
@@ -6,7 +6,7 @@
 
 #include "CDRewardsTable.h"
 
-LevelProgressionComponent::LevelProgressionComponent(Entity* parent) : Component(parent) {
+LevelProgressionComponent::LevelProgressionComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	m_Parent = parent;
 	m_Level = 1;
 	m_SpeedBase = 500.0f;

--- a/dGame/dComponents/LevelProgressionComponent.h
+++ b/dGame/dComponents/LevelProgressionComponent.h
@@ -19,7 +19,7 @@ public:
 	 * Constructor for this component
 	 * @param parent parent that contains this component
 	 */
-	LevelProgressionComponent(Entity* parent);
+	LevelProgressionComponent(Entity* parent, const int32_t componentID);
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
 

--- a/dGame/dComponents/MiniGameControlComponent.h
+++ b/dGame/dComponents/MiniGameControlComponent.h
@@ -8,7 +8,7 @@ class MiniGameControlComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::MINI_GAME_CONTROL;
 
-	MiniGameControlComponent(Entity* parent) : Component(parent) {}
+	MiniGameControlComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {}
 	void Serialize(RakNet::BitStream& outBitStream, bool isConstruction);
 };
 

--- a/dGame/dComponents/MinigameComponent.cpp
+++ b/dGame/dComponents/MinigameComponent.cpp
@@ -1,5 +1,0 @@
-#include "MinigameComponent.h"
-
-void MinigameComponent::Serialize(RakNet::BitStream& outBitStream, bool isConstruction) {
-	outBitStream.Write<uint32_t>(0x40000000);
-}

--- a/dGame/dComponents/MissionComponent.cpp
+++ b/dGame/dComponents/MissionComponent.cpp
@@ -26,7 +26,7 @@
 std::unordered_map<AchievementCacheKey, std::vector<uint32_t>> MissionComponent::m_AchievementCache = {};
 
 //! Initializer
-MissionComponent::MissionComponent(Entity* parent) : Component(parent) {
+MissionComponent::MissionComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	m_LastUsedMissionOrderUID = Game::zoneManager->GetUniqueMissionIdStartingValue();
 }
 

--- a/dGame/dComponents/MissionComponent.h
+++ b/dGame/dComponents/MissionComponent.h
@@ -28,7 +28,7 @@ class MissionComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::MISSION;
 
-	explicit MissionComponent(Entity* parent);
+	explicit MissionComponent(Entity* parent, const int32_t componentID);
 	~MissionComponent() override;
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate, unsigned int& flags);
 	void LoadFromXml(const tinyxml2::XMLDocument& doc) override;

--- a/dGame/dComponents/MissionOfferComponent.cpp
+++ b/dGame/dComponents/MissionOfferComponent.cpp
@@ -39,19 +39,13 @@ bool OfferedMission::GetAcceptsMission() const {
 
 //------------------------ MissionOfferComponent below ------------------------
 
-MissionOfferComponent::MissionOfferComponent(Entity* parent, const LOT parentLot) : Component(parent) {
-	auto* compRegistryTable = CDClientManager::GetTable<CDComponentsRegistryTable>();
-
-	auto value = compRegistryTable->GetByIDAndType(parentLot, eReplicaComponentType::MISSION_OFFER, -1);
-
-	if (value != -1) {
-		const uint32_t componentId = value;
-
+MissionOfferComponent::MissionOfferComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
+	if (componentID != -1) {
 		// Now lookup the missions in the MissionNPCComponent table
 		auto* missionNpcComponentTable = CDClientManager::GetTable<CDMissionNPCComponentTable>();
 
-		auto missions = missionNpcComponentTable->Query([=](const CDMissionNPCComponent& entry) {
-			return entry.id == static_cast<unsigned>(componentId);
+		auto missions = missionNpcComponentTable->Query([componentID](const CDMissionNPCComponent& entry) {
+			return entry.id == static_cast<unsigned>(componentID);
 			});
 
 		for (auto& mission : missions) {

--- a/dGame/dComponents/MissionOfferComponent.h
+++ b/dGame/dComponents/MissionOfferComponent.h
@@ -63,7 +63,7 @@ class MissionOfferComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::MISSION_OFFER;
 
-	MissionOfferComponent(Entity* parent, LOT parentLot);
+	MissionOfferComponent(Entity* parent, const int32_t componentID);
 
 	/**
 	 * Handles the OnUse event triggered by some entity, determines which missions to show based on what they may

--- a/dGame/dComponents/ModelComponent.cpp
+++ b/dGame/dComponents/ModelComponent.cpp
@@ -14,7 +14,7 @@
 #include "Database.h"
 #include "DluAssert.h"
 
-ModelComponent::ModelComponent(Entity* parent) : Component(parent) {
+ModelComponent::ModelComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	using namespace GameMessages;
 	m_OriginalPosition = m_Parent->GetDefaultPosition();
 	m_OriginalRotation = m_Parent->GetDefaultRotation();

--- a/dGame/dComponents/ModelComponent.h
+++ b/dGame/dComponents/ModelComponent.h
@@ -27,7 +27,7 @@ class ModelComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::MODEL;
 
-	ModelComponent(Entity* parent);
+	ModelComponent(Entity* parent, const int32_t componentID);
 
 	void LoadBehaviors();
 	void Update(float deltaTime) override;

--- a/dGame/dComponents/ModuleAssemblyComponent.cpp
+++ b/dGame/dComponents/ModuleAssemblyComponent.cpp
@@ -1,6 +1,6 @@
 #include "ModuleAssemblyComponent.h"
 
-ModuleAssemblyComponent::ModuleAssemblyComponent(Entity* parent) : Component(parent) {
+ModuleAssemblyComponent::ModuleAssemblyComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	m_SubKey = LWOOBJID_EMPTY;
 	m_UseOptionalParts = false;
 	m_AssemblyPartsLOTs = u"";

--- a/dGame/dComponents/ModuleAssemblyComponent.h
+++ b/dGame/dComponents/ModuleAssemblyComponent.h
@@ -14,7 +14,7 @@ class ModuleAssemblyComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::MODULE_ASSEMBLY;
 
-	ModuleAssemblyComponent(Entity* parent);
+	ModuleAssemblyComponent(Entity* parent, const int32_t componentID);
 	~ModuleAssemblyComponent() override;
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;

--- a/dGame/dComponents/MovementAIComponent.cpp
+++ b/dGame/dComponents/MovementAIComponent.cpp
@@ -26,7 +26,7 @@ namespace {
 	std::map<LOT, float> m_PhysicsSpeedCache;
 }
 
-MovementAIComponent::MovementAIComponent(Entity* parent, MovementAIInfo info) : Component(parent) {
+MovementAIComponent::MovementAIComponent(Entity* parent, const int32_t componentID, MovementAIInfo info) : Component(parent, componentID) {
 	m_Info = info;
 	m_AtFinalWaypoint = true;
 

--- a/dGame/dComponents/MovementAIComponent.h
+++ b/dGame/dComponents/MovementAIComponent.h
@@ -62,7 +62,7 @@ class MovementAIComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::MOVEMENT_AI;
 
-	MovementAIComponent(Entity* parentEntity, MovementAIInfo info);
+	MovementAIComponent(Entity* parentEntity, const int32_t componentID, MovementAIInfo info);
 
 	void SetPath(const std::string pathName);
 

--- a/dGame/dComponents/MovingPlatformComponent.cpp
+++ b/dGame/dComponents/MovingPlatformComponent.cpp
@@ -55,7 +55,7 @@ void MoverSubComponent::Serialize(RakNet::BitStream& outBitStream, bool bIsIniti
 
 //------------- MovingPlatformComponent below --------------
 
-MovingPlatformComponent::MovingPlatformComponent(Entity* parent, const std::string& pathName) : Component(parent) {
+MovingPlatformComponent::MovingPlatformComponent(Entity* parent, const int32_t componentID, const std::string& pathName) : Component(parent, componentID) {
 	m_MoverSubComponentType = eMoverSubComponentType::mover;
 	m_MoverSubComponent = new MoverSubComponent(m_Parent->GetDefaultPosition());
 	m_PathName = GeneralUtils::ASCIIToUTF16(pathName);

--- a/dGame/dComponents/MovingPlatformComponent.h
+++ b/dGame/dComponents/MovingPlatformComponent.h
@@ -108,7 +108,7 @@ class MovingPlatformComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::MOVING_PLATFORM;
 
-	MovingPlatformComponent(Entity* parent, const std::string& pathName);
+	MovingPlatformComponent(Entity* parent, const int32_t componentID, const std::string& pathName);
 	~MovingPlatformComponent() override;
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;

--- a/dGame/dComponents/MultiZoneEntranceComponent.cpp
+++ b/dGame/dComponents/MultiZoneEntranceComponent.cpp
@@ -3,7 +3,7 @@
 #include "InventoryComponent.h"
 #include "CharacterComponent.h"
 
-MultiZoneEntranceComponent::MultiZoneEntranceComponent(Entity* parent) : Component(parent) {
+MultiZoneEntranceComponent::MultiZoneEntranceComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	m_Parent = parent;
 	std::string zoneString = GeneralUtils::UTF16ToWTF8(m_Parent->GetVar<std::u16string>(u"MultiZoneIDs"));
 	std::stringstream ss(zoneString);

--- a/dGame/dComponents/MultiZoneEntranceComponent.h
+++ b/dGame/dComponents/MultiZoneEntranceComponent.h
@@ -16,7 +16,7 @@ public:
 	 * Constructor for this component, builds the m_LUPWorlds vector
 	 * @param parent parent that contains this component
 	 */
-	MultiZoneEntranceComponent(Entity* parent);
+	MultiZoneEntranceComponent(Entity* parent, const int32_t componentID);
 	~MultiZoneEntranceComponent() override;
 
 	/**

--- a/dGame/dComponents/PetComponent.cpp
+++ b/dGame/dComponents/PetComponent.cpp
@@ -43,9 +43,8 @@ std::unordered_map<LWOOBJID, LWOOBJID> PetComponent::activePets{};
  * while the faction ones could be checked using their respective missions.
  */
 
-PetComponent::PetComponent(Entity* parentEntity, uint32_t componentId) : Component{ parentEntity } {
-	m_PetInfo = CDClientManager::GetTable<CDPetComponentTable>()->GetByID(componentId); // TODO: Make reference when safe
-	m_ComponentId = componentId;
+PetComponent::PetComponent(Entity* parentEntity, const int32_t componentID) : Component{ parentEntity, componentID } {
+	m_PetInfo = CDClientManager::GetTable<CDPetComponentTable>()->GetByID(componentID); // TODO: Make reference when safe
 
 	m_Interaction = LWOOBJID_EMPTY;
 	m_Owner = LWOOBJID_EMPTY;
@@ -537,7 +536,7 @@ void PetComponent::NotifyTamingBuildSuccess(NiPoint3 position) {
 
 	// Triggers the catch a pet missions
 	constexpr auto PET_FLAG_BASE = 800;
-	tamer->GetCharacter()->SetPlayerFlag(PET_FLAG_BASE + m_ComponentId, true);
+	tamer->GetCharacter()->SetPlayerFlag(PET_FLAG_BASE + m_ComponentID, true);
 
 	auto* missionComponent = tamer->GetComponent<MissionComponent>();
 

--- a/dGame/dComponents/PetComponent.h
+++ b/dGame/dComponents/PetComponent.h
@@ -18,7 +18,7 @@ class PetComponent final : public Component
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::PET;
 
-	explicit PetComponent(Entity* parentEntity, uint32_t componentId);
+	explicit PetComponent(Entity* parentEntity, const int32_t componentID);
 	~PetComponent() override;
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
@@ -249,11 +249,6 @@ private:
 	 * Cache of all the pets that are currently being tamed, indexed by tamer
 	 */
 	static std::unordered_map<LWOOBJID, LWOOBJID> currentActivities;
-
-	/**
-	 * The ID of the component in the pet component table
-	 */
-	uint32_t m_ComponentId;
 
 	/**
 	 * The ID of the model that was built to complete the taming minigame for this pet

--- a/dGame/dComponents/PhantomPhysicsComponent.cpp
+++ b/dGame/dComponents/PhantomPhysicsComponent.cpp
@@ -28,7 +28,7 @@
 #include "dpShapeBox.h"
 #include "dpShapeSphere.h"
 
-PhantomPhysicsComponent::PhantomPhysicsComponent(Entity* parent, int32_t componentId) : PhysicsComponent(parent, componentId) {
+PhantomPhysicsComponent::PhantomPhysicsComponent(Entity* parent, const int32_t componentID) : PhysicsComponent(parent, componentID) {
 	RegisterMsg(MessageType::Game::GET_OBJECT_REPORT_INFO, this, &PhantomPhysicsComponent::OnGetObjectReportInfo);
 
 	m_Position = m_Parent->GetDefaultPosition();

--- a/dGame/dComponents/PhantomPhysicsComponent.h
+++ b/dGame/dComponents/PhantomPhysicsComponent.h
@@ -28,7 +28,7 @@ class PhantomPhysicsComponent final : public PhysicsComponent {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::PHANTOM_PHYSICS;
 
-	PhantomPhysicsComponent(Entity* parent, int32_t componentId);
+	PhantomPhysicsComponent(Entity* parent, const int32_t componentID);
 	~PhantomPhysicsComponent() override;
 	void Update(float deltaTime) override;
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;

--- a/dGame/dComponents/PhysicsComponent.cpp
+++ b/dGame/dComponents/PhysicsComponent.cpp
@@ -15,7 +15,7 @@
 #include "EntityInfo.h"
 #include "Amf3.h"
 
-PhysicsComponent::PhysicsComponent(Entity* parent, int32_t componentId) : Component(parent) {
+PhysicsComponent::PhysicsComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	m_Position = NiPoint3Constant::ZERO;
 	m_Rotation = QuatUtils::IDENTITY;
 	m_DirtyPosition = false;
@@ -23,7 +23,7 @@ PhysicsComponent::PhysicsComponent(Entity* parent, int32_t componentId) : Compon
 	CDPhysicsComponentTable* physicsComponentTable = CDClientManager::GetTable<CDPhysicsComponentTable>();
 
 	if (physicsComponentTable) {
-		auto* info = physicsComponentTable->GetByID(componentId);
+		auto* info = physicsComponentTable->GetByID(componentID);
 		if (info) {
 			m_CollisionGroup = info->collisionGroup;
 		}

--- a/dGame/dComponents/PhysicsComponent.h
+++ b/dGame/dComponents/PhysicsComponent.h
@@ -19,7 +19,7 @@ class dpEntity;
 
 class PhysicsComponent : public Component {
 public:
-	PhysicsComponent(Entity* parent, int32_t componentId);
+	PhysicsComponent(Entity* parent, const int32_t componentID);
 	virtual ~PhysicsComponent() = default;
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;

--- a/dGame/dComponents/PlayerForcedMovementComponent.cpp
+++ b/dGame/dComponents/PlayerForcedMovementComponent.cpp
@@ -1,6 +1,6 @@
 #include "PlayerForcedMovementComponent.h"
 
-PlayerForcedMovementComponent::PlayerForcedMovementComponent(Entity* parent) : Component(parent) {
+PlayerForcedMovementComponent::PlayerForcedMovementComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	m_Parent = parent;
 }
 

--- a/dGame/dComponents/PlayerForcedMovementComponent.h
+++ b/dGame/dComponents/PlayerForcedMovementComponent.h
@@ -16,7 +16,7 @@ public:
 	 * Constructor for this component
 	 * @param parent parent that contains this component
 	 */
-	PlayerForcedMovementComponent(Entity* parent);
+	PlayerForcedMovementComponent(Entity* parent, const int32_t componentID);
 	~PlayerForcedMovementComponent() override;
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;

--- a/dGame/dComponents/PossessableComponent.cpp
+++ b/dGame/dComponents/PossessableComponent.cpp
@@ -4,7 +4,7 @@
 #include "Inventory.h"
 #include "Item.h"
 
-PossessableComponent::PossessableComponent(Entity* parent, uint32_t componentId) : Component(parent) {
+PossessableComponent::PossessableComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	m_Possessor = LWOOBJID_EMPTY;
 	CDItemComponent item = Inventory::FindItemComponent(m_Parent->GetLOT());
 	m_AnimationFlag = static_cast<eAnimationFlags>(item.animationFlag);
@@ -12,7 +12,7 @@ PossessableComponent::PossessableComponent(Entity* parent, uint32_t componentId)
 	// Get the possession Type from the CDClient
 	auto query = CDClientDatabase::CreatePreppedStmt("SELECT possessionType, depossessOnHit FROM PossessableComponent WHERE id = ?;");
 
-	query.bind(1, static_cast<int>(componentId));
+	query.bind(1, static_cast<int>(componentID));
 
 	auto result = query.execQuery();
 

--- a/dGame/dComponents/PossessableComponent.h
+++ b/dGame/dComponents/PossessableComponent.h
@@ -16,14 +16,9 @@ class PossessableComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::POSSESSABLE;
 
-	PossessableComponent(Entity* parentEntity, uint32_t componentId);
+	PossessableComponent(Entity* parentEntity, const int32_t componentID);
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
-
-	/**
-	 * @brief mounts the Entity
-	 */
-	void Mount();
 
 	/**
 	 * @brief dismounts the Entity

--- a/dGame/dComponents/PossessorComponent.cpp
+++ b/dGame/dComponents/PossessorComponent.cpp
@@ -7,7 +7,7 @@
 #include "eControlScheme.h"
 #include "eStateChangeType.h"
 
-PossessorComponent::PossessorComponent(Entity* parent) : Component(parent) {
+PossessorComponent::PossessorComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	m_Possessable = LWOOBJID_EMPTY;
 }
 

--- a/dGame/dComponents/PossessorComponent.h
+++ b/dGame/dComponents/PossessorComponent.h
@@ -20,7 +20,7 @@ class PossessorComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::POSSESSOR;
 
-	PossessorComponent(Entity* parent);
+	PossessorComponent(Entity* parent, const int32_t componentID);
 	~PossessorComponent() override;
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;

--- a/dGame/dComponents/PropertyComponent.h
+++ b/dGame/dComponents/PropertyComponent.h
@@ -16,7 +16,7 @@
 class PropertyComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::PROPERTY;
-	explicit PropertyComponent(Entity* const parentEntity) noexcept : Component{ parentEntity } {}
+	explicit PropertyComponent(Entity* const parentEntity, const int32_t componentID) noexcept : Component{ parentEntity, componentID } {}
 };
 
 #endif // !PROPERTYCOMPONENT_H

--- a/dGame/dComponents/PropertyEntranceComponent.cpp
+++ b/dGame/dComponents/PropertyEntranceComponent.cpp
@@ -17,7 +17,7 @@
 #include "ePropertySortType.h"
 #include "User.h"
 
-PropertyEntranceComponent::PropertyEntranceComponent(Entity* parent, uint32_t componentID) : Component(parent) {
+PropertyEntranceComponent::PropertyEntranceComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	this->propertyQueries = {};
 
 	auto table = CDClientManager::GetTable<CDPropertyEntranceComponentTable>();

--- a/dGame/dComponents/PropertyEntranceComponent.h
+++ b/dGame/dComponents/PropertyEntranceComponent.h
@@ -13,7 +13,7 @@
  */
 class PropertyEntranceComponent final : public Component {
 public:
-	explicit PropertyEntranceComponent(Entity* parent, uint32_t componentID);
+	explicit PropertyEntranceComponent(Entity* parent, const int32_t componentID);
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::PROPERTY_ENTRANCE;
 
 	/**

--- a/dGame/dComponents/PropertyManagementComponent.cpp
+++ b/dGame/dComponents/PropertyManagementComponent.cpp
@@ -30,7 +30,7 @@
 
 PropertyManagementComponent* PropertyManagementComponent::instance = nullptr;
 
-PropertyManagementComponent::PropertyManagementComponent(Entity* parent) : Component(parent) {
+PropertyManagementComponent::PropertyManagementComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	this->owner = LWOOBJID_EMPTY;
 	this->templateId = 0;
 	this->propertyId = LWOOBJID_EMPTY;

--- a/dGame/dComponents/PropertyManagementComponent.h
+++ b/dGame/dComponents/PropertyManagementComponent.h
@@ -31,7 +31,7 @@ enum class PropertyPrivacyOption {
 class PropertyManagementComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::PROPERTY_MANAGEMENT;
-	PropertyManagementComponent(Entity* parent);
+	PropertyManagementComponent(Entity* parent, const int32_t componentID);
 	static PropertyManagementComponent* Instance();
 
 	/**

--- a/dGame/dComponents/PropertyVendorComponent.cpp
+++ b/dGame/dComponents/PropertyVendorComponent.cpp
@@ -10,7 +10,7 @@
 #include "PropertyManagementComponent.h"
 #include "UserManager.h"
 
-PropertyVendorComponent::PropertyVendorComponent(Entity* parent) : Component(parent) {
+PropertyVendorComponent::PropertyVendorComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 }
 
 void PropertyVendorComponent::OnUse(Entity* originator) {

--- a/dGame/dComponents/PropertyVendorComponent.h
+++ b/dGame/dComponents/PropertyVendorComponent.h
@@ -10,7 +10,7 @@
 class PropertyVendorComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::PROPERTY_VENDOR;
-	explicit PropertyVendorComponent(Entity* parent);
+	explicit PropertyVendorComponent(Entity* parent, const int32_t componentID);
 
 	/**
 	 * Handles a use event from some entity, if the property is cleared this allows the entity to claim it

--- a/dGame/dComponents/ProximityMonitorComponent.cpp
+++ b/dGame/dComponents/ProximityMonitorComponent.cpp
@@ -7,7 +7,7 @@
 
 const std::unordered_set<LWOOBJID> ProximityMonitorComponent::m_EmptyObjectSet = {};
 
-ProximityMonitorComponent::ProximityMonitorComponent(Entity* parent, int radiusSmall, int radiusLarge) : Component(parent) {
+ProximityMonitorComponent::ProximityMonitorComponent(Entity* parent, const int32_t componentID, int radiusSmall, int radiusLarge) : Component(parent, componentID) {
 	if (radiusSmall != -1 && radiusLarge != -1) {
 		SetProximityRadius(radiusSmall, "rocketSmall");
 		SetProximityRadius(radiusLarge, "rocketLarge");

--- a/dGame/dComponents/ProximityMonitorComponent.h
+++ b/dGame/dComponents/ProximityMonitorComponent.h
@@ -23,7 +23,7 @@ class ProximityMonitorComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::PROXIMITY_MONITOR;
 
-	ProximityMonitorComponent(Entity* parentEntity, int smallRadius = -1, int largeRadius = -1);
+	ProximityMonitorComponent(Entity* parentEntity, const int32_t componentID, int smallRadius = -1, int largeRadius = -1);
 	~ProximityMonitorComponent() override;
 	void Update(float deltaTime) override;
 

--- a/dGame/dComponents/QuickBuildComponent.cpp
+++ b/dGame/dComponents/QuickBuildComponent.cpp
@@ -23,7 +23,7 @@
 
 #include "CppScripts.h"
 
-QuickBuildComponent::QuickBuildComponent(Entity* const entity) : Component{ entity } {
+QuickBuildComponent::QuickBuildComponent(Entity* const entity, const int32_t componentID) : Component{ entity, componentID } {
 	std::u16string checkPreconditions = entity->GetVar<std::u16string>(u"CheckPrecondition");
 
 	if (!checkPreconditions.empty()) {

--- a/dGame/dComponents/QuickBuildComponent.h
+++ b/dGame/dComponents/QuickBuildComponent.h
@@ -24,7 +24,7 @@ class QuickBuildComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::QUICK_BUILD;
 
-	QuickBuildComponent(Entity* const entity);
+	QuickBuildComponent(Entity* const entity, const int32_t componentID);
 	~QuickBuildComponent() override;
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;

--- a/dGame/dComponents/RacingControlComponent.cpp
+++ b/dGame/dComponents/RacingControlComponent.cpp
@@ -32,8 +32,8 @@
 #define M_PI 3.14159265358979323846264338327950288
 #endif
 
-RacingControlComponent::RacingControlComponent(Entity* parent)
-	: Component(parent) {
+RacingControlComponent::RacingControlComponent(Entity* parent, const int32_t componentID)
+	: Component(parent, componentID) {
 	m_PathName = u"MainPath";
 	m_NumberOfLaps = 3;
 	m_RemainingLaps = m_NumberOfLaps;

--- a/dGame/dComponents/RacingControlComponent.h
+++ b/dGame/dComponents/RacingControlComponent.h
@@ -108,7 +108,7 @@ class RacingControlComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::RACING_CONTROL;
 
-	RacingControlComponent(Entity* parentEntity);
+	RacingControlComponent(Entity* parentEntity, const int32_t componentID);
 	~RacingControlComponent();
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;

--- a/dGame/dComponents/RacingSoundTriggerComponent.h
+++ b/dGame/dComponents/RacingSoundTriggerComponent.h
@@ -9,7 +9,7 @@ class Entity;
 class RacingSoundTriggerComponent : public SoundTriggerComponent {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::RACING_SOUND_TRIGGER;
-	RacingSoundTriggerComponent(Entity* parent) : SoundTriggerComponent(parent){};
+	RacingSoundTriggerComponent(Entity* parent, const int32_t componentID) : SoundTriggerComponent(parent, componentID){};
 };
 
 #endif  //!__RACINGSOUNDTRIGGERCOMPONENT__H__

--- a/dGame/dComponents/RacingStatsComponent.h
+++ b/dGame/dComponents/RacingStatsComponent.h
@@ -8,7 +8,7 @@ class RacingStatsComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::RACING_STATS;
 
-	RacingStatsComponent(Entity* parent) : Component(parent) {}
+	RacingStatsComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {}
 };
 
 #endif  //!__RACINGSTATSCOMPONENT__H__

--- a/dGame/dComponents/RailActivatorComponent.cpp
+++ b/dGame/dComponents/RailActivatorComponent.cpp
@@ -11,9 +11,8 @@
 #include "EntityManager.h"
 #include "eStateChangeType.h"
 
-RailActivatorComponent::RailActivatorComponent(Entity* parent, int32_t componentID) : Component(parent) {
-	m_ComponentID = componentID;
-	const auto tableData = CDClientManager::GetTable<CDRailActivatorComponentTable>()->GetEntryByID(componentID);;
+RailActivatorComponent::RailActivatorComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
+	const auto tableData = CDClientManager::GetTable<CDRailActivatorComponentTable>()->GetEntryByID(componentID);
 
 	m_Path = parent->GetVar<std::u16string>(u"rail_path");
 	m_PathDirection = parent->GetVar<bool>(u"rail_path_direction");

--- a/dGame/dComponents/RailActivatorComponent.h
+++ b/dGame/dComponents/RailActivatorComponent.h
@@ -12,7 +12,7 @@
  */
 class RailActivatorComponent final : public Component {
 public:
-	explicit RailActivatorComponent(Entity* parent, int32_t componentID);
+	explicit RailActivatorComponent(Entity* parent, const int32_t componentID);
 	~RailActivatorComponent() override;
 
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::RAIL_ACTIVATOR;
@@ -37,12 +37,6 @@ public:
 	 */
 	void OnCancelRailMovement(Entity* originator);
 private:
-
-	/**
-	 * The ID of this component in the components database
-	 */
-	int32_t m_ComponentID;
-
 	/**
 	 * The entities that are currently traversing the rail
 	 */

--- a/dGame/dComponents/RenderComponent.cpp
+++ b/dGame/dComponents/RenderComponent.cpp
@@ -16,12 +16,12 @@
 
 std::unordered_map<int32_t, float> RenderComponent::m_DurationCache{};
 
-RenderComponent::RenderComponent(Entity* const parentEntity, const int32_t componentId) : Component{ parentEntity } {
+RenderComponent::RenderComponent(Entity* const parentEntity, const int32_t componentID) : Component{ parentEntity, componentID } {
 	m_LastAnimationName = "";
-	if (componentId == -1) return;
+	if (componentID == -1) return;
 
 	auto query = CDClientDatabase::CreatePreppedStmt("SELECT * FROM RenderComponent WHERE id = ?;");
-	query.bind(1, componentId);
+	query.bind(1, componentID);
 	auto result = query.execQuery();
 
 	if (!result.eof()) {

--- a/dGame/dComponents/RenderComponent.h
+++ b/dGame/dComponents/RenderComponent.h
@@ -63,7 +63,7 @@ class RenderComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::RENDER;
 
-	RenderComponent(Entity* const parentEntity, const int32_t componentId = -1);
+	RenderComponent(Entity* const parentEntity, const int32_t componentID);
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
 	void Update(float deltaTime) override;

--- a/dGame/dComponents/RigidbodyPhantomPhysicsComponent.cpp
+++ b/dGame/dComponents/RigidbodyPhantomPhysicsComponent.cpp
@@ -13,7 +13,7 @@
 #include "EntityInfo.h"
 #include "Amf3.h"
 
-RigidbodyPhantomPhysicsComponent::RigidbodyPhantomPhysicsComponent(Entity* parent, int32_t componentId) : PhysicsComponent(parent, componentId) {
+RigidbodyPhantomPhysicsComponent::RigidbodyPhantomPhysicsComponent(Entity* parent, const int32_t componentID) : PhysicsComponent(parent, componentID) {
 	RegisterMsg(MessageType::Game::GET_OBJECT_REPORT_INFO, this, &RigidbodyPhantomPhysicsComponent::OnGetObjectReportInfo);
 
 	m_Position = m_Parent->GetDefaultPosition();

--- a/dGame/dComponents/RigidbodyPhantomPhysicsComponent.h
+++ b/dGame/dComponents/RigidbodyPhantomPhysicsComponent.h
@@ -21,7 +21,7 @@ class RigidbodyPhantomPhysicsComponent : public PhysicsComponent {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::RIGID_BODY_PHANTOM_PHYSICS;
 
-	RigidbodyPhantomPhysicsComponent(Entity* parent, int32_t componentId);
+	RigidbodyPhantomPhysicsComponent(Entity* parent, const int32_t componentID);
 
 	void Update(const float deltaTime) override;
 

--- a/dGame/dComponents/RocketLaunchpadControlComponent.cpp
+++ b/dGame/dComponents/RocketLaunchpadControlComponent.cpp
@@ -20,10 +20,10 @@
 #include "ServiceType.h"
 #include "MessageType/Master.h"
 
-RocketLaunchpadControlComponent::RocketLaunchpadControlComponent(Entity* parent, int rocketId) : Component(parent) {
+RocketLaunchpadControlComponent::RocketLaunchpadControlComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	auto query = CDClientDatabase::CreatePreppedStmt(
 		"SELECT targetZone, defaultZoneID, targetScene, altLandingPrecondition, altLandingSpawnPointName FROM RocketLaunchpadControlComponent WHERE id = ?;");
-	query.bind(1, rocketId);
+	query.bind(1, componentID);
 
 	auto result = query.execQuery();
 

--- a/dGame/dComponents/RocketLaunchpadControlComponent.h
+++ b/dGame/dComponents/RocketLaunchpadControlComponent.h
@@ -20,7 +20,7 @@ class RocketLaunchpadControlComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::ROCKET_LAUNCH;
 
-	RocketLaunchpadControlComponent(Entity* parent, int rocketId);
+	RocketLaunchpadControlComponent(Entity* parent, const int32_t componentID);
 	~RocketLaunchpadControlComponent() override;
 
 	/**

--- a/dGame/dComponents/ScriptComponent.cpp
+++ b/dGame/dComponents/ScriptComponent.cpp
@@ -6,7 +6,7 @@
 #include "Entity.h"
 #include "ScriptComponent.h"
 
-ScriptComponent::ScriptComponent(Entity* parent, std::string scriptName, bool serialized, bool client) : Component(parent) {
+ScriptComponent::ScriptComponent(Entity* parent, const int32_t componentID, std::string scriptName, bool serialized, bool client) : Component(parent, componentID) {
 	m_Serialized = serialized;
 	m_Client = client;
 

--- a/dGame/dComponents/ScriptComponent.h
+++ b/dGame/dComponents/ScriptComponent.h
@@ -21,7 +21,7 @@ class ScriptComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::SCRIPT;
 
-	ScriptComponent(Entity* parent, std::string scriptName, bool serialized, bool client = false);
+	ScriptComponent(Entity* parent, const int32_t componentID, std::string scriptName, bool serialized, bool client);
 	~ScriptComponent() override;
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;

--- a/dGame/dComponents/ScriptedActivityComponent.h
+++ b/dGame/dComponents/ScriptedActivityComponent.h
@@ -9,7 +9,7 @@ class Entity;
 class ScriptedActivityComponent final : public ActivityComponent {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::SCRIPTED_ACTIVITY;
-	ScriptedActivityComponent(Entity* parent, int activityID) : ActivityComponent(parent, activityID){};
+	ScriptedActivityComponent(Entity* parent, const int32_t componentID) : ActivityComponent(parent, componentID){};
 };
 
 #endif  //!__SCRIPTEDACTIVITYCOMPONENT__H__

--- a/dGame/dComponents/ShootingGalleryComponent.cpp
+++ b/dGame/dComponents/ShootingGalleryComponent.cpp
@@ -2,7 +2,7 @@
 #include "EntityManager.h"
 #include "ScriptedActivityComponent.h"
 
-ShootingGalleryComponent::ShootingGalleryComponent(Entity* parent, int32_t activityID) : ActivityComponent(parent, activityID) {
+ShootingGalleryComponent::ShootingGalleryComponent(Entity* parent, const int32_t componentID) : ActivityComponent(parent, componentID) {
 }
 
 void ShootingGalleryComponent::SetStaticParams(const StaticShootingGalleryParams& params) {

--- a/dGame/dComponents/ShootingGalleryComponent.h
+++ b/dGame/dComponents/ShootingGalleryComponent.h
@@ -76,7 +76,7 @@ class ShootingGalleryComponent final : public ActivityComponent {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::SHOOTING_GALLERY;
 
-	explicit ShootingGalleryComponent(Entity* parent, int32_t activityID);
+	explicit ShootingGalleryComponent(Entity* parent, const int32_t componentID);
 	void Serialize(RakNet::BitStream& outBitStream, bool isInitialUpdate) override;
 
 	/**

--- a/dGame/dComponents/SimplePhysicsComponent.cpp
+++ b/dGame/dComponents/SimplePhysicsComponent.cpp
@@ -15,7 +15,7 @@
 #include "StringifiedEnum.h"
 #include "Amf3.h"
 
-SimplePhysicsComponent::SimplePhysicsComponent(Entity* parent, int32_t componentID) : PhysicsComponent(parent, componentID) {
+SimplePhysicsComponent::SimplePhysicsComponent(Entity* parent, const int32_t componentID) : PhysicsComponent(parent, componentID) {
 	RegisterMsg(MessageType::Game::GET_OBJECT_REPORT_INFO, this, &SimplePhysicsComponent::OnGetObjectReportInfo);
 
 	m_Position = m_Parent->GetDefaultPosition();

--- a/dGame/dComponents/SimplePhysicsComponent.h
+++ b/dGame/dComponents/SimplePhysicsComponent.h
@@ -30,7 +30,7 @@ class SimplePhysicsComponent : public PhysicsComponent {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::SIMPLE_PHYSICS;
 
-	SimplePhysicsComponent(Entity* parent, int32_t componentID);
+	SimplePhysicsComponent(Entity* parent, const int32_t componentID);
 	~SimplePhysicsComponent() override;
 
 	void Update(const float deltaTime) override;

--- a/dGame/dComponents/SkillComponent.cpp
+++ b/dGame/dComponents/SkillComponent.cpp
@@ -489,7 +489,7 @@ void SkillComponent::HandleUnCast(const uint32_t behaviorId, const LWOOBJID targ
 	behavior->UnCast(&context, { target });
 }
 
-SkillComponent::SkillComponent(Entity* parent) : Component(parent) {
+SkillComponent::SkillComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	this->m_skillUid = 0;
 }
 

--- a/dGame/dComponents/SkillComponent.h
+++ b/dGame/dComponents/SkillComponent.h
@@ -63,7 +63,7 @@ class SkillComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::SKILL;
 
-	explicit SkillComponent(Entity* parent);
+	explicit SkillComponent(Entity* parent, const int32_t componentID);
 	~SkillComponent() override;
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;

--- a/dGame/dComponents/SoundTriggerComponent.cpp
+++ b/dGame/dComponents/SoundTriggerComponent.cpp
@@ -25,7 +25,7 @@ void MixerProgram::Serialize(RakNet::BitStream& outBitStream){
 	outBitStream.Write(name.c_str(), name.size());
 	outBitStream.Write(result);
 }
-SoundTriggerComponent::SoundTriggerComponent(Entity* parent) : Component(parent) {
+SoundTriggerComponent::SoundTriggerComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 
 	const auto musicCueName = parent->GetVar<std::string>(u"NDAudioMusicCue_Name");
 	if (!musicCueName.empty()) {

--- a/dGame/dComponents/SoundTriggerComponent.h
+++ b/dGame/dComponents/SoundTriggerComponent.h
@@ -60,7 +60,7 @@ struct MixerProgram {
 class SoundTriggerComponent : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::SOUND_TRIGGER;
-	explicit SoundTriggerComponent(Entity* parent);
+	explicit SoundTriggerComponent(Entity* parent, const int32_t componentID);
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
 	void ActivateMusicCue(const std::string& name, float bordemTime = -1.0);
 	void DeactivateMusicCue(const std::string& name);

--- a/dGame/dComponents/SwitchComponent.cpp
+++ b/dGame/dComponents/SwitchComponent.cpp
@@ -6,7 +6,7 @@
 
 std::vector<SwitchComponent*> SwitchComponent::petSwitches;
 
-SwitchComponent::SwitchComponent(Entity* parent) : Component(parent) {
+SwitchComponent::SwitchComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	m_Active = false;
 
 	m_ResetTime = m_Parent->GetVarAs<int32_t>(u"switch_reset_time");

--- a/dGame/dComponents/SwitchComponent.h
+++ b/dGame/dComponents/SwitchComponent.h
@@ -18,7 +18,7 @@ class SwitchComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::SWITCH;
 
-	SwitchComponent(Entity* parent);
+	SwitchComponent(Entity* parent, const int32_t componentID);
 	~SwitchComponent() override;
 
 	void Update(float deltaTime) override;

--- a/dGame/dComponents/TriggerComponent.cpp
+++ b/dGame/dComponents/TriggerComponent.cpp
@@ -19,7 +19,7 @@
 
 #include <glm/gtc/quaternion.hpp>
 
-TriggerComponent::TriggerComponent(Entity* parent, const std::string triggerInfo) : Component(parent) {
+TriggerComponent::TriggerComponent(Entity* parent, const int32_t componentID, const std::string triggerInfo) : Component(parent, componentID) {
 	m_Parent = parent;
 	m_Trigger = nullptr;
 

--- a/dGame/dComponents/TriggerComponent.h
+++ b/dGame/dComponents/TriggerComponent.h
@@ -9,7 +9,7 @@ class TriggerComponent final : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::TRIGGER;
 
-	explicit TriggerComponent(Entity* parent, const std::string triggerInfo);
+	explicit TriggerComponent(Entity* parent, const int32_t componentID, const std::string triggerInfo);
 
 	void TriggerEvent(eTriggerEventType event, Entity* optionalTarget = nullptr);
 	LUTriggers::Trigger* GetTrigger() const { return m_Trigger; }

--- a/dGame/dComponents/VendorComponent.cpp
+++ b/dGame/dComponents/VendorComponent.cpp
@@ -14,7 +14,7 @@
 #include "UserManager.h"
 #include "CheatDetection.h"
 
-VendorComponent::VendorComponent(Entity* parent) : Component(parent) {
+VendorComponent::VendorComponent(Entity* parent, const int32_t componentID) : Component(parent, componentID) {
 	m_HasStandardCostItems = false;
 	m_HasMultiCostItems = false;
 	SetupConstants();

--- a/dGame/dComponents/VendorComponent.h
+++ b/dGame/dComponents/VendorComponent.h
@@ -21,7 +21,7 @@ struct SoldItem {
 class VendorComponent : public Component {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::VENDOR;
-	VendorComponent(Entity* parent);
+	VendorComponent(Entity* parent, const int32_t componentID);
 
 	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
 

--- a/dScripts/02_server/Map/AM/WanderingVendor.cpp
+++ b/dScripts/02_server/Map/AM/WanderingVendor.cpp
@@ -17,7 +17,7 @@ void WanderingVendor::OnProximityUpdate(Entity* self, Entity* entering, std::str
 		self->CancelTimer("startWalking");
 	} else if (status == "LEAVE") {
 		auto* proximityMonitorComponent = self->GetComponent<ProximityMonitorComponent>();
-		if (!proximityMonitorComponent) self->AddComponent<ProximityMonitorComponent>();
+		if (!proximityMonitorComponent) self->AddComponent<ProximityMonitorComponent>(-1);
 
 		const auto proxObjs = proximityMonitorComponent->GetProximityObjects("playermonitor");
 		bool foundPlayer = false;

--- a/dScripts/NtFactionSpyServer.cpp
+++ b/dScripts/NtFactionSpyServer.cpp
@@ -15,7 +15,7 @@ void NtFactionSpyServer::OnStartup(Entity* self) {
 	// Set the proximity to sense later
 	auto* proximityMonitor = self->GetComponent<ProximityMonitorComponent>();
 	if (proximityMonitor == nullptr) {
-		proximityMonitor = self->AddComponent<ProximityMonitorComponent>(-1, -1);
+		proximityMonitor = self->AddComponent<ProximityMonitorComponent>(-1, -1, -1);
 	}
 
 	proximityMonitor->SetProximityRadius(self->GetVar<float_t>(m_SpyProximityVariable), m_ProximityName);

--- a/dScripts/ai/AG/AgStromlingProperty.cpp
+++ b/dScripts/ai/AG/AgStromlingProperty.cpp
@@ -12,5 +12,5 @@ void AgStromlingProperty::OnStartup(Entity* self) {
 		4
 	};
 
-	self->AddComponent<MovementAIComponent>(movementInfo);
+	self->AddComponent<MovementAIComponent>(-1, movementInfo);
 }

--- a/dScripts/ai/MINIGAME/SG_GF/SERVER/SGCannon.cpp
+++ b/dScripts/ai/MINIGAME/SG_GF/SERVER/SGCannon.cpp
@@ -273,7 +273,7 @@ void SGCannon::DoSpawnTimerFunc(Entity* self, const std::string& name) {
 
 		auto* enemy = Game::entityManager->CreateEntity(info, nullptr, self);
 
-		auto* movementAI = enemy->AddComponent<MovementAIComponent>(MovementAIInfo{});
+		auto* movementAI = enemy->AddComponent<MovementAIComponent>(-1, MovementAIInfo{});
 		auto* simplePhysicsComponent = enemy->GetComponent<SimplePhysicsComponent>();
 		if (simplePhysicsComponent) {
 			simplePhysicsComponent->SetPhysicsMotionState(4);

--- a/tests/dGameTests/dComponentsTests/DestroyableComponentTests.cpp
+++ b/tests/dGameTests/dComponentsTests/DestroyableComponentTests.cpp
@@ -16,7 +16,7 @@ protected:
 	void SetUp() override {
 		SetUpDependencies();
 		baseEntity = new Entity(15, GameDependenciesTest::info);
-		destroyableComponent = baseEntity->AddComponent<DestroyableComponent>();
+		destroyableComponent = baseEntity->AddComponent<DestroyableComponent>(-1);
 		// Initialize some values to be not default
 		destroyableComponent->SetMaxHealth(12345.0f);
 		destroyableComponent->SetHealth(23);
@@ -39,7 +39,7 @@ protected:
 TEST_F(DestroyableTest, PlacementNewAddComponentTest) {
 	ASSERT_NE(destroyableComponent, nullptr);
 	ASSERT_EQ(destroyableComponent->GetArmor(), 7);
-	baseEntity->AddComponent<DestroyableComponent>();
+	baseEntity->AddComponent<DestroyableComponent>(-1);
 	ASSERT_NE(baseEntity->GetComponent<DestroyableComponent>(), nullptr);
 	ASSERT_EQ(destroyableComponent->GetArmor(), 0);
 }
@@ -325,7 +325,7 @@ TEST_F(DestroyableTest, DestroyableComponentFactionTest) {
 
 TEST_F(DestroyableTest, DestroyableComponentValiditiyTest) {
 	auto* enemyEntity = new Entity(19, info);
-	enemyEntity->AddComponent<DestroyableComponent>()->AddFactionNoLookup(16);
+	enemyEntity->AddComponent<DestroyableComponent>(-1)->AddFactionNoLookup(16);
 	destroyableComponent->AddEnemyFaction(16);
 	EXPECT_TRUE(destroyableComponent->IsEnemy(enemyEntity));
 	EXPECT_FALSE(destroyableComponent->IsFriend(enemyEntity));

--- a/tests/dGameTests/dComponentsTests/SavingTests.cpp
+++ b/tests/dGameTests/dComponentsTests/SavingTests.cpp
@@ -32,7 +32,7 @@ protected:
 		character->_doQuickXMLDataParse();
 		character->LoadXmlRespawnCheckpoints();
 
-		entity->AddComponent<CharacterComponent>(character.get(), UNASSIGNED_SYSTEM_ADDRESS)->LoadFromXml(entity->GetCharacter()->GetXMLDoc());
+		entity->AddComponent<CharacterComponent>(-1, character.get(), UNASSIGNED_SYSTEM_ADDRESS)->LoadFromXml(entity->GetCharacter()->GetXMLDoc());
 	}
 
 	void TearDown() override {
@@ -61,7 +61,7 @@ TEST_F(SavingTest, CharacterComponentTest) {
 	// Reload the component and character from the now updated xml data
 	const auto prevTotalTime = characterComponent->GetTotalTimePlayed();
 	character->_doQuickXMLDataParse();
-	entity->AddComponent<CharacterComponent>(character.get(), UNASSIGNED_SYSTEM_ADDRESS);
+	entity->AddComponent<CharacterComponent>(-1, character.get(), UNASSIGNED_SYSTEM_ADDRESS);
 	characterComponent->LoadFromXml(entity->GetCharacter()->GetXMLDoc());
 
 	// Check that the buff component is the same as before which means resaving data and loading it back in didn't change anything


### PR DESCRIPTION
Will be used for Object Debugging purposes to provide further details as to what an object is.
Removed extra fields that stored the componentID on specific objects.
Removed a stray file that doesn't need to exist anymore.
updated component id variables in Entity::Initialize to be consistent.


Tested that bouncers still work, scripts still load, rails still work, characters can see each other, properties still have ugc, properties can still be modified, enemies still do their pathfinding and that the client does not log any "unserialize" errors.