### PR TITLE
fix: donations requiring new high score vs adding to previous one

### DIFF
--- a/dGame/LeaderboardManager.cpp
+++ b/dGame/LeaderboardManager.cpp
@@ -289,6 +289,10 @@ void LeaderboardManager::SaveScore(const LWOOBJID& playerID, const GameID activi
 			ILeaderboard::Score oldScoreFlipped{oldScore->secondaryScore, oldScore->primaryScore, oldScore->tertiaryScore};
 			ILeaderboard::Score newScoreFlipped{newScore.secondaryScore, newScore.primaryScore, newScore.tertiaryScore};
 			newHighScore = newScoreFlipped > oldScoreFlipped;
+		} else if (leaderboardType == Leaderboard::Type::Donations) {
+			// Donations just need to go up if updated
+			newHighScore = true;
+			newScore.primaryScore += oldScore->primaryScore;
 		}
 
 		if (newHighScore) {


### PR DESCRIPTION
tested that jawbox works as intended now for donation counting on the leaderboards