### PR TITLE
fix: fv pipe quick build not spawning as it should

### DIFF
--- a/dGame/Entity.cpp
+++ b/dGame/Entity.cpp
@@ -1613,8 +1613,7 @@ void Entity::Kill(Entity* murderer, const eKillType killType) {
 		else Game::entityManager->DestroyEntity(this);
 	}
 
-	const auto& grpNameQBShowBricks = GetVar<std::string>(u"grpNameQBShowBricks");
-
+	const auto& grpNameQBShowBricks = GetVarAsString(u"grpNameQBShowBricks");
 	if (!grpNameQBShowBricks.empty()) {
 		auto spawners = Game::zoneManager->GetSpawnersByName(grpNameQBShowBricks);
 

--- a/dGame/dComponents/QuickBuildComponent.cpp
+++ b/dGame/dComponents/QuickBuildComponent.cpp
@@ -22,6 +22,8 @@
 #include "RenderComponent.h"
 
 #include "CppScripts.h"
+#include "StringifiedEnum.h"
+#include "Amf3.h"
 
 QuickBuildComponent::QuickBuildComponent(Entity* const entity, const int32_t componentID) : Component{ entity, componentID } {
 	std::u16string checkPreconditions = entity->GetVar<std::u16string>(u"CheckPrecondition");
@@ -42,6 +44,7 @@ QuickBuildComponent::QuickBuildComponent(Entity* const entity, const int32_t com
 	}
 
 	SpawnActivator();
+	RegisterMsg(&QuickBuildComponent::OnGetObjectReportInfo);
 }
 
 QuickBuildComponent::~QuickBuildComponent() {
@@ -567,4 +570,31 @@ void QuickBuildComponent::AddQuickBuildCompleteCallback(const std::function<void
 
 void QuickBuildComponent::AddQuickBuildStateCallback(const std::function<void(eQuickBuildState state)>& callback) {
 	m_QuickBuildStateCallbacks.push_back(callback);
+}
+
+bool QuickBuildComponent::OnGetObjectReportInfo(GameMessages::GetObjectReportInfo& reportInfo) {
+	auto& quickbuild = reportInfo.info->PushDebug("Quick Build");
+	quickbuild.PushDebug<AMFStringValue>("State") = StringifiedEnum::ToString(m_State).data();
+	quickbuild.PushDebug<AMFDoubleValue>("Timer") = m_Timer;
+	quickbuild.PushDebug<AMFDoubleValue>("TimerIncomplete") = m_TimerIncomplete;
+	quickbuild.PushDebug("ActivatorPosition").PushDebug(m_ActivatorPosition);
+	quickbuild.PushDebug<AMFStringValue>("ActivatorId") = std::to_string(m_ActivatorId);
+	quickbuild.PushDebug<AMFBoolValue>("ShowResetEffect") = m_ShowResetEffect;
+	quickbuild.PushDebug<AMFDoubleValue>("Taken") = m_Taken;
+	quickbuild.PushDebug<AMFDoubleValue>("ResetTime") = m_ResetTime;
+	quickbuild.PushDebug<AMFDoubleValue>("CompleteTime") = m_CompleteTime;
+	quickbuild.PushDebug<AMFIntValue>("TakeImagination") = m_TakeImagination;
+	quickbuild.PushDebug<AMFBoolValue>("Interruptible") = m_Interruptible;
+	quickbuild.PushDebug<AMFBoolValue>("SelfActivator") = m_SelfActivator;
+	auto& modules = quickbuild.PushDebug("CustomModules");
+	for (const auto cmodule : m_CustomModules) modules.PushDebug<AMFIntValue>("Module") = cmodule;
+	quickbuild.PushDebug<AMFIntValue>("ActivityId") = m_ActivityId;
+	quickbuild.PushDebug<AMFIntValue>("PostImaginationCost") = m_PostImaginationCost;
+	quickbuild.PushDebug<AMFDoubleValue>("TimeBeforeSmash") = m_TimeBeforeSmash;
+	quickbuild.PushDebug<AMFDoubleValue>("TimeBeforeDrain") = m_TimeBeforeDrain;
+	quickbuild.PushDebug<AMFIntValue>("DrainedImagination") = m_DrainedImagination;
+	quickbuild.PushDebug<AMFBoolValue>("RepositionPlayer") = m_RepositionPlayer;
+	quickbuild.PushDebug<AMFDoubleValue>("SoftTimer") = m_SoftTimer;
+	quickbuild.PushDebug<AMFStringValue>("Builder") = std::to_string(m_Builder);
+	return true;
 }

--- a/dGame/dComponents/QuickBuildComponent.h
+++ b/dGame/dComponents/QuickBuildComponent.h
@@ -261,6 +261,8 @@ public:
 		m_StateDirty = true;
 	}
 private:
+
+	bool OnGetObjectReportInfo(GameMessages::GetObjectReportInfo& reportInfo);
 	/**
 	 * Whether or not the quickbuild state has been changed since we last serialized it.
 	 */

--- a/dZoneManager/Spawner.cpp
+++ b/dZoneManager/Spawner.cpp
@@ -55,7 +55,8 @@ Spawner::Spawner(const SpawnerInfo info) {
 			m_SpawnSmashFoundGroup = true;
 			m_SpawnOnSmashID = ssSpawner ? ssSpawner->m_Info.spawnerID : LWOOBJID_EMPTY;
 			ssSpawner->AddSpawnedEntityDieCallback([=, this]() {
-				Spawn();
+				// Intentionally left as a non debug log since i have no idea how much stuff this would affect
+				LOG("WOULD HAVE SPAWNED %i", m_EntityInfo.lot);
 				});
 		}
 	}


### PR DESCRIPTION
tested that the pipe now spawns a ROCK that you can build.  This ROCK you build spawns the PIPE now. new bug: if you start building the ROCK and stop, the pipe will spawn instead of the previous rock.