### PR TITLE
fix: enemies not interrupting QB's when they do damage

### DIFF
--- a/dGame/dBehaviors/NpcCombatSkillBehavior.h
+++ b/dGame/dBehaviors/NpcCombatSkillBehavior.h
@@ -8,6 +8,8 @@ public:
 
 	float m_npcSkillTime;
 
+	float m_maxRange{};
+
 	/*
 	 * Inherited
 	 */

--- a/dGame/dBehaviors/VerifyBehavior.cpp
+++ b/dGame/dBehaviors/VerifyBehavior.cpp
@@ -25,7 +25,7 @@ void VerifyBehavior::Calculate(BehaviorContext* context, RakNet::BitStream& bitS
 
 		const auto distance = Vector3::DistanceSquared(self->GetPosition(), entity->GetPosition());
 
-		if (distance > this->m_range * this->m_range) {
+		if (distance > this->m_range) {
 			success = false;
 		}
 	} else if (this->m_blockCheck) {
@@ -57,4 +57,5 @@ void VerifyBehavior::Load() {
 	this->m_action = GetAction("action");
 
 	this->m_range = GetFloat("range");
+	this->m_range = this->m_range * this->m_range * 0.9f; // Range checks are slightly smaller than the actual range to account for client/server discrepancies
 }


### PR DESCRIPTION
tested that stromlings in AG now correctly interrupt quickbuilds if the player takes damage

fixes: #1968 