### PR TITLE
feat: behavior states

### DIFF
--- a/dGame/dComponents/ModelComponent.cpp
+++ b/dGame/dComponents/ModelComponent.cpp
@@ -29,19 +29,22 @@ ModelComponent::ModelComponent(Entity* parent, const int32_t componentID) : Comp
 
 bool ModelComponent::OnResetModelToDefaults(GameMessages::GameMsg& msg) {
 	auto& reset = static_cast<GameMessages::ResetModelToDefaults&>(msg);
-	for (auto& behavior : m_Behaviors) behavior.HandleMsg(reset);
-	GameMessages::UnSmash unsmash;
-	unsmash.target = GetParent()->GetObjectID();
-	unsmash.duration = 0.0f;
-	unsmash.Send(UNASSIGNED_SYSTEM_ADDRESS);
+	if (reset.bResetBehaviors) for (auto& behavior : m_Behaviors) behavior.HandleMsg(reset);
 
-	m_Parent->SetPosition(m_OriginalPosition);
-	m_Parent->SetRotation(m_OriginalRotation);
+	if (reset.bUnSmash) {
+		GameMessages::UnSmash unsmash;
+		unsmash.target = GetParent()->GetObjectID();
+		unsmash.duration = 0.0f;
+		unsmash.Send(UNASSIGNED_SYSTEM_ADDRESS);
+		m_NumActiveUnSmash = 0;
+	}
+
+	if (reset.bResetPos) m_Parent->SetPosition(m_OriginalPosition);
+	if (reset.bResetRot) m_Parent->SetRotation(m_OriginalRotation);
 	m_Parent->SetVelocity(NiPoint3Constant::ZERO);
 
 	m_Speed = 3.0f;
 	m_NumListeningInteract = 0;
-	m_NumActiveUnSmash = 0;
 
 	m_NumActiveAttack = 0;
 	GameMessages::SetFaction set{};

--- a/dGame/dGameMessages/GameMessages.h
+++ b/dGame/dGameMessages/GameMessages.h
@@ -848,6 +848,11 @@ namespace GameMessages {
 
 	struct ResetModelToDefaults : public GameMsg {
 		ResetModelToDefaults() : GameMsg(MessageType::Game::RESET_MODEL_TO_DEFAULTS) {}
+
+		bool bResetPos{ true };
+		bool bResetRot{ true };
+		bool bUnSmash{ true };
+		bool bResetBehaviors{ true };
 	};
 
 	struct EmotePlayed : public GameMsg {

--- a/dGame/dPropertyBehaviors/PropertyBehavior.h
+++ b/dGame/dPropertyBehaviors/PropertyBehavior.h
@@ -1,17 +1,22 @@
 #ifndef __PROPERTYBEHAVIOR__H__
 #define __PROPERTYBEHAVIOR__H__
 
+#include "BehaviorStates.h"
 #include "State.h"
+
+#include <optional>
 
 namespace tinyxml2 {
 	class XMLElement;
 }
 
-enum class BehaviorState : uint32_t;
-
 class AMFArrayValue;
 class BehaviorMessageBase;
 class ModelComponent;
+
+struct UpdateResult {
+	std::optional<BehaviorState> newState;
+};
 
 /**
  * Represents the Entity of a Property Behavior and holds data associated with the behavior
@@ -45,6 +50,7 @@ public:
 	void OnHit();
 
 private:
+	State& GetActiveState();
 	// The current active behavior state. Behaviors can only be in ONE state at a time.
 	BehaviorState m_ActiveState;
 

--- a/dGame/dPropertyBehaviors/State.cpp
+++ b/dGame/dPropertyBehaviors/State.cpp
@@ -163,8 +163,8 @@ void State::Deserialize(const tinyxml2::XMLElement& state) {
 	}
 }
 
-void State::Update(float deltaTime, ModelComponent& modelComponent) {
-	for (auto& strip : m_Strips) strip.Update(deltaTime, modelComponent);
+void State::Update(float deltaTime, ModelComponent& modelComponent, UpdateResult& updateResult) {
+	for (auto& strip : m_Strips) strip.Update(deltaTime, modelComponent, updateResult);
 }
 
 void State::OnChatMessageReceived(const std::string& sMessage) {

--- a/dGame/dPropertyBehaviors/State.h
+++ b/dGame/dPropertyBehaviors/State.h
@@ -9,6 +9,7 @@ namespace tinyxml2 {
 
 class AMFArrayValue;
 class ModelComponent;
+struct UpdateResult;
 
 class State {
 public:
@@ -21,7 +22,7 @@ public:
 	void Serialize(tinyxml2::XMLElement& state) const;
 	void Deserialize(const tinyxml2::XMLElement& state);
 
-	void Update(float deltaTime, ModelComponent& modelComponent);
+	void Update(float deltaTime, ModelComponent& modelComponent, UpdateResult& updateResult);
 
 	void OnChatMessageReceived(const std::string& sMessage);
 	void OnHit();

--- a/dGame/dPropertyBehaviors/Strip.h
+++ b/dGame/dPropertyBehaviors/Strip.h
@@ -12,6 +12,7 @@ namespace tinyxml2 {
 
 class AMFArrayValue;
 class ModelComponent;
+struct UpdateResult;
 
 class Strip {
 public:
@@ -33,9 +34,9 @@ public:
 	// Checks the movement logic for whether or not to proceed
 	// Returns true if the movement can continue, false if it needs to wait more.
 	bool CheckMovement(float deltaTime, ModelComponent& modelComponent);
-	void Update(float deltaTime, ModelComponent& modelComponent);
+	void Update(float deltaTime, ModelComponent& modelComponent, UpdateResult& updateResult);
 	void SpawnDrop(LOT dropLOT, Entity& entity);
-	void ProcNormalAction(float deltaTime, ModelComponent& modelComponent);
+	void ProcNormalAction(float deltaTime, ModelComponent& modelComponent, UpdateResult& updateResult);
 	void RemoveStates(ModelComponent& modelComponent) const;
 
 	// 2 actions are required for strips to work


### PR DESCRIPTION
All behaviors on the `State` tab will now function
tested that a model with 2 behaviors was able to
- have an on chat constantly running listening for inputs in the home state
- have a separate behavior with home, square and star states working and switching without interrupting the other behaviors

