### PR TITLE
feat: hardcore limit % coins dropped on death

### DIFF
--- a/dGame/EntityManager.cpp
+++ b/dGame/EntityManager.cpp
@@ -87,6 +87,8 @@ void EntityManager::ReloadConfig() {
 	auto hcXpReduction = Game::config->GetValue("hardcore_uscore_reduction");
 	m_HardcoreUscoreReduction = hcXpReduction.empty() ? 1.0f : GeneralUtils::TryParse<float>(hcXpReduction).value_or(1.0f);
 	m_HardcoreMode = GetHardcoreDisabledWorlds().contains(Game::zoneManager->GetZoneID().GetMapID()) ? false : m_HardcoreMode;
+	auto hcCoinKeep = Game::config->GetValue("hardcore_coin_keep");
+	m_HardcoreCoinKeep = hcCoinKeep.empty() ? false : GeneralUtils::TryParse<float>(hcCoinKeep).value_or(0.0f);
 }
 
 void EntityManager::Initialize() {

--- a/dGame/EntityManager.h
+++ b/dGame/EntityManager.h
@@ -81,6 +81,7 @@ public:
 	const std::set<LOT>& GetHardcoreUscoreReducedLots() const { return m_HardcoreUscoreReducedLots; };
 	const std::set<LOT>& GetHardcoreUscoreExcludedEnemies() const { return m_HardcoreUscoreExcludedEnemies; };
 	const std::set<LWOMAPID>& GetHardcoreDisabledWorlds() const { return m_HardcoreDisabledWorlds; };
+	float GetHardcoreCoinKeep() const { return m_HardcoreCoinKeep; }
 
 	// Messaging
 	bool SendMessage(GameMessages::GameMsg& msg) const;
@@ -125,6 +126,7 @@ private:
 	std::set<LOT> m_HardcoreUscoreReducedLots{};
 	std::set<LOT> m_HardcoreUscoreExcludedEnemies{};
 	std::set<LWOMAPID> m_HardcoreDisabledWorlds{};
+	float m_HardcoreCoinKeep{};
 };
 
 #endif // ENTITYMANAGER_H

--- a/dGame/dComponents/DestroyableComponent.cpp
+++ b/dGame/dComponents/DestroyableComponent.cpp
@@ -1024,7 +1024,7 @@ void DestroyableComponent::DoHardcoreModeDrops(const LWOOBJID source) {
 			//drop all coins:
 			constexpr auto MAX_TO_DROP_PER_GM = 100'000;
 			while (coinsToDrop > MAX_TO_DROP_PER_GM) {
-				LOG("Dropping 100,000, %i left", coins);
+				LOG("Dropping 100,000, %llu left", coinsToDrop);
 				GameMessages::SendDropClientLoot(m_Parent, source, LOT_NULL, MAX_TO_DROP_PER_GM, m_Parent->GetPosition());
 				coinsToDrop -= MAX_TO_DROP_PER_GM;
 			}

--- a/resources/worldconfig.ini
+++ b/resources/worldconfig.ini
@@ -99,3 +99,6 @@ hardcore_uscore_excluded_enemies=
 
 # Disables hardcore mode for specific worlds, if hardcore is enabled
 hardcore_disabled_worlds=
+
+# Keeps this percentage of a players' coins on death in hardcore
+hardcore_coin_keep=


### PR DESCRIPTION
tested weird quantities of coins never let you gain money (worst case the player loses a couple coins)
tested that very large quantities of coins drop (client limits to 15 drops per gm)
tested that small quantities are not susceptible to rounding errors