### PR TITLE
fix: bugs in private instances causing master crashes

### DIFF
--- a/dMasterServer/InstanceManager.cpp
+++ b/dMasterServer/InstanceManager.cpp
@@ -333,7 +333,7 @@ int InstanceManager::GetHardCap(LWOMAPID mapID) {
 }
 
 void InstanceManager::PruneUnreadyInstances() {
-	for (int i = m_Instances.size() - 1; i >= 0; i--) {
+	for (int i = static_cast<int>(m_Instances.size()) - 1; i >= 0; i--) {
 		if (!m_Instances[i]->GetIsReady()) m_Instances.erase(m_Instances.cbegin() + i);
 	}
 }

--- a/dMasterServer/InstanceManager.cpp
+++ b/dMasterServer/InstanceManager.cpp
@@ -332,6 +332,12 @@ int InstanceManager::GetHardCap(LWOMAPID mapID) {
 	return zone ? zone->population_hard_cap : 12;
 }
 
+void InstanceManager::PruneUnreadyInstances() {
+	for (int i = m_Instances.size() - 1; i >= 0; i--) {
+		if (!m_Instances[i]->GetIsReady()) m_Instances.erase(m_Instances.cbegin() + i);
+	}
+}
+
 void Instance::SetShutdownComplete(const bool value) {
 	m_Shutdown = value;
 }
@@ -359,4 +365,3 @@ bool Instance::IsFull(bool isFriendTransfer) const {
 
 	return true;
 }
-

--- a/dMasterServer/InstanceManager.h
+++ b/dMasterServer/InstanceManager.h
@@ -133,6 +133,7 @@ public:
 	const InstancePtr& CreatePrivateInstance(LWOMAPID mapID, LWOCLONEID cloneID, const std::string& password);
 	const InstancePtr& FindPrivateInstance(const std::string& password);
 	void SetIsShuttingDown(bool value) { this->m_IsShuttingDown = value; };
+	void PruneUnreadyInstances();
 
 private:
 	std::string mExternalIP;

--- a/dMasterServer/MasterServer.cpp
+++ b/dMasterServer/MasterServer.cpp
@@ -665,7 +665,7 @@ void HandlePacket(Packet* packet) {
 			inStream.Read(theirInstanceID);
 
 			const auto& instance =
-				Game::im->FindInstance(theirZoneID, theirInstanceID);
+				Game::im->FindInstanceWithPrivate(theirZoneID, theirInstanceID);
 			if (instance) {
 				instance->AddPlayer(Player());
 			} else {
@@ -762,7 +762,7 @@ void HandlePacket(Packet* packet) {
 
 			LOG("Got world ready %i %i", zoneID, instanceID);
 
-			const auto& instance = Game::im->FindInstance(zoneID, instanceID);
+			const auto& instance = Game::im->FindInstanceWithPrivate(zoneID, instanceID);
 
 			if (instance == nullptr) {
 				LOG("Failed to find zone to ready");
@@ -858,12 +858,10 @@ int ShutdownSequence(int32_t signal) {
 	}
 
 	// A server might not be finished spinning up yet, remove all of those here.
+	// prune the unready ones before looping over all of them
+	Game::im->PruneUnreadyInstances();
 	for (const auto& instance : Game::im->GetInstances()) {
 		if (!instance) continue;
-
-		if (!instance->GetIsReady()) {
-			Game::im->RemoveInstance(instance);
-		}
 
 		instance->SetIsShuttingDown(true);
 	}


### PR DESCRIPTION
tested that creating a private instance and shutting down the server no longer crashes master