### PR TITLE
fix: inventory items being in the wrong state due to changed IDs

### DIFF
--- a/dGame/dInventory/Inventory.cpp
+++ b/dGame/dInventory/Inventory.cpp
@@ -324,10 +324,13 @@ Inventory::~Inventory() {
 void Inventory::RegenerateItemIDs() {
 	std::map<LWOOBJID, Item*> newItems{};
 	for (auto* const item : items | std::views::values) {
+		const bool equipped = item->IsEquipped();
+		if (equipped) item->UnEquip();
 		const auto oldID = item->GetId();
 		const auto newID = item->GenerateID();
 		LOG("Updating item ID from %llu to %llu", oldID, newID);
 		newItems.insert_or_assign(newID, item);
+		if (equipped) item->Equip();
 	}
 
 	// We don't want to delete the item pointers, we're just moving from map to map


### PR DESCRIPTION
Tested that the regenerated ids now are equipped on the player