### PR TITLE
fix: security fixes

### DIFF
--- a/dCommon/dEnums/dCommonVars.h
+++ b/dCommon/dEnums/dCommonVars.h
@@ -58,6 +58,7 @@ constexpr LWOCLONEID LWOCLONEID_INVALID = -1;     	//!< Invalid LWOCLONEID
 constexpr LWOINSTANCEID LWOINSTANCEID_INVALID = -1; //!< Invalid LWOINSTANCEID
 constexpr LWOMAPID LWOMAPID_INVALID = -1;       	//!< Invalid LWOMAPID
 constexpr uint64_t LWOZONEID_INVALID = 0;       	//!< Invalid LWOZONEID
+constexpr uint32_t MAX_MESSAGE_LENGTH = 0x500000;   //!< Prevent exceptionally large msgs from being processed. Should always be used to check user provided inputs.
 
 constexpr float PI = 3.14159f;
 

--- a/dGame/dGameMessages/DoClientProjectileImpact.h
+++ b/dGame/dGameMessages/DoClientProjectileImpact.h
@@ -61,6 +61,8 @@ public:
 
 		uint32_t sBitStreamLength{};
 		stream.Read(sBitStreamLength);
+		const uint32_t MAX_BITSTREAM_LENGTH = 0x500000; // Prevent DoS via unbounded sBitStream
+		if (sBitStreamLength > MAX_BITSTREAM_LENGTH) return false;
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
 			stream.Read(character);

--- a/dGame/dGameMessages/DoClientProjectileImpact.h
+++ b/dGame/dGameMessages/DoClientProjectileImpact.h
@@ -61,8 +61,7 @@ public:
 
 		uint32_t sBitStreamLength{};
 		stream.Read(sBitStreamLength);
-		const uint32_t MAX_BITSTREAM_LENGTH = 0x500000; // Prevent DoS via unbounded sBitStream
-		if (sBitStreamLength > MAX_BITSTREAM_LENGTH) return false;
+		if (sBitStreamLength > MAX_MESSAGE_LENGTH) return false;
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
 			stream.Read(character);

--- a/dGame/dGameMessages/EchoStartSkill.h
+++ b/dGame/dGameMessages/EchoStartSkill.h
@@ -100,6 +100,8 @@ public:
 
 		uint32_t sBitStreamLength{};
 		stream.Read(sBitStreamLength);
+		const uint32_t MAX_BITSTREAM_LENGTH = 0x500000; // Prevent DoS via unbounded sBitStream
+		if (sBitStreamLength > MAX_BITSTREAM_LENGTH) return false;
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
 			stream.Read(character);

--- a/dGame/dGameMessages/EchoStartSkill.h
+++ b/dGame/dGameMessages/EchoStartSkill.h
@@ -100,8 +100,7 @@ public:
 
 		uint32_t sBitStreamLength{};
 		stream.Read(sBitStreamLength);
-		const uint32_t MAX_BITSTREAM_LENGTH = 0x500000; // Prevent DoS via unbounded sBitStream
-		if (sBitStreamLength > MAX_BITSTREAM_LENGTH) return false;
+		if (sBitStreamLength > MAX_MESSAGE_LENGTH) return false;
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
 			stream.Read(character);

--- a/dGame/dGameMessages/EchoSyncSkill.h
+++ b/dGame/dGameMessages/EchoSyncSkill.h
@@ -47,6 +47,8 @@ public:
 
 		uint32_t sBitStreamLength{};
 		stream.Read(sBitStreamLength);
