### PR TITLE
fix: remove non-functioning saving of gm invis, re-add gm invis as a feature

### DIFF
--- a/dGame/dComponents/GhostComponent.cpp
+++ b/dGame/dComponents/GhostComponent.cpp
@@ -29,26 +29,6 @@ GhostComponent::~GhostComponent() {
 	}
 }
 
-void GhostComponent::LoadFromXml(const tinyxml2::XMLDocument& doc) {
-	auto* objElement = doc.FirstChildElement("obj");
-	if (!objElement) return;
-	auto* ghstElement = objElement->FirstChildElement("ghst");
-	if (!ghstElement) return;
-	m_IsGMInvisible = ghstElement->BoolAttribute("i");
-}
-
-void GhostComponent::UpdateXml(tinyxml2::XMLDocument& doc) {
-	auto* objElement = doc.FirstChildElement("obj");
-	if (!objElement) return;
-	auto* ghstElement = objElement->FirstChildElement("ghst");
-	if (ghstElement) objElement->DeleteChild(ghstElement);
-	// Only save if GM invisible
-	const auto* const user = UserManager::Instance()->GetUser(m_Parent->GetSystemAddress());
-	if (!m_IsGMInvisible || !user || user->GetMaxGMLevel() < eGameMasterLevel::FORUM_MODERATOR) return;
-	ghstElement = objElement->InsertNewChildElement("ghst");
-	if (ghstElement) ghstElement->SetAttribute("i", m_IsGMInvisible);
-}
-
 void GhostComponent::SetGhostReferencePoint(const NiPoint3& value) {
 	m_GhostReferencePoint = value;
 }
@@ -107,7 +87,7 @@ bool GhostComponent::OnToggleGMInvis(GameMessages::ToggleGMInvis& gmInvisMsg) {
 				Game::entityManager->DestructEntity(m_Parent, player->GetSystemAddress());
 			}
 		} else {
-			if (toUser->GetMaxGMLevel() >= thisUser->GetMaxGMLevel()) {
+			if (toUser->GetMaxGMLevel() < thisUser->GetMaxGMLevel()) {
 				Game::entityManager->ConstructEntity(m_Parent, player->GetSystemAddress());
 				auto* controllableComp = m_Parent->GetComponent<ControllablePhysicsComponent>();
 				controllableComp->SetDirtyPosition(true);
@@ -121,11 +101,8 @@ bool GhostComponent::OnToggleGMInvis(GameMessages::ToggleGMInvis& gmInvisMsg) {
 
 bool GhostComponent::OnGetGMInvis(GameMessages::GetGMInvis& gmInvisMsg) {
 	LOG_DEBUG("GM Invisibility requested: %s", m_IsGMInvisible ? "true" : "false");
-	// TODO: disabled for now while bugs are fixed
-	// gmInvisMsg.bGMInvis = m_IsGMInvisible;
-	// return gmInvisMsg.bGMInvis;
-	gmInvisMsg.bGMInvis = false;
-	return false;
+	gmInvisMsg.bGMInvis = m_IsGMInvisible;
+	return gmInvisMsg.bGMInvis;
 }
 
 bool GhostComponent::MsgGetObjectReportInfo(GameMessages::GetObjectReportInfo& reportMsg) {

--- a/dGame/dComponents/GhostComponent.h
+++ b/dGame/dComponents/GhostComponent.h
@@ -16,8 +16,6 @@ public:
 	static inline const eReplicaComponentType ComponentType = eReplicaComponentType::GHOST;
 	GhostComponent(Entity* parent, const int32_t componentID);
 	~GhostComponent() override;
-	void LoadFromXml(const tinyxml2::XMLDocument& doc) override;
-	void UpdateXml(tinyxml2::XMLDocument& doc) override;
 
 	void SetGhostOverride(bool value) { m_GhostOverride = value; };
 


### PR DESCRIPTION
Does not save, only works for this world. Doesn't seem like the client reflects the correct state anyways so let's not oversell the feature in the first place.

Fixed an issue where the incorrect comparison was used to make players invisible again (the same check that makes then INvisible needs to make them visible.)

refs: #1938 #246 