+		const uint32_t MAX_BITSTREAM_LENGTH = 0x500000; // Prevent DoS via unbounded sBitStream
+		if (sBitStreamLength > MAX_BITSTREAM_LENGTH) return false;
 		for (unsigned int k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
 			stream.Read(character);

--- a/dGame/dGameMessages/EchoSyncSkill.h
+++ b/dGame/dGameMessages/EchoSyncSkill.h
@@ -47,8 +47,7 @@ public:
 
 		uint32_t sBitStreamLength{};
 		stream.Read(sBitStreamLength);
-		const uint32_t MAX_BITSTREAM_LENGTH = 0x500000; // Prevent DoS via unbounded sBitStream
-		if (sBitStreamLength > MAX_BITSTREAM_LENGTH) return false;
+		if (sBitStreamLength > MAX_MESSAGE_LENGTH) return false;
 		for (unsigned int k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
 			stream.Read(character);

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -2405,11 +2405,20 @@ void GameMessages::SendUnSmash(Entity* entity, LWOOBJID builderID, float duratio
 
 void GameMessages::HandleControlBehaviors(RakNet::BitStream& inStream, Entity* entity, const SystemAddress& sysAddr) {
 	AMFDeserialize reader;
-	std::unique_ptr<AMFArrayValue> amfArguments{ static_cast<AMFArrayValue*>(reader.Read(inStream).release()) };
+	std::unique_ptr<AMFArrayValue> amfArguments;
+	try {
+		auto deserializedData = reader.Read(inStream);
+		amfArguments.reset(static_cast<AMFArrayValue*>(deserializedData.release()));
+	} catch (...) {
+		LOG("Failed to deserialize AMF data for control behaviors command");
+		return;
+	}
 	if (amfArguments->GetValueType() != eAmf::Array) return;
 
 	uint32_t commandLength{};
 	inStream.Read(commandLength);
+
+	if (commandLength > 0x500000) return; // Prevent DoS via unbounded command buffer
 
 	std::string command;
 	command.reserve(commandLength);
@@ -3615,6 +3624,9 @@ void GameMessages::HandlePetTamingTryBuild(RakNet::BitStream& inStream, Entity* 
 	bool clientFailed;
 
 	inStream.Read(brickCount);
+
+	const uint32_t MAX_BRICK_COUNT = 0x500000;
+	if (brickCount > MAX_BRICK_COUNT) return; // Prevent DoS via unbounded brick count
 
 	bricks.reserve(brickCount);
 
@@ -5806,6 +5818,9 @@ void GameMessages::HandleReportBug(RakNet::BitStream& inStream, Entity* entity) 
 	uint32_t messageLength;
 	inStream.Read(messageLength);
 
+	const uint32_t MAX_STRING_LENGTH = 0x50000; // Prevent DoS via unbounded strings
+	if (messageLength > MAX_STRING_LENGTH) return;
+
 	for (uint32_t i = 0; i < (messageLength); ++i) {
 		uint16_t character;
 		inStream.Read(character);
@@ -5817,6 +5832,7 @@ void GameMessages::HandleReportBug(RakNet::BitStream& inStream, Entity* entity) 
 
 	uint32_t clientVersionLength;
 	inStream.Read(clientVersionLength);
+	if (clientVersionLength > MAX_STRING_LENGTH) return;
 	for (unsigned int k = 0; k < clientVersionLength; k++) {
 		unsigned char character;
 		inStream.Read(character);
@@ -5825,6 +5841,7 @@ void GameMessages::HandleReportBug(RakNet::BitStream& inStream, Entity* entity) 
 
 	uint32_t nOtherPlayerIDLength;
 	inStream.Read(nOtherPlayerIDLength);
+	if (nOtherPlayerIDLength > MAX_STRING_LENGTH) return;
 	for (unsigned int k = 0; k < nOtherPlayerIDLength; k++) {
 		unsigned char character;
 		inStream.Read(character);
@@ -5833,6 +5850,7 @@ void GameMessages::HandleReportBug(RakNet::BitStream& inStream, Entity* entity) 
 
 	uint32_t selectionLength;
 	inStream.Read(selectionLength);
+	if (selectionLength > MAX_STRING_LENGTH) return;
 	for (unsigned int k = 0; k < selectionLength; k++) {
 		unsigned char character;
 		inStream.Read(character);
@@ -6134,15 +6152,19 @@ void GameMessages::HandleUpdateInventoryGroup(RakNet::BitStream& inStream, Entit
 	bool locked{}; // All groups are locked by default
 
 	uint32_t size{};
+	const uint32_t MAX_STRING_LENGTH = 0x500000; // Prevent DoS via oversized inventory group strings
 	if (!inStream.Read(size)) return;
+	if (size > MAX_STRING_LENGTH) return; // Bounds check before resize
 	action.resize(size);
 	if (!inStream.Read(action.data(), size)) return;
 
 	if (!inStream.Read(size)) return;
+	if (size > MAX_STRING_LENGTH) return; // Bounds check before resize
 	groupUpdate.groupId.resize(size);
 	if (!inStream.Read(groupUpdate.groupId.data(), size)) return;
 
 	if (!inStream.Read(size)) return;
+	if (size > MAX_STRING_LENGTH / 2) return; // Bounds check: size * 2 would overflow or exceed limit
 	groupName.resize(size);
 	if (!inStream.Read(reinterpret_cast<char*>(groupName.data()), size * 2)) return;
 

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -5835,7 +5835,7 @@ void GameMessages::HandleReportBug(RakNet::BitStream& inStream, Entity* entity) 
 
 	uint32_t clientVersionLength;
 	inStream.Read(clientVersionLength);
-	if (clientVersionLength > MAX_STRING_LENGTH) return;
+	if (clientVersionLength > MAX_MESSAGE_LENGTH) return;
 	for (unsigned int k = 0; k < clientVersionLength; k++) {
 		unsigned char character;
 		inStream.Read(character);
@@ -5844,7 +5844,7 @@ void GameMessages::HandleReportBug(RakNet::BitStream& inStream, Entity* entity) 
 
 	uint32_t nOtherPlayerIDLength;
 	inStream.Read(nOtherPlayerIDLength);
-	if (nOtherPlayerIDLength > MAX_STRING_LENGTH) return;
+	if (nOtherPlayerIDLength > MAX_MESSAGE_LENGTH) return;
 	for (unsigned int k = 0; k < nOtherPlayerIDLength; k++) {
 		unsigned char character;
 		inStream.Read(character);
@@ -5853,7 +5853,7 @@ void GameMessages::HandleReportBug(RakNet::BitStream& inStream, Entity* entity) 
 
 	uint32_t selectionLength;
 	inStream.Read(selectionLength);
-	if (selectionLength > MAX_STRING_LENGTH) return;
+	if (selectionLength > MAX_MESSAGE_LENGTH) return;
 	for (unsigned int k = 0; k < selectionLength; k++) {
 		unsigned char character;
 		inStream.Read(character);

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -2408,6 +2408,11 @@ void GameMessages::HandleControlBehaviors(RakNet::BitStream& inStream, Entity* e
 	std::unique_ptr<AMFArrayValue> amfArguments;
 	try {
 		auto deserializedData = reader.Read(inStream);
+		if (!deserializedData || deserializedData->GetValueType() != eAmf::Array) {
+			LOG("Failed to deserialize AMF data for control behaviors command: not an array");
+			return;
+		}
+
 		amfArguments.reset(static_cast<AMFArrayValue*>(deserializedData.release()));
 	} catch (...) {
 		LOG("Failed to deserialize AMF data for control behaviors command");

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -2423,7 +2423,7 @@ void GameMessages::HandleControlBehaviors(RakNet::BitStream& inStream, Entity* e
 	uint32_t commandLength{};
 	inStream.Read(commandLength);
 
-	if (commandLength > 0x500000) return; // Prevent DoS via unbounded command buffer
+	if (commandLength > MAX_MESSAGE_LENGTH) return; // Prevent DoS via unbounded command buffer
 
 	std::string command;
 	command.reserve(commandLength);
@@ -3630,8 +3630,7 @@ void GameMessages::HandlePetTamingTryBuild(RakNet::BitStream& inStream, Entity* 
 
 	inStream.Read(brickCount);
 
-	const uint32_t MAX_BRICK_COUNT = 0x500000;
-	if (brickCount > MAX_BRICK_COUNT) return; // Prevent DoS via unbounded brick count
+	if (brickCount > MAX_MESSAGE_LENGTH) return; // Prevent DoS via unbounded brick count
 
 	bricks.reserve(brickCount);
 
@@ -5823,8 +5822,7 @@ void GameMessages::HandleReportBug(RakNet::BitStream& inStream, Entity* entity) 
 	uint32_t messageLength;
 	inStream.Read(messageLength);
 
-	const uint32_t MAX_STRING_LENGTH = 0x50000; // Prevent DoS via unbounded strings
-	if (messageLength > MAX_STRING_LENGTH) return;
+	if (messageLength > MAX_MESSAGE_LENGTH) return;
 
 	for (uint32_t i = 0; i < (messageLength); ++i) {
 		uint16_t character;
@@ -6157,19 +6155,18 @@ void GameMessages::HandleUpdateInventoryGroup(RakNet::BitStream& inStream, Entit
 	bool locked{}; // All groups are locked by default
 
 	uint32_t size{};
-	const uint32_t MAX_STRING_LENGTH = 0x500000; // Prevent DoS via oversized inventory group strings
 	if (!inStream.Read(size)) return;
-	if (size > MAX_STRING_LENGTH) return; // Bounds check before resize
+	if (size > MAX_MESSAGE_LENGTH) return; // Bounds check before resize
 	action.resize(size);
 	if (!inStream.Read(action.data(), size)) return;
 
 	if (!inStream.Read(size)) return;
-	if (size > MAX_STRING_LENGTH) return; // Bounds check before resize
+	if (size > MAX_MESSAGE_LENGTH) return; // Bounds check before resize
 	groupUpdate.groupId.resize(size);
 	if (!inStream.Read(groupUpdate.groupId.data(), size)) return;
 
 	if (!inStream.Read(size)) return;
-	if (size > MAX_STRING_LENGTH / 2) return; // Bounds check: size * 2 would overflow or exceed limit
+	if (size > MAX_MESSAGE_LENGTH / 2) return; // Bounds check: size * 2 would overflow or exceed limit
 	groupName.resize(size);
 	if (!inStream.Read(reinterpret_cast<char*>(groupName.data()), size * 2)) return;
 

--- a/dGame/dGameMessages/RequestServerProjectileImpact.h
+++ b/dGame/dGameMessages/RequestServerProjectileImpact.h
@@ -54,6 +54,8 @@ public:
 
 		uint32_t sBitStreamLength{};
 		stream.Read(sBitStreamLength);
+		const uint32_t MAX_BITSTREAM_LENGTH = 0x500000; // Prevent DoS via unbounded sBitStream
+		if (sBitStreamLength > MAX_BITSTREAM_LENGTH) return false;
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
 			stream.Read(character);

--- a/dGame/dGameMessages/RequestServerProjectileImpact.h
+++ b/dGame/dGameMessages/RequestServerProjectileImpact.h
@@ -54,8 +54,7 @@ public:
 
 		uint32_t sBitStreamLength{};
 		stream.Read(sBitStreamLength);
-		const uint32_t MAX_BITSTREAM_LENGTH = 0x500000; // Prevent DoS via unbounded sBitStream
-		if (sBitStreamLength > MAX_BITSTREAM_LENGTH) return false;
+		if (sBitStreamLength > MAX_MESSAGE_LENGTH) return false;
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
 			stream.Read(character);

--- a/dGame/dGameMessages/StartSkill.h
+++ b/dGame/dGameMessages/StartSkill.h
@@ -111,6 +111,8 @@ public:
 
 		uint32_t sBitStreamLength{};
 		stream.Read(sBitStreamLength);
+		const uint32_t MAX_BITSTREAM_LENGTH = 0x500000; // Prevent DoS via unbounded sBitStream
+		if (sBitStreamLength > MAX_BITSTREAM_LENGTH) return false;
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
 			stream.Read(character);

--- a/dGame/dGameMessages/StartSkill.h
+++ b/dGame/dGameMessages/StartSkill.h
@@ -111,8 +111,7 @@ public:
 
 		uint32_t sBitStreamLength{};
 		stream.Read(sBitStreamLength);
-		const uint32_t MAX_BITSTREAM_LENGTH = 0x500000; // Prevent DoS via unbounded sBitStream
-		if (sBitStreamLength > MAX_BITSTREAM_LENGTH) return false;
+		if (sBitStreamLength > MAX_MESSAGE_LENGTH) return false;
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
 			stream.Read(character);

--- a/dGame/dGameMessages/SyncSkill.h
+++ b/dGame/dGameMessages/SyncSkill.h
@@ -46,6 +46,8 @@ public:
 		stream.Read(bDone);
 		uint32_t sBitStreamLength{};
 		stream.Read(sBitStreamLength);
+		const uint32_t MAX_BITSTREAM_LENGTH = 0x500000; // Prevent DoS via unbounded sBitStream
+		if (sBitStreamLength > MAX_BITSTREAM_LENGTH) return false;
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
 			stream.Read(character);

--- a/dGame/dGameMessages/SyncSkill.h
+++ b/dGame/dGameMessages/SyncSkill.h
@@ -46,8 +46,7 @@ public:
 		stream.Read(bDone);
 		uint32_t sBitStreamLength{};
 		stream.Read(sBitStreamLength);
-		const uint32_t MAX_BITSTREAM_LENGTH = 0x500000; // Prevent DoS via unbounded sBitStream
-		if (sBitStreamLength > MAX_BITSTREAM_LENGTH) return false;
+		if (sBitStreamLength > MAX_MESSAGE_LENGTH) return false;
 		for (uint32_t k = 0; k < sBitStreamLength; k++) {
 			unsigned char character;
 			stream.Read(character);

--- a/dMasterServer/InstanceManager.cpp
+++ b/dMasterServer/InstanceManager.cpp
@@ -308,7 +308,7 @@ const InstancePtr& InstanceManager::FindPrivateInstance(const std::string& passw
 			continue;
 		}
 
-		LOG("Password: %s == %s => %d", password.c_str(), instance->GetPassword().c_str(), password == instance->GetPassword());
+		LOG("Checking private zone password match (result: %d)", password == instance->GetPassword());
 
 		if (instance->GetPassword() == password) {
 			return instance;

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -720,7 +720,7 @@ void HandlePacket(Packet* packet) {
 				password += character;
 			}
 			const auto& newInst = Game::im->CreatePrivateInstance(mapId, cloneId, password.c_str());
-			LOG("Creating private zone %i/%i/%i with password %s", newInst->GetMapID(), newInst->GetCloneID(), newInst->GetInstanceID(), password.c_str());
+			LOG("Creating private zone %i/%i/%i", newInst->GetMapID(), newInst->GetCloneID(), newInst->GetInstanceID());
 
 			break;
 		}
@@ -747,7 +747,7 @@ void HandlePacket(Packet* packet) {
 
 			const auto& instance = Game::im->FindPrivateInstance(password.c_str());
 
-			LOG("Join private zone: %llu %d %s %p", requestID, mythranShift, password.c_str(), instance.get());
+			LOG("Join private zone: %llu %d %p", requestID, mythranShift, instance.get());
 
 			if (instance == nullptr) {
 				return;

--- a/dNet/AuthPackets.cpp
+++ b/dNet/AuthPackets.cpp
@@ -307,6 +307,6 @@ void AuthPackets::SendLoginResponse(dServer* server, const SystemAddress& sysAdd
 		bitStream.Write(LUString(username));
 		server->SendToMaster(bitStream);
 
-		LOG("Set sessionKey: %i for user %s", sessionKey, username.c_str());
+		LOG("Set session key for user %s", username.c_str());
 	}
 }

--- a/dNet/ClientPackets.cpp
+++ b/dNet/ClientPackets.cpp
@@ -11,14 +11,17 @@ ChatMessage ClientPackets::HandleChatMessage(Packet* packet) {
 	CINSTREAM_SKIP_HEADER;
 
 	ChatMessage message;
-	uint32_t messageLength;
+	int32_t messageLength;
 
 	inStream.Read(message.chatChannel);
 	inStream.Read(message.unknown);
 	inStream.Read(messageLength);
 
-	for (uint32_t i = 0; i < (messageLength - 1); ++i) {
-		uint16_t character;
+	const int32_t MAX_MESSAGE_LENGTH = 0x500000; // Prevent DoS via unbounded message length
+	if (messageLength > MAX_MESSAGE_LENGTH) return message;
+
+	for (int32_t i = 0; i < (messageLength - 1); ++i) {
+		char16_t character;
 		inStream.Read(character);
 		message.message.push_back(character);
 	}

--- a/dNet/ClientPackets.cpp
+++ b/dNet/ClientPackets.cpp
@@ -17,7 +17,7 @@ ChatMessage ClientPackets::HandleChatMessage(Packet* packet) {
 	inStream.Read(message.unknown);
 	inStream.Read(messageLength);
 
-	if (messageLength > MAX_MESSAGE_LENGTH) return message;
+	if (messageLength > MAX_MESSAGE_LENGTH || messageLength < 0) return message;
 
 	for (int32_t i = 0; i < (messageLength - 1); ++i) {
 		char16_t character;

--- a/dNet/ClientPackets.cpp
+++ b/dNet/ClientPackets.cpp
@@ -11,7 +11,7 @@ ChatMessage ClientPackets::HandleChatMessage(Packet* packet) {
 	CINSTREAM_SKIP_HEADER;
 
 	ChatMessage message;
-	int32_t messageLength;
+	int32_t messageLength{};
 
 	inStream.Read(message.chatChannel);
 	inStream.Read(message.unknown);

--- a/dNet/ClientPackets.cpp
+++ b/dNet/ClientPackets.cpp
@@ -17,7 +17,6 @@ ChatMessage ClientPackets::HandleChatMessage(Packet* packet) {
 	inStream.Read(message.unknown);
 	inStream.Read(messageLength);
 
-	const int32_t MAX_MESSAGE_LENGTH = 0x500000; // Prevent DoS via unbounded message length
 	if (messageLength > MAX_MESSAGE_LENGTH) return message;
 
 	for (int32_t i = 0; i < (messageLength - 1); ++i) {

--- a/dNet/dServer.cpp
+++ b/dNet/dServer.cpp
@@ -215,6 +215,8 @@ bool dServer::Startup() {
 	mPeer = RakNetworkFactory::GetRakPeerInterface();
 
 	if (!mPeer) return false;
+
+	if (mUseEncryption) mPeer->InitializeSecurity(NULL, NULL, NULL, NULL);
 	if (!mPeer->Startup(mMaxConnections, 10, &mSocketDescriptor, 1)) return false;
 
 	if (mIsInternal) {
@@ -226,7 +228,6 @@ bool dServer::Startup() {
 	}
 
 	mPeer->SetMaximumIncomingConnections(mMaxConnections);
-	if (mUseEncryption) mPeer->InitializeSecurity(NULL, NULL, NULL, NULL);
 
 	return true;
 }

--- a/dNet/dServer.cpp
+++ b/dNet/dServer.cpp
@@ -216,7 +216,7 @@ bool dServer::Startup() {
 
 	if (!mPeer) return false;
 
-	if (mUseEncryption) mPeer->InitializeSecurity(NULL, NULL, NULL, NULL);
+	if (mUseEncryption) mPeer->InitializeSecurity(nullptr, nullptr, nullptr, nullptr);
 	if (!mPeer->Startup(mMaxConnections, 10, &mSocketDescriptor, 1)) return false;
 
 	if (mIsInternal) {


### PR DESCRIPTION
dont print passwords for worlds
bound strings from clients
actually enable encryption between rakpeers
dont allow underflow when reading a string

Tested that packets are encrypted
tested that models can still be built
tested that combat still works